### PR TITLE
[C#]: #211 - Correct logic for dealing with returning default values when a message extension.

### DIFF
--- a/examples/csharp/Otf/ExampleTokenListener.cs
+++ b/examples/csharp/Otf/ExampleTokenListener.cs
@@ -159,7 +159,7 @@ namespace Adaptive.SimpleBinaryEncoding.Examples.Otf
 
             if (Presence.Optional == encoding.Presence)
             {
-                if (token.Version < actingVersion)
+                if (actingVersion < token.Version)
                 {
                     return encoding.ApplicableNullVal;
                 }


### PR DESCRIPTION
apparently C# code was having the same issue.
