### PR TITLE
fixed wrong class name generation for fixed length strings

### DIFF
--- a/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -982,7 +982,7 @@ public class JavaGenerator implements CodeGenerator
                 indent + "        CodecUtil.charsPut(buffer, this.offset + %d, src, srcOffset, length);\n" +
                 indent + "        return this;\n" +
                 indent + "    }\n",
-                containingClassName,
+                formatClassName(containingClassName),
                 toUpperFirstChar(propertyName),
                 fieldLength,
                 offset


### PR DESCRIPTION
when having a type defined like this:

&lt;type name="string" primitiveType="char" length="32" characterEncoding="UTF-8"/&gt;

the Java code generator creates an uncompilable put method in the corresponding class, returning unformatted class name as defined in the XML, for example as group name. Workaround naming groups Uppercase works, of course.
