### PR TITLE
[Java]: avoid unintended or evil buffer overrun and an eventual jvm crash

### DIFF
--- a/main/java/uk/co/real_logic/sbe/codec/java/DirectBuffer.java
+++ b/main/java/uk/co/real_logic/sbe/codec/java/DirectBuffer.java
@@ -435,7 +435,8 @@ public class DirectBuffer
      */
     public int getBytes(final int index, final byte[] dst, final int offset, final int length)
     {
-        final int count = Math.min(length, capacity - index);
+        int count = Math.min(length, capacity - index);
+        count = Math.min(count, dst.length - offset);
         UNSAFE.copyMemory(byteArray, addressOffset + index, dst, BYTE_ARRAY_OFFSET + offset, count);
 
         return count;
@@ -515,7 +516,8 @@ public class DirectBuffer
      */
     public int putBytes(final int index, final byte[] src, final int offset, final int length)
     {
-        final int count = Math.min(length, capacity - index);
+        int count = Math.min(length, capacity - index);
+        count = Math.min(count, src.length - offset);
         UNSAFE.copyMemory(src, BYTE_ARRAY_OFFSET + offset, byteArray, addressOffset + index,  count);
 
         return count;

--- a/test/java/uk/co/real_logic/sbe/codec/java/DirectBufferTest.java
+++ b/test/java/uk/co/real_logic/sbe/codec/java/DirectBufferTest.java
@@ -15,10 +15,11 @@
  */
 package uk.co.real_logic.sbe.codec.java;
 
-import org.junit.Test;
+import org.junit.Rule;
 import org.junit.experimental.theories.DataPoint;
 import org.junit.experimental.theories.Theories;
 import org.junit.experimental.theories.Theory;
+import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import uk.co.real_logic.sbe.util.BitUtil;
 
@@ -33,7 +34,6 @@ import static uk.co.real_logic.sbe.util.BitUtil.SIZE_OF_BYTE;
 @RunWith(Theories.class)
 public class DirectBufferTest
 {
-    private static final ByteOrder BYTE_ORDER = ByteOrder.nativeOrder();
     private static final int BUFFER_CAPACITY = 4096;
     private static final int INDEX = 8;
 
@@ -43,6 +43,15 @@ public class DirectBufferTest
     private static final float FLOAT_VALUE = 5.0f;
     private static final long LONG_VALUE = 6;
     private static final double DOUBLE_VALUE = 7.0d;
+
+    @Rule
+    public ExpectedException exceptionRule = ExpectedException.none(); 
+
+    @DataPoint
+    public static final ByteOrder NATIVE_BYTE_ORDER = ByteOrder.nativeOrder();
+
+    @DataPoint
+    public static final ByteOrder NONNATIVE_BYTE_ORDER = (NATIVE_BYTE_ORDER == ByteOrder.BIG_ENDIAN) ? ByteOrder.LITTLE_ENDIAN : ByteOrder.BIG_ENDIAN;
 
     @DataPoint
     public static final DirectBuffer BYTE_ARRAY_BACKED = new DirectBuffer(new byte[BUFFER_CAPACITY]);
@@ -63,117 +72,126 @@ public class DirectBufferTest
         new DirectBuffer(BitUtil.getUnsafe().allocateMemory(BUFFER_CAPACITY), BUFFER_CAPACITY);
 
     @Theory
-    @Test(expected = IndexOutOfBoundsException.class)
     public void shouldThrowExceptionForLimitAboveCapacity(final DirectBuffer buffer)
     {
+        exceptionRule.expect(IndexOutOfBoundsException.class);
         final int position = BUFFER_CAPACITY + 1;
+
         buffer.checkLimit(position);
     }
 
     @Theory
-    public void shouldGetLongFromBuffer(final DirectBuffer buffer)
+    public void shouldNotThrowExceptionForLimitAboveCapacity(final DirectBuffer buffer)
     {
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final int position = BUFFER_CAPACITY;
 
-        duplicateBuffer.putLong(INDEX, LONG_VALUE);
-
-        assertThat(Long.valueOf(buffer.getLong(INDEX, BYTE_ORDER)), is(Long.valueOf(LONG_VALUE)));
+        buffer.checkLimit(position);
     }
 
     @Theory
-    public void shouldPutLongToBuffer(final DirectBuffer buffer)
+    public void shouldGetLongFromBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
 
-        buffer.putLong(INDEX, LONG_VALUE, BYTE_ORDER);
+        duplicateBuffer.putLong(INDEX, LONG_VALUE);
+
+        assertThat(Long.valueOf(buffer.getLong(INDEX, byteOrder)), is(Long.valueOf(LONG_VALUE)));
+    }
+
+    @Theory
+    public void shouldPutLongToBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
+    {
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
+
+        buffer.putLong(INDEX, LONG_VALUE, byteOrder);
 
         assertThat(Long.valueOf(duplicateBuffer.getLong(INDEX)), is(Long.valueOf(LONG_VALUE)));
     }
 
     @Theory
-    public void shouldGetIntFromBuffer(final DirectBuffer buffer)
+    public void shouldGetIntFromBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
 
         duplicateBuffer.putInt(INDEX, INT_VALUE);
 
-        assertThat(valueOf(buffer.getInt(INDEX, BYTE_ORDER)), is(valueOf(INT_VALUE)));
+        assertThat(valueOf(buffer.getInt(INDEX, byteOrder)), is(valueOf(INT_VALUE)));
     }
 
     @Theory
-    public void shouldPutIntToBuffer(final DirectBuffer buffer)
+    public void shouldPutIntToBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
 
-        buffer.putInt(INDEX, INT_VALUE, BYTE_ORDER);
+        buffer.putInt(INDEX, INT_VALUE, byteOrder);
 
         assertThat(valueOf(duplicateBuffer.getInt(INDEX)), is(valueOf(INT_VALUE)));
     }
 
     @Theory
