### PR TITLE
[Java] default output directory of SbeTool to CWD

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/SbeTool.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/SbeTool.java
@@ -171,9 +171,9 @@ public class SbeTool
                 return;
             }
 
+            final String outputDirName = System.getProperty(OUTPUT_DIR, ".");
             if (Boolean.parseBoolean(System.getProperty(GENERATE_STUBS, "true")))
             {
-                final String outputDirName = System.getProperty(OUTPUT_DIR, "");
                 final String targetLanguage = System.getProperty(TARGET_LANGUAGE, "Java");
 
                 generate(ir, outputDirName, targetLanguage);
@@ -187,7 +187,6 @@ public class SbeTool
                 final int nameEnd = inputFilename.lastIndexOf('.');
                 final String namePart = inputFilename.substring(0, nameEnd);
 
-                final String outputDirName = System.getProperty(OUTPUT_DIR, "");
                 final File fullPath = new File(outputDirName, namePart + ".sbeir");
 
                 try (final IrEncoder irEncoder = new IrEncoder(fullPath.getAbsolutePath(), ir))


### PR DESCRIPTION
The docs [here](https://github.com/real-logic/simple-binary-encoding/wiki/Sbe-Tool-Guide) say the output directory defaults to current : "sbe.output.dir: Target directory for output generation, defaults to current directory."

However it attempts to write to /packagename.

Small patch to fix that.