### PR TITLE
specify Java 7 target for compiled classes

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -154,7 +154,7 @@
     </target>
 
     <target name="build" depends="init" description="Build the main source">
-        <javac srcdir="${dir.main.src}" destdir="${dir.main.build}" includeAntRuntime="false" debug="true" target="1.7">
+        <javac srcdir="${dir.main.src}" destdir="${dir.main.build}" includeAntRuntime="false" debug="true" source="1.7" target="1.7">
             <compilerarg value="-Xlint:unchecked"/>
             <compilerarg value="-XDignore.symbol.file"/>
         </javac>


### PR DESCRIPTION
Should permit to solve https://github.com/real-logic/simple-binary-encoding/issues/142 next time the project is built and uploaded to mavencentral.
