### PR TITLE
private methods that don't access instance data should be static

### DIFF
--- a/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleTokenListener.java
+++ b/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleTokenListener.java
@@ -198,7 +198,7 @@ public class ExampleTokenListener implements TokenListener
         return sb;
     }
 
-    private long readEncodingAsLong(
+    private static long readEncodingAsLong(
         final DirectBuffer buffer, final int bufferIndex, final Token typeToken, final int actingVersion)
     {
         final PrimitiveValue constOrNotPresentValue = constOrNotPresentValue(typeToken, actingVersion);

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -187,7 +187,7 @@ public class CppGenerator implements CodeGenerator
         }
     }
 
-    private void generateGroupClassHeader(
+    private static void generateGroupClassHeader(
         final StringBuilder sb, final String groupName, final List<Token> tokens, final int index, final String indent)
     {
         final String dimensionsClassName = formatClassName(tokens.get(index + 1).name());
@@ -317,7 +317,7 @@ public class CppGenerator implements CodeGenerator
         ));
     }
 
-    private CharSequence generateGroupProperty(
+    private static CharSequence generateGroupProperty(
         final String groupName, final Token token, final String cppTypeForNumInGroup, final String indent)
     {
         final StringBuilder sb = new StringBuilder();
@@ -615,7 +615,7 @@ public class CppGenerator implements CodeGenerator
         }
     }
 
-    private CharSequence generateChoiceNotPresentCondition(final int sinceVersion, final String indent)
+    private static CharSequence generateChoiceNotPresentCondition(final int sinceVersion, final String indent)
     {
         if (0 == sinceVersion)
         {
@@ -707,7 +707,7 @@ public class CppGenerator implements CodeGenerator
         return sb;
     }
 
-    private CharSequence generateEnumLookupMethod(final List<Token> tokens, final Token encodingToken)
+    private static CharSequence generateEnumLookupMethod(final List<Token> tokens, final Token encodingToken)
     {
         final String enumName = formatClassName(encodingToken.name());
         final StringBuilder sb = new StringBuilder();
@@ -759,7 +759,7 @@ public class CppGenerator implements CodeGenerator
         );
     }
 
-    private CharSequence generateArrayFieldNotPresentCondition(final int sinceVersion, final String indent)
+    private static CharSequence generateArrayFieldNotPresentCondition(final int sinceVersion, final String indent)
     {
         if (0 == sinceVersion)
         {
@@ -775,7 +775,7 @@ public class CppGenerator implements CodeGenerator
         );
     }
 
-    private CharSequence generateStringNotPresentCondition(final int sinceVersion, final String indent)
+    private static CharSequence generateStringNotPresentCondition(final int sinceVersion, final String indent)
     {
         if (0 == sinceVersion)
         {
@@ -791,7 +791,7 @@ public class CppGenerator implements CodeGenerator
         );
     }
 
-    private CharSequence generateTypeFieldNotPresentCondition(final int sinceVersion, final String indent)
+    private static CharSequence generateTypeFieldNotPresentCondition(final int sinceVersion, final String indent)
     {
         if (0 == sinceVersion)
         {
@@ -807,7 +807,10 @@ public class CppGenerator implements CodeGenerator
         );
     }
 
-    private CharSequence generateFileHeader(final String namespaceName, final String className, final List<String> typesToInclude)
+    private static CharSequence generateFileHeader(
+        final String namespaceName,
+        final String className,
+        final List<String> typesToInclude)
     {
         final StringBuilder sb = new StringBuilder();
 
@@ -859,7 +862,7 @@ public class CppGenerator implements CodeGenerator
         return sb;
     }
 
-    private CharSequence generateClassDeclaration(final String className)
+    private static CharSequence generateClassDeclaration(final String className)
     {
         return String.format(
             "class %s\n" +
@@ -868,7 +871,7 @@ public class CppGenerator implements CodeGenerator
         );
     }
 
-    private CharSequence generateEnumDeclaration(final String name)
+    private static CharSequence generateEnumDeclaration(final String name)
     {
         return "class " + name + "\n{\npublic:\n\n";
     }
@@ -1227,7 +1230,7 @@ public class CppGenerator implements CodeGenerator
         return sb;
     }
 
-    private CharSequence generateFixedFlyweightCode(final String className, final int size)
+    private static CharSequence generateFixedFlyweightCode(final String className, final int size)
     {
         return String.format(
             "private:\n" +
@@ -1290,7 +1293,7 @@ public class CppGenerator implements CodeGenerator
         );
     }
 
