### PR TITLE
Utility classs should not have public constructors

### DIFF
--- a/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleUsingGeneratedStub.java
+++ b/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleUsingGeneratedStub.java
@@ -24,15 +24,15 @@ import java.io.UnsupportedEncodingException;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 
-public class ExampleUsingGeneratedStub
+public final class ExampleUsingGeneratedStub
 {
+
     private static final String ENCODING_FILENAME = "sbe.encoding.filename";
     private static final byte[] VEHICLE_CODE;
     private static final byte[] MANUFACTURER_CODE;
     private static final byte[] MAKE;
     private static final byte[] MODEL;
     private static final UnsafeBuffer ACTIVATION_CODE;
-
     private static final MessageHeaderDecoder MESSAGE_HEADER_DECODER = new MessageHeaderDecoder();
     private static final MessageHeaderEncoder MESSAGE_HEADER_ENCODER = new MessageHeaderEncoder();
     private static final CarDecoder CAR_DECODER = new CarDecoder();
@@ -52,6 +52,11 @@ public class ExampleUsingGeneratedStub
         {
             throw new RuntimeException(ex);
         }
+    }
+
+    private ExampleUsingGeneratedStub()
+    {
+        throw new AssertionError("Must not instantiate this class.");
     }
 
     public static void main(final String[] args) throws Exception

--- a/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleUsingGeneratedStubExtension.java
+++ b/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleUsingGeneratedStubExtension.java
@@ -25,7 +25,7 @@ import java.nio.channels.FileChannel;
 
 import static extension.CarEncoder.cupHolderCountNullValue;
 
-public class ExampleUsingGeneratedStubExtension
+public final class ExampleUsingGeneratedStubExtension
 {
     private static final String ENCODING_FILENAME = "sbe.encoding.filename";
     private static final byte[] VEHICLE_CODE;
@@ -56,6 +56,11 @@ public class ExampleUsingGeneratedStubExtension
         {
             throw new RuntimeException(ex);
         }
+    }
+
+    private ExampleUsingGeneratedStubExtension()
+    {
+        throw new AssertionError("Must not instantiate this class.");
     }
 
     public static void main(final String[] args) throws Exception

--- a/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/OtfExample.java
+++ b/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/OtfExample.java
@@ -36,12 +36,17 @@ import java.io.PrintWriter;
 import java.nio.ByteBuffer;
 import java.util.List;
 
