### PR TITLE
Code Improvements: remove useless parentheses, dead stores & change mutable members

### DIFF
--- a/sbe-benchmarks/src/main/java/uk/co/real_logic/sbe/CarBenchmark.java
+++ b/sbe-benchmarks/src/main/java/uk/co/real_logic/sbe/CarBenchmark.java
@@ -239,9 +239,9 @@ public class CarBenchmark
         System.out.printf(
             "%d - %d(ns) average duration for %s.testEncode() - message encodedLength %d\n",
             runNumber,
-            (totalDuration / reps),
+            totalDuration / reps,
             benchmark.getClass().getName(),
-            (state.carEncoder.encodedLength() + state.messageHeaderEncoder.encodedLength()));
+            state.carEncoder.encodedLength() + state.messageHeaderEncoder.encodedLength());
     }
 
     private static void perfTestDecode(final int runNumber)
@@ -261,8 +261,8 @@ public class CarBenchmark
         System.out.printf(
             "%d - %d(ns) average duration for %s.testDecode() - message encodedLength %d\n",
             runNumber,
-            (totalDuration / reps),
+            totalDuration / reps,
             benchmark.getClass().getName(),
-            (state.carDecoder.encodedLength() + state.messageHeaderDecoder.encodedLength()));
+            state.carDecoder.encodedLength() + state.messageHeaderDecoder.encodedLength());
     }
 }

--- a/sbe-benchmarks/src/main/java/uk/co/real_logic/sbe/MarketDataBenchmark.java
+++ b/sbe-benchmarks/src/main/java/uk/co/real_logic/sbe/MarketDataBenchmark.java
@@ -173,9 +173,9 @@ public class MarketDataBenchmark
         System.out.printf(
             "%d - %d(ns) average duration for %s.testEncode() - message encodedLength %d\n",
             runNumber,
-            (totalDuration / reps),
+            totalDuration / reps,
             benchmark.getClass().getName(),
-            (state.marketDataEncoder.encodedLength() + state.messageHeaderEncoder.encodedLength()));
+            state.marketDataEncoder.encodedLength() + state.messageHeaderEncoder.encodedLength());
     }
 
     private static void perfTestDecode(final int runNumber)
@@ -195,8 +195,8 @@ public class MarketDataBenchmark
         System.out.printf(
             "%d - %d(ns) average duration for %s.testDecode() - message encodedLength %d\n",
             runNumber,
-            (totalDuration / reps),
+            totalDuration / reps,
             benchmark.getClass().getName(),
-            (state.marketDataDecoder.encodedLength() + state.messageHeaderDecoder.encodedLength()));
+            state.marketDataDecoder.encodedLength() + state.messageHeaderDecoder.encodedLength());
     }
 }

--- a/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/OtfExample.java
+++ b/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/OtfExample.java
@@ -66,7 +66,6 @@ public class OtfExample
         final UnsafeBuffer buffer = new UnsafeBuffer(encodedMsgBuffer);
 
         final int templateId = headerDecoder.getTemplateId(buffer, bufferOffset);
-        final int schemaId = headerDecoder.getSchemaId(buffer, bufferOffset);
         final int actingVersion = headerDecoder.getSchemaVersion(buffer, bufferOffset);
         final int blockLength = headerDecoder.getBlockLength(buffer, bufferOffset);
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/PrimitiveValue.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/PrimitiveValue.java
@@ -257,7 +257,7 @@ public class PrimitiveValue
             throw new IllegalStateException("PrimitiveValue is not a byte[] representation");
         }
 
-        return byteArrayValue;
+        return byteArrayValue.clone();
     }
 
     /**
@@ -271,12 +271,12 @@ public class PrimitiveValue
     {
         if (representation == Representation.BYTE_ARRAY)
         {
-            return byteArrayValue;
+            return byteArrayValue.clone();
         }
         else if (representation == Representation.LONG && size == 1 && type == PrimitiveType.CHAR)
         {
             byteArrayValueForLong[0] = (byte)longValue;
-            return byteArrayValueForLong;
+            return byteArrayValueForLong.clone();
         }
 
         throw new IllegalStateException("PrimitiveValue is not a byte[] representation");


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:UselessParenthesesCheck Useless parentheses around expression shoud be removed to prevent any misunderstanding
squid:S1854 Dead stores should be removed
squid:S2384 Mutable members should not be stored or return directly

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:UselessParenthesesCheck
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1854
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2384

Please let me know if you have any questions.

Zeeshan
