### PR TITLE
added failonerror and fork to build files and a small fix for the javagenerator

### DIFF
--- a/build.xml
+++ b/build.xml
@@ -610,7 +610,7 @@
     <target name="generate:java:sbeir-stubs"
             depends="dist"
             description="Generate serialized IR stubs for Java">
-        <java classname="uk.co.real_logic.sbe.SbeTool">
+        <java classname="uk.co.real_logic.sbe.SbeTool" failonerror="true" fork="true">
             <classpath refid="sbetool.classpath"/>
             <sysproperty key="sbe.output.dir" value="${dir.main.src}"/>
             <sysproperty key="sbe.target.language" value="Java"/>
@@ -621,7 +621,7 @@
     <target name="generate:cpp98:sbeir-stubs"
             depends="dist"
             description="Generate serialized IR stubs for C++98">
-        <java classname="uk.co.real_logic.sbe.SbeTool">
+        <java classname="uk.co.real_logic.sbe.SbeTool" failonerror="true" fork="true">
             <classpath refid="sbetool.classpath"/>
             <sysproperty key="sbe.output.dir" value="${dir.main.cpp.src}"/>
             <sysproperty key="sbe.target.language" value="cpp98"/>
@@ -632,7 +632,7 @@
     <target name="generate:csharp:sbeir-stubs"
             depends="dist"
             description="Generate serialized IR stubs for C#">
-        <java classname="uk.co.real_logic.sbe.SbeTool">
+        <java classname="uk.co.real_logic.sbe.SbeTool" failonerror="true" fork="true">
             <classpath refid="sbetool.classpath"/>
             <sysproperty key="sbe.output.dir" value="${dir.main.csharp.src}"/>
             <sysproperty key="sbe.target.language" value="csharp"/>
@@ -669,7 +669,7 @@
             depends="dist">
         <mkdir dir="${dir.gen.java}"/>
         <mkdir dir="${dir.examples.build}"/>
-        <java classname="uk.co.real_logic.sbe.SbeTool">
+        <java classname="uk.co.real_logic.sbe.SbeTool" failonerror="true" fork="true">
             <classpath refid="examples.classpath"/>
             <sysproperty key="sbe.validation.xsd" value="main/resources/fpl/SimpleBinary1-0.xsd"/>
             <sysproperty key="sbe.validation.stop.on.error" value="true"/>
@@ -684,13 +684,13 @@
         <javac srcdir="${dir.examples.src}" destdir="${dir.examples.build}" includeAntRuntime="false" debug="true">
             <classpath refid="examples.classpath"/>
         </javac>
-        <java classname="uk.co.real_logic.sbe.examples.ExampleUsingGeneratedStub">
+        <java classname="uk.co.real_logic.sbe.examples.ExampleUsingGeneratedStub" failonerror="true" fork="true">
             <classpath refid="examples.classpath"/>
         </java>
-        <java classname="uk.co.real_logic.sbe.examples.ExampleUsingGeneratedStubExtension">
+        <java classname="uk.co.real_logic.sbe.examples.ExampleUsingGeneratedStubExtension" failonerror="true" fork="true">
             <classpath refid="examples.classpath"/>
         </java>
-        <java classname="uk.co.real_logic.sbe.examples.OtfExample">
+        <java classname="uk.co.real_logic.sbe.examples.OtfExample" failonerror="true" fork="true">
             <classpath refid="examples.classpath"/>
         </java>
     </target>
@@ -699,7 +699,7 @@
             depends="dist"
             description="Generate and run C++ generated code example">
         <mkdir dir="${dir.gen.cpp98}"/>
-        <java classname="uk.co.real_logic.sbe.SbeTool">
+        <java classname="uk.co.real_logic.sbe.SbeTool" failonerror="true" fork="true">
             <classpath refid="examples.classpath"/>
             <sysproperty key="sbe.output.dir" value="${dir.gen.cpp98}"/>
             <sysproperty key="sbe.target.language" value="cpp98"/>
@@ -755,14 +755,14 @@
                 <fileset dir="${dir.main.cpp.build}" includes="*.o*"/>
                 <fileset dir="${dir.examples.cpp98.src}" includes="SbeOtfDecoder.cpp"/>
             </cc>
-            <java classname="uk.co.real_logic.sbe.SbeTool">
+            <java classname="uk.co.real_logic.sbe.SbeTool" failonerror="true" fork="true">
                 <classpath refid="examples.classpath"/>
                 <sysproperty key="sbe.output.dir" value="${dir.gen.cpp98}"/>
                 <sysproperty key="sbe.generate.stubs" value="false"/>
                 <sysproperty key="sbe.generate.ir" value="true"/>
                 <arg value="${dir.examples.resources}/example-schema.xml"/>
             </java>
