### PR TITLE
Add guard to remaining __STDC_LIMIT_MACROS definitions

### DIFF
--- a/examples/cpp98/SbeOtfDecoder.cpp
+++ b/examples/cpp98/SbeOtfDecoder.cpp
@@ -20,7 +20,9 @@
 #include <stdlib.h>
 #include <stdint.h>
 #else
-#define __STDC_LIMIT_MACROS 1
+#if !defined(__STDC_LIMIT_MACROS)
+    #define __STDC_LIMIT_MACROS 1
+#endif
 #include <stdint.h>
 #include <sys/types.h>
 #include <sys/uio.h>

--- a/main/cpp/otf_api/Ir.cpp
+++ b/main/cpp/otf_api/Ir.cpp
@@ -14,7 +14,9 @@
  * limitations under the License.
  */
 
-#define __STDC_LIMIT_MACROS 1
+#if !defined(__STDC_LIMIT_MACROS)
+    #define __STDC_LIMIT_MACROS 1
+#endif
 #include <stdint.h>
 #include <stdio.h>
 #include <iostream>

--- a/main/cpp/otf_api/Ir.h
+++ b/main/cpp/otf_api/Ir.h
@@ -16,7 +16,9 @@
 #ifndef _IR_H_
 #define _IR_H_
 
-#define __STDC_LIMIT_MACROS 1
+#if !defined(__STDC_LIMIT_MACROS)
+    #define __STDC_LIMIT_MACROS 1
+#endif
 #include <stdint.h>
 #include <string.h>
 

--- a/main/cpp/otf_api/Listener.h
+++ b/main/cpp/otf_api/Listener.h
@@ -17,7 +17,9 @@
 #ifndef _LISTENER_H_
 #define _LISTENER_H_
 
-#define __STDC_LIMIT_MACROS 1
+#if !defined(__STDC_LIMIT_MACROS)
+    #define __STDC_LIMIT_MACROS 1
+#endif
 #include <stdint.h>
 #include <string.h>
 

--- a/perf/cpp/benchlet.hpp
+++ b/perf/cpp/benchlet.hpp
@@ -16,7 +16,9 @@
 #ifndef _BENCHLET_HPP
 #define _BENCHLET_HPP
 
-#define __STDC_LIMIT_MACROS 1
+#if !defined(__STDC_LIMIT_MACROS)
+    #define __STDC_LIMIT_MACROS 1
+#endif
 #include <stdint.h>
 #include <stdio.h>
 #include <stdlib.h>

--- a/test/cpp/OtfIrTest.cpp
+++ b/test/cpp/OtfIrTest.cpp
@@ -13,7 +13,9 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-#define __STDC_LIMIT_MACROS 1
+#if !defined(__STDC_LIMIT_MACROS)
+    #define __STDC_LIMIT_MACROS 1
+#endif
 #include <stdint.h>
 #include <iostream>
 


### PR DESCRIPTION
10e75064f6296ca50db9d3ee17feb097169c77b3 only fixed one.  Fix the rest.

The defines can go away entirely if SBE switches to C++11.

I copied the existing style for consistency rather than using '#ifndef'