### PR TITLE
Fix null pointer exception and CSharp compiler error

### DIFF
--- a/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -376,7 +376,7 @@ public class CSharpGenerator implements CodeGenerator
                     "        const int sizeOfLengthField = %3$d;\n" +
                     "        int limit = Limit;\n" +
                     "        _buffer.CheckLimit(limit + sizeOfLengthField);\n" +
-                    "        int dataLength = _buffer.%4$sGet%5$s(limit);\n" +
+                    "        int dataLength = (int)_buffer.%4$sGet%5$s(limit);\n" +
                     "        int bytesCopied = Math.Min(length, dataLength);\n" +
                     "        Limit = limit + sizeOfLengthField + dataLength;\n" +
                     "        _buffer.GetBytes(limit + sizeOfLengthField, dst, dstOffset, bytesCopied);\n\n" +

--- a/main/java/uk/co/real_logic/sbe/xml/XmlSchemaParser.java
+++ b/main/java/uk/co/real_logic/sbe/xml/XmlSchemaParser.java
@@ -292,6 +292,11 @@ public class XmlSchemaParser
      */
     public static String getAttributeValueOrNull(final Node elementNode, final String attrName)
     {
+        if (elementNode == null || elementNode.getAttributes() == null)
+        {
+            return null;
+        }
+
         final Node attrNode = elementNode.getAttributes().getNamedItem(attrName);
 
         if (attrNode == null)


### PR DESCRIPTION
An empty messageHeader composite throws a NullPointerException because even though getAttributeValueOrNull() says that elementNode can be null, no null check is done on the element or the attribute map.

Also the CSharp generated code will not compile if you have a uint32 length field in a variable data complex type.

Fixes for each of these is in a separate commit.  Let me know if you want me to also separate them into separate pull requests.