-public class OtfExample
+public final class OtfExample
 {
     private static final MessageHeaderEncoder MESSAGE_HEADER = new MessageHeaderEncoder();
     private static final CarEncoder CAR_ENCODER = new CarEncoder();
     private static final int MSG_BUFFER_CAPACITY = 4 * 1024;
     private static final int SCHEMA_BUFFER_CAPACITY = 16 * 1024;
+
+    private OtfExample()
+    {
+        throw new AssertionError("Must not instantiate this class.");
+    }
 
     public static void main(final String[] args) throws Exception
     {

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/PrimitiveType.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/PrimitiveType.java
@@ -144,8 +144,13 @@ public enum PrimitiveType
      * Used to hold a reference to the values array without having it defensively copied
      * on every call to {@link PrimitiveType#values()}.
      */
-    static class Singleton
+    static final class Singleton
     {
+        private Singleton()
+        {
+            throw new AssertionError("Must not instantiate this class.");
+        }
+
         public static final PrimitiveType[] VALUES = PrimitiveType.values();
     }
 }

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/SbeTool.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/SbeTool.java
@@ -53,8 +53,13 @@ import java.io.FileInputStream;
  * <li><code>sbe.output.dir</code>: Target directory for code generation, defaults to current directory.</li>
  * </ul>
  */
-public class SbeTool
+public final class SbeTool
 {
+    private SbeTool()
+    {
+        throw new AssertionError("Must not instantiate this class.");
+    }
+
     /**
      * Boolean system property to control throwing exceptions on all errors
      */

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppUtil.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppUtil.java
@@ -24,7 +24,7 @@ import java.util.Map;
 /**
  * Utilities for mapping between IR and the C++ language.
  */
-public class CppUtil
+public final class CppUtil
 {
     private static Map<PrimitiveType, String> typeNameByPrimitiveTypeMap = new EnumMap<>(PrimitiveType.class);
 
@@ -41,6 +41,11 @@ public class CppUtil
         typeNameByPrimitiveTypeMap.put(PrimitiveType.UINT64, "std::uint64_t");
         typeNameByPrimitiveTypeMap.put(PrimitiveType.FLOAT, "float");
         typeNameByPrimitiveTypeMap.put(PrimitiveType.DOUBLE, "double");
+    }
+
+    private CppUtil()
+    {
+        throw new AssertionError("Must not instantiate this class.");
     }
 
     /**

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaUtil.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaUtil.java
@@ -23,7 +23,7 @@ import java.util.Map;
 /**
  * Utilities for mapping between IR and the Java language.
  */
-public class JavaUtil
+public final class JavaUtil
 {
     private static final Map<PrimitiveType, String> TYPE_NAME_BY_PRIMITIVE_TYPE_MAP = new EnumMap<>(PrimitiveType.class);
 
@@ -41,6 +41,12 @@ public class JavaUtil
         TYPE_NAME_BY_PRIMITIVE_TYPE_MAP.put(PrimitiveType.FLOAT, "float");
         TYPE_NAME_BY_PRIMITIVE_TYPE_MAP.put(PrimitiveType.DOUBLE, "double");
     }
+
+    private JavaUtil()
+    {
+        throw new AssertionError("Must not instantiate this class.");
+    }
+
 
     /**
      * Map the name of a {@link uk.co.real_logic.sbe.PrimitiveType} to a Java primitive type name.

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/IrUtil.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/IrUtil.java
@@ -27,9 +27,14 @@ import uk.co.real_logic.sbe.ir.generated.SignalCodec;
 import java.io.UnsupportedEncodingException;
 import java.nio.ByteOrder;
 
-public class IrUtil
+public final class IrUtil
 {
     public static final byte[] EMPTY_BUFFER = new byte[0];
+
+    private IrUtil()
+    {
+        throw new AssertionError("Must not instantiate this class.");
+    }
 
     public static ByteOrderCodec mapByteOrder(final ByteOrder byteOrder)
     {

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/otf/OtfMessageDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/otf/OtfMessageDecoder.java
@@ -34,8 +34,13 @@ import static uk.co.real_logic.sbe.ir.Signal.BEGIN_VAR_DATA;
  * be reused repeatably by calling {@link OtfMessageDecoder#decode(DirectBuffer, int, int, int, List, TokenListener)}
  * which is thread safe to be used across multiple threads.
  */
-public class OtfMessageDecoder
+public final class OtfMessageDecoder
 {
+    private OtfMessageDecoder()
+    {
+        throw new AssertionError("Must not instantiate this class.");
+    }
+
     /**
      * Decode a message from the provided buffer based on the message schema described with IR {@link Token}s.
      *

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/otf/Types.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/otf/Types.java
@@ -24,8 +24,13 @@ import java.nio.ByteOrder;
 /**
  * Utility functions for applying to types to help with on-the-fly (OTF) decoding.
  */
-public class Types
+public final class Types
 {
+    private Types()
+    {
+        throw new AssertionError("Must not instantiate this class.");
+    }
+
     /**
      * Get an integer value from a buffer at a given index for a {@link PrimitiveType}.
      *

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/util/ValidationUtil.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/util/ValidationUtil.java
@@ -22,8 +22,13 @@ import java.util.Set;
 /**
  * Various validation utilities used across parser, IR, and generator
  */
-public class ValidationUtil
+public final class ValidationUtil
 {
+    private ValidationUtil()
+    {
+        throw new AssertionError("Must not instantiate this class.");
+    }
+
     private static boolean isSbeCppIdentifierStart(final char c)
     {
         return Character.isLetter(c) || c == '_';


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S1118 Utility classs should not have public constructors

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:S1118


Please let me know if you have any questions.

Zeeshan