-    private CharSequence generateConstructorsAndOperators(final String className)
+    private static CharSequence generateConstructorsAndOperators(final String className)
     {
         return String.format(
             "    %1$s(void) : m_buffer(nullptr), m_bufferLength(0), m_offset(0) {}\n\n" +
@@ -1497,7 +1500,7 @@ public class CppGenerator implements CodeGenerator
         return sb;
     }
 
-    private void generateFieldMetaAttributeMethod(final StringBuilder sb, final Token token, final String indent)
+    private static void generateFieldMetaAttributeMethod(final StringBuilder sb, final Token token, final String indent)
     {
         final Encoding encoding = token.encoding();
         final String epoch = encoding.epoch() == null ? "" : encoding.epoch();
@@ -1523,7 +1526,10 @@ public class CppGenerator implements CodeGenerator
         ));
     }
 
-    private CharSequence generateEnumFieldNotPresentCondition(final int sinceVersion, final String enumName, final String indent)
+    private static CharSequence generateEnumFieldNotPresentCondition(
+        final int sinceVersion,
+        final String enumName,
+        final String indent)
     {
         if (0 == sinceVersion)
         {
@@ -1605,7 +1611,7 @@ public class CppGenerator implements CodeGenerator
         return sb;
     }
 
-    private Object generateBitsetProperty(final String propertyName, final Token token, final String indent)
+    private static Object generateBitsetProperty(final String propertyName, final Token token, final String indent)
     {
         final StringBuilder sb = new StringBuilder();
 
@@ -1636,7 +1642,7 @@ public class CppGenerator implements CodeGenerator
         return sb;
     }
 
-    private Object generateCompositeProperty(final String propertyName, final Token token, final String indent)
+    private static Object generateCompositeProperty(final String propertyName, final Token token, final String indent)
     {
         final String compositeName = formatClassName(token.name());
         final int offset = token.offset();

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -70,7 +70,7 @@ public class JavaGenerator implements CodeGenerator
         this.shouldGenerateGroupOrderAnnotation = shouldGenerateGroupOrderAnnotation;
     }
 
-    private String validateBufferImplementation(
+    private static String validateBufferImplementation(
         final String fullyQualifiedBufferImplementation, final Class<?> bufferClass)
     {
         Verify.notNull(fullyQualifiedBufferImplementation, "fullyQualifiedBufferImplementation");
@@ -460,7 +460,7 @@ public class JavaGenerator implements CodeGenerator
         ));
     }
 
-    private String primitiveTypeName(final Token token)
+    private static String primitiveTypeName(final Token token)
     {
         return javaTypeName(token.encoding().primitiveType());
     }
@@ -524,7 +524,7 @@ public class JavaGenerator implements CodeGenerator
         ));
     }
 
-    private CharSequence generateGroupDecoderProperty(final String groupName, final Token token, final String indent)
+    private static CharSequence generateGroupDecoderProperty(final String groupName, final Token token, final String indent)
     {
         final StringBuilder sb = new StringBuilder();
         final String className = formatClassName(groupName);
@@ -1159,7 +1159,7 @@ public class JavaGenerator implements CodeGenerator
         return sb;
     }
 
-    private CharSequence generateFileHeader(final String className, final String packageName, final String fqBuffer)
+    private static CharSequence generateFileHeader(final String className, final String packageName, final String fqBuffer)
     {
         return String.format(
             "/* Generated SBE (Simple Binary Encoding) message codec */\n" +
@@ -1173,7 +1173,7 @@ public class JavaGenerator implements CodeGenerator
         );
     }
 
-    private CharSequence generateEnumFileHeader(final String className, final String packageName)
+    private static CharSequence generateEnumFileHeader(final String className, final String packageName)
     {
         return String.format(
             "/* Generated SBE (Simple Binary Encoding) message codec */\n" +
@@ -1236,7 +1236,7 @@ public class JavaGenerator implements CodeGenerator
         }
     }
 
-    private CharSequence generateClassDeclaration(final String className)
+    private static CharSequence generateClassDeclaration(final String className)
     {
         return String.format(
             "@SuppressWarnings(\"all\")\n" +
@@ -1266,7 +1266,7 @@ public class JavaGenerator implements CodeGenerator
         }
     }
 
-    private CharSequence generateEnumDeclaration(final String name)
+    private static CharSequence generateEnumDeclaration(final String name)
     {
         return "public enum " + name + "\n{\n";
     }
@@ -1429,7 +1429,7 @@ public class JavaGenerator implements CodeGenerator
         );
     }
 
-    private CharSequence generateArrayFieldNotPresentCondition(final int sinceVersion, final String indent)
+    private static CharSequence generateArrayFieldNotPresentCondition(final int sinceVersion, final String indent)
     {
         if (0 == sinceVersion)
         {
@@ -1445,7 +1445,7 @@ public class JavaGenerator implements CodeGenerator
         );
     }
 
-    private CharSequence generateStringNotPresentCondition(final int sinceVersion, final String indent)
+    private static CharSequence generateStringNotPresentCondition(final int sinceVersion, final String indent)
     {
         if (0 == sinceVersion)
         {
@@ -1461,7 +1461,7 @@ public class JavaGenerator implements CodeGenerator
         );
     }
 