-    public void shouldGetShortFromBuffer(final DirectBuffer buffer)
+    public void shouldGetShortFromBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
 
         duplicateBuffer.putShort(INDEX, SHORT_VALUE);
 
-        assertThat(Short.valueOf(buffer.getShort(INDEX, BYTE_ORDER)), is(Short.valueOf(SHORT_VALUE)));
+        assertThat(Short.valueOf(buffer.getShort(INDEX, byteOrder)), is(Short.valueOf(SHORT_VALUE)));
     }
 
     @Theory
-    public void shouldPutShortToBuffer(final DirectBuffer buffer)
+    public void shouldPutShortToBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
 
-        buffer.putShort(INDEX, SHORT_VALUE, BYTE_ORDER);
+        buffer.putShort(INDEX, SHORT_VALUE, byteOrder);
 
         assertThat(Short.valueOf(duplicateBuffer.getShort(INDEX)), is(Short.valueOf(SHORT_VALUE)));
     }
 
     @Theory
-    public void shouldGetDoubleFromBuffer(final DirectBuffer buffer)
+    public void shouldGetDoubleFromBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
 
         duplicateBuffer.putDouble(INDEX, DOUBLE_VALUE);
 
-        assertThat(Double.valueOf(buffer.getDouble(INDEX, BYTE_ORDER)), is(Double.valueOf(DOUBLE_VALUE)));
+        assertThat(Double.valueOf(buffer.getDouble(INDEX, byteOrder)), is(Double.valueOf(DOUBLE_VALUE)));
     }
 
     @Theory
-    public void shouldPutDoubleToBuffer(final DirectBuffer buffer)
+    public void shouldPutDoubleToBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
 
-        buffer.putDouble(INDEX, DOUBLE_VALUE, BYTE_ORDER);
+        buffer.putDouble(INDEX, DOUBLE_VALUE, byteOrder);
 
         assertThat(Double.valueOf(duplicateBuffer.getDouble(INDEX)), is(Double.valueOf(DOUBLE_VALUE)));
     }
 
     @Theory
-    public void shouldGetFloatFromBuffer(final DirectBuffer buffer)
+    public void shouldGetFloatFromBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
 
         duplicateBuffer.putFloat(INDEX, FLOAT_VALUE);
 
-        assertThat(Float.valueOf(buffer.getFloat(INDEX, BYTE_ORDER)), is(Float.valueOf(FLOAT_VALUE)));
+        assertThat(Float.valueOf(buffer.getFloat(INDEX, byteOrder)), is(Float.valueOf(FLOAT_VALUE)));
     }
 
     @Theory
-    public void shouldPutFloatToBuffer(final DirectBuffer buffer)
+    public void shouldPutFloatToBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
 
-        buffer.putFloat(INDEX, FLOAT_VALUE, BYTE_ORDER);
+        buffer.putFloat(INDEX, FLOAT_VALUE, byteOrder);
 
         assertThat(Float.valueOf(duplicateBuffer.getFloat(INDEX)), is(Float.valueOf(FLOAT_VALUE)));
     }
 
     @Theory
-    public void shouldGetByteFromBuffer(final DirectBuffer buffer)
+    public void shouldGetByteFromBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
 
         duplicateBuffer.put(INDEX, BYTE_VALUE);
 
