### PR TITLE
[Java]: All javac tasks should have Java 7 source and target compatibility

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -3,6 +3,10 @@
 
     <property file="build.properties"/>
     <property name="module.name" value="sbe"/>
+
+    <property name="ant.build.javac.source" value="1.7" />
+    <property name="ant.build.javac.target" value="1.7" />
+
     <property name="dir.main.src" location="main/java"/>
     <property name="dir.main.build" location="target/main/java/classes"/>
 
@@ -154,7 +158,7 @@
     </target>
 
     <target name="build" depends="init" description="Build the main source">
-        <javac srcdir="${dir.main.src}" destdir="${dir.main.build}" includeAntRuntime="false" debug="true" source="1.7" target="1.7">
+        <javac srcdir="${dir.main.src}" destdir="${dir.main.build}" includeAntRuntime="false" debug="true">
             <compilerarg value="-Xlint:unchecked"/>
             <compilerarg value="-XDignore.symbol.file"/>
         </javac>

--- a/perf-build.xml
+++ b/perf-build.xml
@@ -2,6 +2,9 @@
 <project name="sbe-benchmarks" default="java:perf:test">
     <description>Benchmarks for different codecs</description>
 
+    <property name="ant.build.javac.source" value="1.7" />
+    <property name="ant.build.javac.target" value="1.7" />
+
     <property name="dir.perf.java" location="perf/java"/>
 
     <property name="dir.resources.sbe" location="perf/resources/sbe"/>


### PR DESCRIPTION
This is an enhance to  #143 and #142.
With the properties added, all javac tasks will use source=1.7 and target=1.7
