### PR TITLE
[python] Fixes and improvements to enum handling

### DIFF
--- a/main/java/uk/co/real_logic/sbe/generation/python/PythonGenerator.java
+++ b/main/java/uk/co/real_logic/sbe/generation/python/PythonGenerator.java
@@ -394,7 +394,7 @@ public class PythonGenerator implements CodeGenerator
 
         sb.append(String.format(
             "    def %1$sLength(self):\n" +
-            "        return struct.unpack_from('%4$s', self.buffer_, position())[0]\n\n",
+            "        return struct.unpack_from('%4$s', self.buffer_, getPosition())[0]\n\n",
             formatPropertyName(propertyName),
             generateArrayFieldNotPresentCondition(token.version(), BASE_INDENT),
             formatByteOrderEncoding(lengthToken.encoding().byteOrder(), lengthToken.encoding().primitiveType()),
@@ -928,7 +928,7 @@ public class PythonGenerator implements CodeGenerator
             "        return self\n\n" +
 
             "    def getPosition(self):\n" +
-            "        return self.position_\n\n" +
+            "        return self.position_[0]\n\n" +
 
             "    def setPosition(self, position):\n" +
             "        if position > self.bufferLength_:\n" +
@@ -936,7 +936,7 @@ public class PythonGenerator implements CodeGenerator
             "        self.position_[0] = position\n\n" +
 
             "    def encodedLength(self):\n" +
-            "        return self.position() - self.offset_\n\n" +
+            "        return self.getPosition() - self.offset_\n\n" +
 
             "    def buffer(self):\n" +
             "        return self.buffer_\n\n" +

--- a/main/java/uk/co/real_logic/sbe/generation/python/PythonGenerator.java
+++ b/main/java/uk/co/real_logic/sbe/generation/python/PythonGenerator.java
@@ -783,12 +783,12 @@ public class PythonGenerator implements CodeGenerator
         ));
 
         sb.append(String.format(
-            indent + "    def set%1$s(self, index, value):\n" +
+            indent + "    def set%2$s(self, index, value):\n" +
             indent + "        if index < 0 or index >= %3$d:\n" +
-            indent + "            raise Exception('index out of range for %1$s')\n" +
-            indent + "        struct.pack_into('%2$s', self.buffer_, self.offset_ + %4$d + (index * %5$d), value)\n",
-            propertyName,
-            toUpperFirstChar(pythonTypeName),
+            indent + "            raise Exception('index out of range for %2$s')\n" +
+            indent + "        struct.pack_into('%1$s', self.buffer_, self.offset_ + %4$d + (index * %5$d), value)\n",
+            pythonTypeName,
+            toUpperFirstChar(propertyName),
             token.arrayLength(),
             offset,
             token.encoding().primitiveType().size(),

--- a/main/java/uk/co/real_logic/sbe/generation/python/PythonGenerator.java
+++ b/main/java/uk/co/real_logic/sbe/generation/python/PythonGenerator.java
@@ -314,12 +314,12 @@ public class PythonGenerator implements CodeGenerator
                     "    def get%1$s(self):\n" +
                     "        sizeOfLengthField = %3$d\n" +
                     "        lengthPosition = self.getPosition()\n" +
-                    "        dataLength = struct.unpack_from('%5$s', self.buffer_, lengthPosition[0])[0]\n" +
-                    "        self.setPosition(lengthPosition[0] + sizeOfLengthField)\n" +
+                    "        dataLength = struct.unpack_from('%5$s', self.buffer_, lengthPosition)[0]\n" +
+                    "        self.setPosition(lengthPosition + sizeOfLengthField)\n" +
                     "        pos = self.getPosition()\n" +
-                    "        fmt = '" + byteOrder + "'+str(dataLength)+'c'\n" +
-                    "        data = struct.unpack_from(fmt, self.buffer_, lengthPosition[0])\n" +
-                    "        self.setPosition(pos[0] + dataLength)\n" +
+                    "        fmt = '" + byteOrder + "' + str(dataLength) + 's'\n" +
+                    "        data = struct.unpack_from(fmt, self.buffer_, pos)[0]\n" +
+                    "        self.setPosition(pos + dataLength)\n" +
                     "        return data\n\n",
                     propertyName,
                     generateArrayFieldNotPresentCondition(token.version(), BASE_INDENT),
@@ -332,13 +332,12 @@ public class PythonGenerator implements CodeGenerator
                     "    def set%1$s(self, buffer):\n" +
                     "        sizeOfLengthField = %2$d\n" +
                     "        lengthPosition = self.getPosition()\n" +
-                    "        struct.pack_into('%3$s', self.buffer_, lengthPosition[0], len(buffer))\n" +
-                    "        self.setPosition(lengthPosition[0] + sizeOfLengthField)\n" +
+                    "        struct.pack_into('%3$s', self.buffer_, lengthPosition, len(buffer))\n" +
+                    "        self.setPosition(lengthPosition + sizeOfLengthField)\n" +
                     "        pos = self.getPosition()\n" +
-                    "        fmt = '" + byteOrder + "c'\n" +
-                    "        for i in range(0,len(buffer)):\n" +
-                    "           struct.pack_into(fmt, self.buffer_, lengthPosition[0]+i, buffer[i])\n" +
-                    "        self.setPosition(pos[0] + len(buffer))\n\n",
+                    "        fmt = '" + byteOrder + "' + str(len(buffer)) + 's'\n" +
+                    "        struct.pack_into(fmt, self.buffer_, pos, buffer)\n" +
+                    "        self.setPosition(pos + len(buffer))\n\n",
                     propertyName,
                     sizeOfLengthField,
                     lengthPythonType,


### PR DESCRIPTION
This pull request has a couple of minor fixes to the python code generation and a pretty significant change to the enum handling.  My goal was to simplify the enum code and add a feature that allows you to easily retrieve the name of an enum value.  The decoder now returns an instance of the enum class and there is a \_\_str\_\_() instance method that handles the enum value to value name conversion.

Here is an example of a new style generated class:

```python
import struct

class Model:
    A = 'A'
    B = 'B'
    C = 'C'
    NULL_VALUE = '\0'
 
    VALID_VALUES = {
        A,
        B,
        C,
        NULL_VALUE,
    }

    AS_TEXT = {
        A : 'A',
        B : 'B',
        C : 'C',
        NULL_VALUE : 'NULL_VALUE',
    }

    def __init__(self, value):
        self.value = value
        if self.value not in Model.VALID_VALUES:
            raise ValueError('Invalid value for Model: {}'.format(value))

    def __str__(self):
        return Model.AS_TEXT[self.value]
```