### PR TITLE
SBE Java Generator Bug: when having a group that starts with a lower cas...

### DIFF
--- a/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -170,13 +170,14 @@ public class JavaGenerator implements CodeGenerator
             {
                 final Token groupToken = tokens.get(index);
                 final String groupName = groupToken.name();
+                final String groupClassName = formatClassName(groupName);
                 sb.append(generateGroupProperty(groupName, groupToken, indent));
 
                 generateGroupClassHeader(sb, groupName, parentMessageClassName, tokens, index, indent + INDENT);
 
                 final List<Token> rootFields = new ArrayList<>();
                 index = collectRootFields(tokens, ++index, rootFields);
-                sb.append(generateFields(groupName, rootFields, indent + INDENT));
+                sb.append(generateFields(groupClassName, rootFields, indent + INDENT));
 
                 if (tokens.get(index).signal() == Signal.BEGIN_GROUP)
                 {

--- a/test/resources/code-generation-schema.xml
+++ b/test/resources/code-generation-schema.xml
@@ -19,6 +19,7 @@
             <type name="length" primitiveType="uint8"/>
             <type name="varData" primitiveType="uint8" length="0" characterEncoding="UTF-8"/>
         </composite>
+        <type name="string20" primitiveType="char" length="20"/>
     </types>
     <types>
         <type name="CharConstType" presence="constant" primitiveType="char">g</type>
@@ -61,12 +62,13 @@
         </group>
         <group name="performanceFigures" id="11" dimensionType="groupSizeEncoding">
             <field name="octaneRating" id="12" type="uint8"/>
-            <group name="acceleration" id="13" dimensionType="groupSizeEncoding">
-                <field name="mph" id="14" type="uint16"/>
-                <field name="seconds" id="15" type="float"/>
+            <field name="observations" id="13" type="string20"/>
+            <group name="acceleration" id="14" dimensionType="groupSizeEncoding">
+                <field name="mph" id="15" type="uint16"/>
+                <field name="seconds" id="16" type="float"/>
             </group>
         </group>
-        <data name="make" id="16" type="varDataEncoding"/>
-        <data name="model" id="17" type="varDataEncoding"/>
+        <data name="make" id="17" type="varDataEncoding"/>
+        <data name="model" id="18" type="varDataEncoding"/>
     </message>
 </messageSchema>


### PR DESCRIPTION
SBE Java Generator Bug: when having a group that starts with a lower case letter and that group contains a fix length array, the corresponding put%s() method has the wrong return type (it uses the name of the group instead of using the name of the class)