@@ -181,9 +199,9 @@ public class DirectBufferTest
     }
 
     @Theory
-    public void shouldPutByteToBuffer(final DirectBuffer buffer)
+    public void shouldPutByteToBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
 
         buffer.putByte(INDEX, BYTE_VALUE);
 
@@ -209,11 +227,11 @@ public class DirectBufferTest
     }
 
     @Theory
-    public void shouldGetBytesFromBuffer(final DirectBuffer buffer)
+    public void shouldGetBytesFromBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
         final byte[] testBytes = "Hello World".getBytes();
 
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
         duplicateBuffer.position(INDEX);
         duplicateBuffer.put(testBytes);
 
@@ -224,11 +242,11 @@ public class DirectBufferTest
     }
 
     @Theory
-    public void shouldGetBytesFromBufferToBuffer(final DirectBuffer buffer)
+    public void shouldGetBytesFromBufferToBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
         final byte[] testBytes = "Hello World".getBytes();
 
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
         duplicateBuffer.position(INDEX);
         duplicateBuffer.put(testBytes);
 
@@ -239,11 +257,11 @@ public class DirectBufferTest
     }
 
     @Theory
-    public void shouldGetBytesFromBufferToDirectBuffer(final DirectBuffer buffer)
+    public void shouldGetBytesFromBufferToDirectBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
         final byte[] testBytes = "Hello World".getBytes();
 
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
         duplicateBuffer.position(INDEX);
         duplicateBuffer.put(testBytes);
 
@@ -257,11 +275,11 @@ public class DirectBufferTest
     }
 
     @Theory
-    public void shouldGetBytesFromBufferToSlice(final DirectBuffer buffer)
+    public void shouldGetBytesFromBufferToSlice(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
         final byte[] testBytes = "Hello World".getBytes();
 
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
         duplicateBuffer.position(INDEX);
         duplicateBuffer.put(testBytes);
 
@@ -292,13 +310,13 @@ public class DirectBufferTest
     }
 
     @Theory
-    public void shouldPutBytesToBuffer(final DirectBuffer buffer)
+    public void shouldPutBytesToBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
         final byte[] testBytes = "Hello World".getBytes();
         buffer.putBytes(INDEX, testBytes);
 
         final byte[] buff = new byte[testBytes.length];
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
         duplicateBuffer.position(INDEX);
         duplicateBuffer.get(buff);
 
@@ -306,7 +324,7 @@ public class DirectBufferTest
     }
 
     @Theory
-    public void shouldPutBytesToBufferFromBuffer(final DirectBuffer buffer)
+    public void shouldPutBytesToBufferFromBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
         final byte[] testBytes = "Hello World".getBytes();
         final ByteBuffer srcBuffer = ByteBuffer.wrap(testBytes);
@@ -314,7 +332,7 @@ public class DirectBufferTest
         buffer.putBytes(INDEX, srcBuffer, testBytes.length);
 
         final byte[] buff = new byte[testBytes.length];
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
         duplicateBuffer.position(INDEX);
         duplicateBuffer.get(buff);
 
@@ -322,7 +340,7 @@ public class DirectBufferTest
     }
 
     @Theory
-    public void shouldPutBytesToBufferFromDirectBuffer(final DirectBuffer buffer)
+    public void shouldPutBytesToBufferFromDirectBuffer(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
         final byte[] testBytes = "Hello World".getBytes();
         final ByteBuffer srcBuffer = ByteBuffer.allocateDirect(testBytes.length);
@@ -332,7 +350,7 @@ public class DirectBufferTest
         buffer.putBytes(INDEX, srcBuffer, testBytes.length);
 
         final byte[] buff = new byte[testBytes.length];
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
         duplicateBuffer.position(INDEX);
         duplicateBuffer.get(buff);
 
@@ -340,7 +358,7 @@ public class DirectBufferTest
     }
 
     @Theory
