### PR TITLE
SbeTool generates uncompilable C# code in some cases

### DIFF
--- a/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -704,9 +704,9 @@ public class CSharpGenerator implements CodeGenerator
         }
 
         return String.format(
-            indent + "        if (actingVersion < %1$d) return %2$s;\n\n",
+            indent + "        if (_actingVersion < %1$d) return %2$s;\n\n",
             Integer.valueOf(sinceVersion),
-            sinceVersion > 0 ? generateLiteral(encoding.primitiveType(), encoding.nullValue().toString()) : "(byte)0"
+            sinceVersion > 0 ? generateLiteral(encoding.primitiveType(), encoding.applicableNullValue().toString()) : "(byte)0"
         );
     }
 
@@ -1096,7 +1096,7 @@ public class CSharpGenerator implements CodeGenerator
         }
 
         return String.format(
-            indent + "        if (actingVersion_ < %d) return %s.NULL_VALUE;\n\n",
+            indent + "        if (_actingVersion < %d) return %s.NULL_VALUE;\n\n",
             Integer.valueOf(sinceVersion),
             enumName
         );


### PR DESCRIPTION
Optional fields, and enums in lowercase will generate code that doesn't compile
