### PR TITLE
C++ nested namespaces

### DIFF
--- a/sbe-benchmarks/src/main/cpp/SbeCarCodecBench.h
+++ b/sbe-benchmarks/src/main/cpp/SbeCarCodecBench.h
@@ -19,7 +19,7 @@
 #include "CodecBench.h"
 #include "uk_co_real_logic_sbe_benchmarks/Car.h"
 
-using namespace uk_co_real_logic_sbe_benchmarks;
+using namespace uk::co::real_logic::sbe::benchmarks;
 
 char VEHICLE_CODE[] = {'a', 'b', 'c', 'd', 'e', 'f'};
 uint32_t SOMENUMBERS[] = { 1, 2, 3, 4, 5 };

--- a/sbe-benchmarks/src/main/cpp/SbeMarketDataCodecBench.h
+++ b/sbe-benchmarks/src/main/cpp/SbeMarketDataCodecBench.h
@@ -20,7 +20,7 @@
 #include "uk_co_real_logic_sbe_benchmarks_fix/MessageHeader.h"
 #include "uk_co_real_logic_sbe_benchmarks_fix/MarketDataIncrementalRefreshTrades.h"
 
-using namespace uk_co_real_logic_sbe_benchmarks_fix;
+using namespace uk::co::real_logic::sbe::benchmarks::fix;
 
 class SbeMarketDataCodecBench : public CodecBench<SbeMarketDataCodecBench>
 {

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/SbeTool.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/SbeTool.java
@@ -122,6 +122,11 @@ public class SbeTool
     public static final String JAVA_GENERATE_INTERFACES = "sbe.java.generate.interfaces";
 
     /**
+     * Boolean system property to turn on or off collapsing of nested namespaces in generated C++ stubs. Defaults to false.
+     */
+    public static final String CPP_NAMESPACES_COLLAPSE = "sbe.cpp.namespaces.collapse";
+
+    /**
      * Package in which the generated Java interfaces will be placed.
      */
     public static final String JAVA_INTERFACE_PACKAGE = "org.agrona.sbe";

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -56,13 +56,13 @@ public class CppGenerator implements CodeGenerator
         try (final Writer out = outputManager.createOutput(messageHeader))
         {
             final List<Token> tokens = ir.headerStructure().tokens();
-            out.append(generateFileHeader(ir.applicableNamespace().replace('.', '_'), messageHeader, null));
+            out.append(generateFileHeader(ir.namespaces(), messageHeader, null));
             out.append(generateClassDeclaration(messageHeader));
             out.append(generateFixedFlyweightCode(messageHeader, tokens.get(0).encodedLength()));
             out.append(generateCompositePropertyElements(
                 messageHeader, tokens.subList(1, tokens.size() - 1), BASE_INDENT));
 
-            out.append("};\n}\n#endif\n");
+            out.append(CppUtil.closingBraces(ir.namespaces().length) + "}\n#endif\n");
         }
     }
 
@@ -124,7 +124,7 @@ public class CppGenerator implements CodeGenerator
 
             try (final Writer out = outputManager.createOutput(className))
             {
-                out.append(generateFileHeader(ir.applicableNamespace().replace('.', '_'), className, typesToInclude));
+                out.append(generateFileHeader(ir.namespaces(), className, typesToInclude));
                 out.append(generateClassDeclaration(className));
                 out.append(generateMessageFlyweightCode(className, msgToken));
 
@@ -146,7 +146,7 @@ public class CppGenerator implements CodeGenerator
                 out.append(sb);
                 out.append(generateVarData(className, varData, BASE_INDENT));
 
-                out.append("};\n}\n#endif\n");
+                out.append(CppUtil.closingBraces(ir.namespaces().length) + "}\n#endif\n");
             }
         }
     }
@@ -566,7 +566,7 @@ public class CppGenerator implements CodeGenerator
 
         try (final Writer out = outputManager.createOutput(bitSetName))
         {
-            out.append(generateFileHeader(ir.applicableNamespace().replace('.', '_'), bitSetName, null));
+            out.append(generateFileHeader(ir.namespaces(), bitSetName, null));
             out.append(generateClassDeclaration(bitSetName));
             out.append(generateFixedFlyweightCode(bitSetName, tokens.get(0).encodedLength()));
 
@@ -583,7 +583,7 @@ public class CppGenerator implements CodeGenerator
 
             out.append(generateChoices(bitSetName, tokens.subList(1, tokens.size() - 1)));
 
-            out.append("};\n}\n#endif\n");
+            out.append(CppUtil.closingBraces(ir.namespaces().length) + "}\n#endif\n");
         }
     }
 
