### PR TITLE
Add define guard to definition of __STDC_LIMIT_MACROS

### DIFF
--- a/main/cpp/sbe/sbe.hpp
+++ b/main/cpp/sbe/sbe.hpp
@@ -16,7 +16,9 @@
 #ifndef _SBE_HPP_
 #define _SBE_HPP_
 
-#define __STDC_LIMIT_MACROS 1
+#if !defined(__STDC_LIMIT_MACROS)
+    #define __STDC_LIMIT_MACROS 1
+#endif
 #include <string.h>
 #include <stdint.h>
 #include <limits.h>


### PR DESCRIPTION
Without this, a compiler warning (warning: "__STDC_LIMIT_MACROS"
redefined) is generated when your build system or another library
already defined __STDC_LIMIT_MACROS