### PR TITLE
[Java] Schema version was not propagated to groups

### DIFF
--- a/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -241,6 +241,7 @@ public class JavaGenerator implements CodeGenerator
             indent + "    {\n" +
             indent + "        this.parentMessage = parentMessage;\n" +
             indent + "        this.buffer = buffer;\n" +
+            indent + "        actingVersion = SCHEMA_VERSION;\n" +
             indent + "        dimensions.wrap(buffer, parentMessage.limit(), actingVersion);\n" +
             indent + "        dimensions.numInGroup((%2$s)count);\n" +
             indent + "        dimensions.blockLength((%3$s)%4$d);\n" +


### PR DESCRIPTION
version was always set to 0 when encoding. Preventing to retrieve field values while encoding (to set values within Object field for instance)