@@ -594,14 +594,14 @@ public class CppGenerator implements CodeGenerator
 
         try (final Writer out = outputManager.createOutput(enumName))
         {
-            out.append(generateFileHeader(ir.applicableNamespace().replace('.', '_'), enumName, null));
+            out.append(generateFileHeader(ir.namespaces(), enumName, null));
             out.append(generateEnumDeclaration(enumName));
 
             out.append(generateEnumValues(tokens.subList(1, tokens.size() - 1), enumToken));
 
             out.append(generateEnumLookupMethod(tokens.subList(1, tokens.size() - 1), enumToken));
 
-            out.append("};\n}\n#endif\n");
+            out.append(CppUtil.closingBraces(ir.namespaces().length) + "}\n#endif\n");
         }
     }
 
@@ -611,14 +611,14 @@ public class CppGenerator implements CodeGenerator
 
         try (final Writer out = outputManager.createOutput(compositeName))
         {
-            out.append(generateFileHeader(ir.applicableNamespace().replace('.', '_'), compositeName,
+            out.append(generateFileHeader(ir.namespaces(), compositeName,
                 generateTypesToIncludes(tokens.subList(1, tokens.size() - 1))));
             out.append(generateClassDeclaration(compositeName));
             out.append(generateFixedFlyweightCode(compositeName, tokens.get(0).encodedLength()));
 
             out.append(generateCompositePropertyElements(compositeName, tokens.subList(1, tokens.size() - 1), BASE_INDENT));
 
-            out.append("};\n}\n#endif\n");
+            out.append(CppUtil.closingBraces(ir.namespaces().length) + "}\n#endif\n");
         }
     }
 
@@ -815,7 +815,7 @@ public class CppGenerator implements CodeGenerator
     }
 
     private static CharSequence generateFileHeader(
-        final String namespaceName,
+        final String[] namespaces,
         final String className,
         final List<String> typesToInclude)
     {
@@ -844,7 +844,7 @@ public class CppGenerator implements CodeGenerator
             "#  include <cstring>\n" +
             "#endif\n\n" +
             "#include <sbe/sbe.h>\n\n",
-            namespaceName.toUpperCase(),
+            String.join("_", namespaces).toUpperCase(),
             className.toUpperCase()
         ));
 
@@ -860,11 +860,12 @@ public class CppGenerator implements CodeGenerator
             sb.append("\n");
         }
 
-        sb.append(String.format(
+        sb.append(
             "using namespace sbe;\n\n" +
-            "namespace %1$s {\n\n",
-            namespaceName
-        ));
+            "namespace " +
+            String.join(" {\nnamespace ", namespaces) +
+            " {\n\n"
+        );
 
         return sb;
     }

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppUtil.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppUtil.java
@@ -139,4 +139,9 @@ public class CppUtil
                 return "";
         }
     }
+
+    public static String closingBraces(final int count)
+    {
+        return new String(new char[count]).replace("\0", "};\n");
+    }
 }

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/Ir.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/Ir.java
@@ -18,6 +18,7 @@ package uk.co.real_logic.sbe.ir;
 import org.agrona.Verify;
 
 import java.util.*;
