### PR TITLE
Classes and methods that rely on default system encoding should not be used

### DIFF
--- a/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleUsingGeneratedStub.java
+++ b/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleUsingGeneratedStub.java
@@ -23,6 +23,7 @@ import java.io.FileOutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.Charset;
 
 public class ExampleUsingGeneratedStub
 {
@@ -154,7 +155,7 @@ public class ExampleUsingGeneratedStub
             .next().mph(60).seconds(7.1f)
             .next().mph(100).seconds(11.8f);
 
-        car.make(new String(MAKE));
+        car.make(new String(MAKE, Charset.forName("UTF-8")));
         car.putModel(MODEL, srcOffset, MODEL.length);
         car.putActivationCode(ACTIVATION_CODE, 0, ACTIVATION_CODE.capacity());
 
@@ -239,7 +240,7 @@ public class ExampleUsingGeneratedStub
 
         final UnsafeBuffer tempBuffer = new UnsafeBuffer(buffer);
         final int tempBufferLength = car.getActivationCode(tempBuffer, 0, tempBuffer.capacity());
-        sb.append("\ncar.activationCode=").append(new String(buffer, 0, tempBufferLength));
+        sb.append("\ncar.activationCode=").append(new String(buffer, 0, tempBufferLength, Charset.forName("UTF-8")));
 
         sb.append("\ncar.encodedLength=").append(car.encodedLength());
 

--- a/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleUsingGeneratedStubExtension.java
+++ b/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleUsingGeneratedStubExtension.java
@@ -22,6 +22,7 @@ import java.io.FileOutputStream;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
+import java.nio.charset.Charset;
 
 import static extension.CarEncoder.cupHolderCountNullValue;
 
@@ -247,7 +248,7 @@ public class ExampleUsingGeneratedStubExtension
 
         final UnsafeBuffer tempBuffer = new UnsafeBuffer(buffer);
         final int tempBufferLength = car.getActivationCode(tempBuffer, 0, tempBuffer.capacity());
-        sb.append("\ncar.activationCode=").append(new String(buffer, 0, tempBufferLength));
+        sb.append("\ncar.activationCode=").append(new String(buffer, 0, tempBufferLength, Charset.forName("UTF-8")));
 
         sb.append("\ncar.encodedLength=").append(car.encodedLength());
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/PrimitiveValue.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/PrimitiveValue.java
@@ -17,6 +17,7 @@ package uk.co.real_logic.sbe;
 
 import java.io.UnsupportedEncodingException;
 import java.math.BigInteger;
+import java.nio.charset.Charset;
 import java.util.Arrays;
 
 import static java.lang.Double.doubleToLongBits;
@@ -154,7 +155,7 @@ public class PrimitiveValue
                 {
                     throw new IllegalArgumentException("Constant char value malformed: " + value);
                 }
-                return new PrimitiveValue((long)value.getBytes()[0], 1);
+                return new PrimitiveValue((long)value.getBytes(Charset.forName("UTF-8"))[0], 1);
 
             case INT8:
                 return new PrimitiveValue(Byte.parseByte(value), 1);


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1943 Classes and methods that rely on default system encoding should not be used

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1943


Please let me know if you have any questions.

Zeeshan