-            <java classname="uk.co.real_logic.sbe.examples.ExampleUsingGeneratedStub">
+            <java classname="uk.co.real_logic.sbe.examples.ExampleUsingGeneratedStub" failonerror="true" fork="true">
                 <classpath refid="examples.classpath"/>
                 <sysproperty key="sbe.encoding.filename" value="${dir.gen.cpp98}/Car.data"/>
             </java>
@@ -851,7 +851,7 @@
     <target name="cpp:test:codegen" depends="dist">
         <sequential>
             <mkdir dir="${dir.gen.cpp98}"/>
-            <java classname="uk.co.real_logic.sbe.SbeTool">
+            <java classname="uk.co.real_logic.sbe.SbeTool" failonerror="true" fork="true">
                 <classpath refid="examples.classpath"/>
                 <sysproperty key="sbe.output.dir" value="${dir.gen.cpp98}"/>
                 <sysproperty key="sbe.target.language" value="cpp98"/>
@@ -859,7 +859,7 @@
                 <arg value="${dir.test.resources}/code-generation-schema-cpp.xml"/>
             </java>
             <copy file="${dir.gen.cpp98}/code-generation-schema-cpp.sbeir" todir="${dir.exec.test.cpp}"/>
-            <java classname="uk.co.real_logic.sbe.SbeTool">
+            <java classname="uk.co.real_logic.sbe.SbeTool" failonerror="true" fork="true">
                 <classpath refid="examples.classpath"/>
                 <sysproperty key="sbe.output.dir" value="${dir.gen.cpp98}"/>
                 <sysproperty key="sbe.target.language" value="cpp98"/>
@@ -867,7 +867,7 @@
                 <arg value="${dir.test.resources}/composite-offsets-schema.xml"/>
             </java>
             <copy file="${dir.gen.cpp98}/composite-offsets-schema.sbeir" todir="${dir.exec.test.cpp}"/>
-            <java classname="uk.co.real_logic.sbe.SbeTool">
+            <java classname="uk.co.real_logic.sbe.SbeTool" failonerror="true" fork="true">
                 <classpath refid="examples.classpath"/>
                 <sysproperty key="sbe.output.dir" value="${dir.gen.cpp98}"/>
                 <sysproperty key="sbe.target.language" value="cpp98"/>

--- a/main/csharp/ir/generated/FrameCodec.cs
+++ b/main/csharp/ir/generated/FrameCodec.cs
@@ -12,7 +12,7 @@ namespace Adaptive.SimpleBinaryEncoding.Ir.Generated
     public const ushort TemplateId = (ushort)1;
     public const ushort SchemaId = (ushort)0;
     public const ushort Schema_Version = (ushort)0;
-    public const string SematicType = "";
+    public const string SemanticType = "";
 
     private readonly FrameCodec _parentMessage;
     private DirectBuffer _buffer;

--- a/main/csharp/ir/generated/TokenCodec.cs
+++ b/main/csharp/ir/generated/TokenCodec.cs
@@ -12,7 +12,7 @@ namespace Adaptive.SimpleBinaryEncoding.Ir.Generated
     public const ushort TemplateId = (ushort)2;
     public const ushort SchemaId = (ushort)0;
     public const ushort Schema_Version = (ushort)0;
-    public const string SematicType = "";
+    public const string SemanticType = "";
 
     private readonly TokenCodec _parentMessage;
     private DirectBuffer _buffer;

--- a/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -1160,7 +1160,7 @@ public class JavaGenerator implements CodeGenerator
             "        limit(offset + actingBlockLength);\n\n" +
             "        return this;\n" +
             "    }\n\n" +
-            "    public %9$s wrapForDecode(" +
+            "    public %9$s wrapForDecode(\n" +
             "        final DirectBuffer buffer, final int offset, final int actingBlockLength, final int actingVersion)\n" +
             "    {\n" +
             "        this.buffer = buffer;\n" +

--- a/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodec.java
+++ b/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodec.java
@@ -58,7 +58,8 @@ public class FrameCodec
         return this;
     }
 
-    public FrameCodec wrapForDecode(final DirectBuffer buffer, final int offset, final int actingBlockLength, final int actingVersion)
+    public FrameCodec wrapForDecode(
+        final DirectBuffer buffer, final int offset, final int actingBlockLength, final int actingVersion)
     {
         this.buffer = buffer;
         this.offset = offset;

--- a/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodec.java
+++ b/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodec.java
@@ -58,7 +58,8 @@ public class TokenCodec
         return this;
     }
 