+import java.util.regex.Pattern;
 
 /**
  * Intermediate representation of SBE messages to be used for the generation of encoders and decoders
@@ -34,6 +35,8 @@ public class Ir
     private final HeaderStructure headerStructure;
     private final Map<Long, List<Token>> messagesByIdMap = new HashMap<>();
     private final Map<String, List<Token>> typesByNameMap = new HashMap<>();
+
+    private final String[] namespaces;
 
     /**
      * Create a new IR container taking a defensive copy of the headerStructure {@link Token}s passed.
@@ -62,6 +65,8 @@ public class Ir
         this.version = version;
         this.semanticVersion = semanticVersion;
         this.headerStructure = new HeaderStructure(new ArrayList<>(headerTokens));
+
+        this.namespaces = Pattern.compile("\\.").split(namespaceName == null ? packageName : namespaceName);
     }
 
     /**
@@ -151,6 +156,16 @@ public class Ir
     public String namespaceName()
     {
         return namespaceName;
+    }
+
+    /**
+     * Get the namespaces array to be used for generated code.
+     *
+     * @return the namespaces array to be used for generated code.
+     */
+    public String[] namespaces()
+    {
+        return namespaces;
     }
 
     /**

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/Ir.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/Ir.java
@@ -17,6 +17,8 @@ package uk.co.real_logic.sbe.ir;
 
 import org.agrona.Verify;
 
+import uk.co.real_logic.sbe.SbeTool;
+
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -66,7 +68,14 @@ public class Ir
         this.semanticVersion = semanticVersion;
         this.headerStructure = new HeaderStructure(new ArrayList<>(headerTokens));
 
-        this.namespaces = Pattern.compile("\\.").split(namespaceName == null ? packageName : namespaceName);
+        if (Boolean.getBoolean(SbeTool.CPP_NAMESPACES_COLLAPSE))
+        {
+            this.namespaces = new String[]{ (namespaceName == null ? packageName : namespaceName).replace(".", "_") };
+        }
+        else
+        {
+            this.namespaces = Pattern.compile("\\.").split(namespaceName == null ? packageName : namespaceName);
+        }
     }
 
     /**

--- a/sbe-tool/src/test/cpp/BoundsCheckTest.cpp
+++ b/sbe-tool/src/test/cpp/BoundsCheckTest.cpp
@@ -22,7 +22,7 @@
 #include "code_generation_test/Car.h"
 
 using namespace std;
-using namespace code_generation_test;
+using namespace code::generation::test;
 
 #define SERIAL_NUMBER 1234u
 #define MODEL_YEAR 2013

--- a/sbe-tool/src/test/cpp/CodeGenTest.cpp
+++ b/sbe-tool/src/test/cpp/CodeGenTest.cpp
@@ -20,7 +20,7 @@
 #include "code_generation_test/Car.h"
 
 using namespace std;
-using namespace code_generation_test;
+using namespace code::generation::test;
 
 static const std::size_t BUFFER_LEN = 2048;
 

--- a/sbe-tool/src/test/cpp/CompositeElementsTest.cpp
+++ b/sbe-tool/src/test/cpp/CompositeElementsTest.cpp
@@ -23,7 +23,7 @@
 #include "otf/OtfMessageDecoder.h"
 
 using namespace std;
-using namespace composite_elements;
+using namespace composite::elements;
 using namespace sbe::otf;
 
 enum EventNumber

--- a/sbe-tool/src/test/cpp/CompositeOffsetsCodeGenTest.cpp
+++ b/sbe-tool/src/test/cpp/CompositeOffsetsCodeGenTest.cpp
@@ -20,7 +20,7 @@
 #include "composite_offsets_test/TestMessage1.h"
 
 using namespace std;
-using namespace composite_offsets_test;
+using namespace composite::offsets::test;
 
 class CompositeOffsetsCodeGenTest : public testing::Test
 {

--- a/sbe-tool/src/test/cpp/CompositeOffsetsIrTest.cpp
+++ b/sbe-tool/src/test/cpp/CompositeOffsetsIrTest.cpp
@@ -23,7 +23,7 @@
 #include "otf/IrDecoder.h"
 
 using namespace std;
-using namespace composite_offsets_test;
+using namespace composite::offsets::test;
 using namespace sbe::otf;
 
 static const char *SCHEMA_FILENAME = "composite-offsets-schema.sbeir";

--- a/sbe-tool/src/test/cpp/GroupWithDataTest.cpp
+++ b/sbe-tool/src/test/cpp/GroupWithDataTest.cpp
@@ -22,7 +22,7 @@
 #include "group_with_data/TestMessage4.h"
 
 using namespace std;
-using namespace group_with_data;
+using namespace group::with::data;
 
 static const sbe_uint32_t TAG_1 = 32;
 static const std::uint64_t ENTRIES_COUNT = 2;

--- a/sbe-tool/src/test/cpp/MessageBlockLengthTest.cpp
+++ b/sbe-tool/src/test/cpp/MessageBlockLengthTest.cpp
@@ -23,7 +23,7 @@
 #include "otf/OtfMessageDecoder.h"
 
 using namespace std;
-using namespace message_block_length_test;
+using namespace message::block::length::test;
 using namespace sbe::otf;
 
 class MessageBlockLengthIrTest : public testing::Test, public OtfMessageDecoder::BasicTokenListener

--- a/sbe-tool/src/test/cpp/Rc3OtfFullIrTest.cpp
+++ b/sbe-tool/src/test/cpp/Rc3OtfFullIrTest.cpp
@@ -24,7 +24,7 @@
 #include "otf/OtfMessageDecoder.h"
 
 using namespace std;
-using namespace code_generation_test;
+using namespace code::generation::test;
 
 static const char *SCHEMA_FILENAME = "code-generation-schema.sbeir";
 


### PR DESCRIPTION
Given a project name `proj.provider.messages` the currently generated C++ code is namespaced into `proj_provider_messages`, which is hardly an expected outcome.

This proposed PR will namespace the stubs properly nested:

    namespace proj {
    namespace provider {
    namespace messages {
    ......
    };
    };
    };

While it is in the _C++17_ standard to allow the collapsed syntax:

    namespace proj::provider::messages {
    ......
    };

It still may take some time to propagate throughout the toolchain, so my suggestion is to stick to the explicit nesting.

This PR addresses #121.