### PR TITLE
[C#] Fix CSharp compiler error when using uint32 length argument on vari...

### DIFF
--- a/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -376,7 +376,7 @@ public class CSharpGenerator implements CodeGenerator
                     "        const int sizeOfLengthField = %3$d;\n" +
                     "        int limit = Limit;\n" +
                     "        _buffer.CheckLimit(limit + sizeOfLengthField);\n" +
-                    "        int dataLength = _buffer.%4$sGet%5$s(limit);\n" +
+                    "        int dataLength = (int)_buffer.%4$sGet%5$s(limit);\n" +
                     "        int bytesCopied = Math.Min(length, dataLength);\n" +
                     "        Limit = limit + sizeOfLengthField + dataLength;\n" +
                     "        _buffer.GetBytes(limit + sizeOfLengthField, dst, dstOffset, bytesCopied);\n\n" +


### PR DESCRIPTION
[C#] Fix CSharp compiler error when using uint32 length argument on variable length data types

As noted, the optimal solution would be to disallow anything greater than 31 bits for use as a length, but this fix will at least make the generated C# code compile and behave like the generated Java code.