-    public TokenCodec wrapForDecode(final DirectBuffer buffer, final int offset, final int actingBlockLength, final int actingVersion)
+    public TokenCodec wrapForDecode(
+        final DirectBuffer buffer, final int offset, final int actingBlockLength, final int actingVersion)
     {
         this.buffer = buffer;
         this.offset = offset;

--- a/perf-build.xml
+++ b/perf-build.xml
@@ -42,13 +42,13 @@
     </target>
 
     <target name="java:codegen" depends="init">
-        <java classname="uk.co.real_logic.sbe.SbeTool">
+        <java classname="uk.co.real_logic.sbe.SbeTool" failonerror="true" fork="true">
             <classpath refid="perf.tools.classpath"/>
             <sysproperty key="sbe.output.dir" value="${dir.target.perf.java}"/>
             <sysproperty key="sbe.target.language" value="Java"/>
             <arg value="${dir.resources.sbe}/car.xml"/>
         </java>
-        <java classname="uk.co.real_logic.sbe.SbeTool">
+        <java classname="uk.co.real_logic.sbe.SbeTool" failonerror="true" fork="true">
             <classpath refid="perf.tools.classpath"/>
             <sysproperty key="sbe.output.dir" value="${dir.target.perf.java}"/>
             <sysproperty key="sbe.target.language" value="Java"/>
@@ -57,7 +57,7 @@
 
         <fail unless="protobuf.home" message="protobuf.home is not defined (please add a build-local.properties and define it."/>
 
-        <exec executable="${protobuf.home}/bin/protoc">
+        <exec executable="${protobuf.home}/bin/protoc" failonerror="true">
             <arg value="-I${dir.resources.protobuf}"/>
             <arg value="--java_out"/>
             <arg value="${dir.target.perf.java}"/>
@@ -88,7 +88,7 @@
     </target>
 
     <target name="java:perf:test" depends="java:compile">
-        <exec executable="java">
+        <exec executable="java" failonerror="true">
             <arg value="-jar"/>
             <arg value="target/perf/dist/microbenchmarks.jar"/>
             <arg value="-wi"/>
@@ -100,13 +100,13 @@
     </target>
 
     <target name="cpp:codegen" depends="init">
-        <java classname="uk.co.real_logic.sbe.SbeTool">
+        <java classname="uk.co.real_logic.sbe.SbeTool" failonerror="true" fork="true">
             <classpath refid="perf.tools.classpath"/>
             <sysproperty key="sbe.output.dir" value="${dir.target.perf.cpp}"/>
             <sysproperty key="sbe.target.language" value="Cpp98"/>
             <arg value="${dir.resources.sbe}/car-c.xml"/>
         </java>
-        <java classname="uk.co.real_logic.sbe.SbeTool">
+        <java classname="uk.co.real_logic.sbe.SbeTool" failonerror="true" fork="true">
             <classpath refid="perf.tools.classpath"/>
             <sysproperty key="sbe.output.dir" value="${dir.target.perf.cpp}"/>
             <sysproperty key="sbe.target.language" value="Cpp98"/>
@@ -116,17 +116,17 @@
 
     <target name="cpp:compile" depends="clean, init, cpp:codegen">
         <sequential>
-            <exec executable="cmake" dir="target/perf">
+            <exec executable="cmake" dir="target/perf" failonerror="true">
                 <arg value="../../perf/cpp"/>
             </exec>
-            <exec executable="make" dir="target/perf"/>
+            <exec executable="make" dir="target/perf" failonerror="true"/>
         </sequential>
     </target>
 
     <target name="cpp:perf:test" depends="cpp:compile">
         <sequential>
-            <exec executable="target/perf/benchlet-sbe-md-runner"/>
-            <exec executable="target/perf/benchlet-sbe-car-runner"/>
+            <exec executable="target/perf/benchlet-sbe-md-runner" failonerror="true"/>
+            <exec executable="target/perf/benchlet-sbe-car-runner" failonerror="true"/>
         </sequential>
     </target>
 


### PR DESCRIPTION
I observed strange behaviour when running the examples on a machine with custom ant deploy.
Basically the problem was related to the fact that if fork is not used for the java tasks, it would inherit the classpath used by ant, thus the SbeTool and OtfExample failed.

Also, I have regenerated the otf decoder stubs because of some checkstyle warnings.
