### PR TITLE
Use relative includes where possible in C++ code

### DIFF
--- a/main/cpp/otf_api/Field.h
+++ b/main/cpp/otf_api/Field.h
@@ -18,7 +18,7 @@
 
 #include <vector>
 
-#include "otf_api/Ir.h"
+#include "Ir.h"
 
 namespace sbe {
 namespace on_the_fly {

--- a/main/cpp/otf_api/IrCollection.h
+++ b/main/cpp/otf_api/IrCollection.h
@@ -33,7 +33,7 @@
 #include <map>
 #include <iostream>
 
-#include "otf_api/Ir.h"
+#include "Ir.h"
 #include "uk_co_real_logic_sbe_ir_generated/TokenCodec.hpp"
 #include "uk_co_real_logic_sbe_ir_generated/FrameCodec.hpp"
 

--- a/main/cpp/otf_api/Listener.cpp
+++ b/main/cpp/otf_api/Listener.cpp
@@ -18,7 +18,7 @@
 #include <iostream>
 #include <sys/types.h>
 
-#include "otf_api/Listener.h"
+#include "Listener.h"
 
 /*
  * builtins for GCC. MSVC has similar ones.

--- a/main/cpp/otf_api/Listener.h
+++ b/main/cpp/otf_api/Listener.h
@@ -23,12 +23,12 @@
 
 #include <stack>
 
-#include "otf_api/OnNext.h"
-#include "otf_api/OnError.h"
-#include "otf_api/OnCompleted.h"
-#include "otf_api/Field.h"
-#include "otf_api/Group.h"
-#include "otf_api/Ir.h"
+#include "OnNext.h"
+#include "OnError.h"
+#include "OnCompleted.h"
+#include "Field.h"
+#include "Group.h"
+#include "Ir.h"
 
 /**
  * \mainpage Simple Binary Encoding

--- a/main/cpp/otf_api/OnError.h
+++ b/main/cpp/otf_api/OnError.h
@@ -16,7 +16,7 @@
 #ifndef _ONERROR_H_
 #define _ONERROR_H_
 
-#include "otf_api/Field.h"
+#include "Field.h"
 
 namespace sbe {
 namespace on_the_fly {

--- a/main/cpp/otf_api/OnNext.h
+++ b/main/cpp/otf_api/OnNext.h
@@ -16,8 +16,8 @@
 #ifndef _ONNEXT_H_
 #define _ONNEXT_H_
 
-#include "otf_api/Field.h"
-#include "otf_api/Group.h"
+#include "Field.h"
+#include "Group.h"
 
 namespace sbe {
 namespace on_the_fly {

--- a/main/java/uk/co/real_logic/sbe/generation/cpp98/Cpp98Generator.java
+++ b/main/java/uk/co/real_logic/sbe/generation/cpp98/Cpp98Generator.java
@@ -732,8 +732,7 @@ public class Cpp98Generator implements CodeGenerator
             for (final String incName : typesToInclude)
             {
                 sb.append(String.format(
-                    "#include <%1$s/%2$s.hpp>\n",
-                    namespaceName,
+                    "#include \"%1$s.hpp\"\n",
                     toUpperFirstChar(incName)
                 ));
             }


### PR DESCRIPTION
Using relative includes makes it much easier to drop the shipped headers and generated code into a C++ project.  Adjust the OTF and generated headers to use relative includes.