-    private CharSequence generateTypeFieldNotPresentCondition(final int sinceVersion, final String indent)
+    private static CharSequence generateTypeFieldNotPresentCondition(final int sinceVersion, final String indent)
     {
         if (0 == sinceVersion)
         {
@@ -1538,7 +1538,7 @@ public class JavaGenerator implements CodeGenerator
         return sb;
     }
 
-    private void generateArrayLengthMethod(
+    private static void generateArrayLengthMethod(
         final String propertyName, final String indent, final int fieldLength, final StringBuilder sb)
     {
         sb.append(String.format(
@@ -1615,12 +1615,12 @@ public class JavaGenerator implements CodeGenerator
         return sb;
     }
 
-    private int sizeOfPrimitive(final Encoding encoding)
+    private static int sizeOfPrimitive(final Encoding encoding)
     {
         return encoding.primitiveType().size();
     }
 
-    private void generateCharacterEncodingMethod(
+    private static void generateCharacterEncodingMethod(
         final StringBuilder sb, final String propertyName, final String encoding, final String indent)
     {
         sb.append(String.format(
@@ -1691,7 +1691,7 @@ public class JavaGenerator implements CodeGenerator
         return sb;
     }
 
-    private CharSequence generateByteLiteralList(final byte[] bytes)
+    private static CharSequence generateByteLiteralList(final byte[] bytes)
     {
         final StringBuilder values = new StringBuilder();
         for (final byte b : bytes)
@@ -1707,7 +1707,7 @@ public class JavaGenerator implements CodeGenerator
         return values;
     }
 
-    private CharSequence generateFixedFlyweightCode(
+    private static CharSequence generateFixedFlyweightCode(
         final String className, final int size, final boolean callsSuper, final String bufferImplementation)
     {
         final String body = callsSuper ?
@@ -1915,7 +1915,7 @@ public class JavaGenerator implements CodeGenerator
         return sb;
     }
 
-    private void eachField(final List<Token> tokens, final BiConsumer<Token, Token> consumer)
+    private static void eachField(final List<Token> tokens, final BiConsumer<Token, Token> consumer)
     {
         for (int i = 0, size = tokens.size(); i < size;)
         {
@@ -1933,7 +1933,7 @@ public class JavaGenerator implements CodeGenerator
         }
     }
 
-    private void generateFieldIdMethod(final StringBuilder sb, final Token token, final String indent)
+    private static void generateFieldIdMethod(final StringBuilder sb, final Token token, final String indent)
     {
         sb.append(String.format(
             "\n" +
@@ -1946,7 +1946,7 @@ public class JavaGenerator implements CodeGenerator
         ));
     }
 
-    private void generateFieldMetaAttributeMethod(final StringBuilder sb, final Token token, final String indent)
+    private static void generateFieldMetaAttributeMethod(final StringBuilder sb, final Token token, final String indent)
     {
         final Encoding encoding = token.encoding();
         final String epoch = encoding.epoch() == null ? "" : encoding.epoch();

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/IrDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/IrDecoder.java
@@ -128,7 +128,7 @@ public class IrDecoder implements AutoCloseable
         return index;
     }
 
-    private int captureMessage(final List<Token> tokens, int index, final Ir ir)
+    private static int captureMessage(final List<Token> tokens, int index, final Ir ir)
     {
         final List<Token> messageTokens = new ArrayList<>();
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/json/JsonTokenListener.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/json/JsonTokenListener.java
@@ -127,7 +127,7 @@ public class JsonTokenListener implements TokenListener
         }
     }
 
-    private boolean isLastGroup(final int groupIndex, final int numInGroup)
+    private static boolean isLastGroup(final int groupIndex, final int numInGroup)
     {
         return groupIndex == numInGroup - 1;
     }

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/IrGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/IrGenerator.java
@@ -412,7 +412,7 @@ public class IrGenerator
         tokenList.add(token);
     }
 
-    private String semanticTypeOf(final Type type, final Field field)
+    private static String semanticTypeOf(final Type type, final Field field)
     {
         final String typeSemanticType = null != type ? type.semanticType() : null;
         if (typeSemanticType != null)

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/Message.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/Message.java
@@ -382,7 +382,7 @@ public class Message
         return blockLength;
     }
 
-    private void validateBlockLength(final Node node, final long specifiedBlockLength, final long computedBlockLength)
+    private static void validateBlockLength(final Node node, final long specifiedBlockLength, final long computedBlockLength)
     {
         if (0 != specifiedBlockLength && computedBlockLength > specifiedBlockLength)
         {


### PR DESCRIPTION
This pull request is focused on resolving occurrences of Sonar rule 
squid:S2325 private methods that don't access instance data should be static

You can find more information about the issue here: 
https://dev.eclipse.org/sonar/coding_rules#q=squid:S2325


Please let me know if you have any questions.

Zeeshan
