### PR TITLE
Correctly encode int64 minimum value.

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -1779,6 +1779,10 @@ public class CppGenerator implements CodeGenerator
 
             case INT64:
                 literal = value + "L";
+                if (value.equals("-9223372036854775808"))
+                {
+                    literal = "INT64_MIN";
+                }
                 break;
 
             case UINT64:


### PR DESCRIPTION
Due to a quirk in C++ int64 minimum value can not be encoded as
literal. You need to use INT64_MIN constant.