### PR TITLE
Overcome warnings in generated Java source compilation units.

### DIFF
--- a/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -1169,6 +1169,7 @@ public class JavaGenerator implements CodeGenerator
     private CharSequence generateClassDeclaration(final String className)
     {
         return String.format(
+            "@SuppressWarnings(\"all\")\n" +
             "public class %s\n" +
             "{\n",
             className


### PR DESCRIPTION
When the SBE tool is used to generate Java source, the resulting compilation units cause warnings such as:

    The value of the field UpdateBatchDecoder.UpdatesDecoder.actingVersion is not used
    The value of the field BondSymbolInfoDecoder.parentMessage is not used

While filtering can be used to ignore such warnings within an IDE, it is preferable to overcome the warnings in a manner that does not require end user intervention.

This PR adopts the simplest possible by solution by adding ``@SuppressWarnings("all")`` to the generated compilation units. Being a ``java.lang`` annotation, this requires no additional import. It has also been available since Java 1.5. While [SuppressWarnings](http://docs.oracle.com/javase/8/docs/api/java/lang/SuppressWarnings.html) does not require a compiler to support the ``all`` warning name, compilers are required to ignore any warning names they do not recognise. Both OpenJDK and Eclipse recognise ``all``.

The cleaner alternative to this PR would be to modify ``JavaGenerator`` to only generate the fields when required. I did not pursue this path given it would require more substantial changes to ``JavaGenerator`` and I thought a more lightweight change would be preferred. If not please feel free to let me know and I can submit a more comprehensive PR.