-    public void shouldPutBytesToBufferFromSlice(final DirectBuffer buffer)
+    public void shouldPutBytesToBufferFromSlice(final DirectBuffer buffer, final ByteOrder byteOrder)
     {
         final byte[] testBytes = "Hello World".getBytes();
         final ByteBuffer srcBuffer =
@@ -352,7 +370,7 @@ public class DirectBufferTest
         buffer.putBytes(INDEX, srcBuffer, testBytes.length);
 
         final byte[] buff = new byte[testBytes.length];
-        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(BYTE_ORDER);
+        final ByteBuffer duplicateBuffer = buffer.duplicateByteBuffer().order(byteOrder);
         duplicateBuffer.position(INDEX);
         duplicateBuffer.get(buff);
 
@@ -373,5 +391,119 @@ public class DirectBufferTest
         buffer.getBytes(INDEX, buff);
 
         assertThat(buff, is(testBytes));
+    }
+
+    @Theory
+    public void shouldGetByteArrayFromBufferNPE(final DirectBuffer buffer)
+    {
+        exceptionRule.expect(NullPointerException.class);
+        final byte[] testBytes = null;
+
+        buffer.getBytes(INDEX, testBytes, 0, 10);
+    }
+
+    @Theory
+    public void shouldPutByteArrayToBufferNPE(final DirectBuffer buffer)
+    {
+        exceptionRule.expect(NullPointerException.class);
+        final byte[] testBytes = null;
+
+        buffer.putBytes(INDEX, testBytes, 0, 10);
+    }
+
+    @Theory
+    public void shouldGetBytesFromBufferNPE(final DirectBuffer buffer)
+    {
+        exceptionRule.expect(NullPointerException.class);
+        final ByteBuffer testBytes = null;
+
+        buffer.getBytes(INDEX, testBytes, 10);
+    }
+
+    @Theory
+    public void shouldPutBytesToBufferNPE(final DirectBuffer buffer)
+    {
+        exceptionRule.expect(NullPointerException.class);
+        final ByteBuffer testBytes = null;
+
+        buffer.putBytes(INDEX, testBytes, 10);
+    }
+
+    @Theory
+    public void shouldGetDirectBytesFromBufferNPE(final DirectBuffer buffer)
+    {
+        exceptionRule.expect(NullPointerException.class);
+        final DirectBuffer testBytes = null;
+
+        buffer.getBytes(INDEX, testBytes, 0, 10);
+    }
+
+    @Theory
+    public void shouldPutDirectBytesToBufferNPE(final DirectBuffer buffer)
+    {
+        exceptionRule.expect(NullPointerException.class);
+        final DirectBuffer testBytes = null;
+
+        buffer.putBytes(INDEX, testBytes, 0, 10);
+    }
+
+    @Theory
+    public void shouldGetByteArrayFromBufferTruncate(final DirectBuffer buffer)
+    {
+        final byte[] testBytes = new byte[10];
+
+        int result = buffer.getBytes(INDEX, testBytes, 0, 21);
+
+        assertThat(result, is(10));
+    }
+
+    @Theory
+    public void shouldPutByteArrayToBufferTruncate(final DirectBuffer buffer)
+    {
+        final byte[] testBytes = new byte[11];
+
+        int result = buffer.putBytes(INDEX, testBytes, 0, 20);
+
+        assertThat(result, is(11));
+    }
+
+    @Theory
+    public void shouldGetBytesFromBufferTruncate(final DirectBuffer buffer)
+    {
+        final ByteBuffer testBytes = ByteBuffer.allocate(12);
+
+        int result = buffer.getBytes(INDEX, testBytes, 20);
+
+        assertThat(result, is(12));
+    }
+
+    @Theory
+    public void shouldPutBytesToBufferTruncate(final DirectBuffer buffer)
+    {
+        final ByteBuffer testBytes = ByteBuffer.allocate(13);
+
+        int result = buffer.putBytes(INDEX, testBytes, 20);
+
+        assertThat(result, is(13));
+    }
+
+    @Theory
+    public void shouldGetDirectBytesFromBufferTruncate(final DirectBuffer buffer)
+    {
+        final DirectBuffer testBytes = new DirectBuffer(new byte[14]);
+
+        int result = buffer.getBytes(INDEX, testBytes, 0, 20);
+
+        assertThat(result, is(14));
+    }
+
+    @Theory
+    public void shouldPutDirectBytesToBufferTruncate(final DirectBuffer buffer)
+    {
+        final DirectBuffer testBytes = new DirectBuffer(new byte[15]);
+
+        int result = buffer.putBytes(INDEX, testBytes, 0, 20);
+
+        assertThat(result, is(15));
     }
 }


### PR DESCRIPTION
This commit contains a fix and unit tests that cover 98% of the code in DirectBuffer,
I changed getBytes(int,byte[],int,int) and putBytes(int,byte[],int,int) methods to also take into account the actual size of the byte[] buffer.
Also, accessing the byte[] buffer makes the method throw NPE in case the specified parameter is null, thus avoiding an illegal memory access which leads to jvm crash.
At this point, the behaviour of the methods getBytes(int,byte[],int,int) and putBytes(int,byte[],int,int) is similar to the other putBytes and getBytes methods.

Beside this, I made the byte order a DataPoint for the DirectBufferTest class in order to cover the non-native byte order branches inside the DirectBuffer methods.
