### PR TITLE
Use universal reference instead of paying std::function overhead

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -308,7 +308,7 @@ public class CppGenerator implements CodeGenerator
             indent + "        }\n" +
             indent + "    }\n\n" +
             indent + "#else\n" +
-            indent + "    inline void forEach(std::function<void(%1$s&)> func)\n" +
+            indent + "    template<class Func> inline void forEach(Func&& func)\n" +
             indent + "    {\n" +
             indent + "        while(hasNext())\n" +
             indent + "        {\n" +
@@ -840,7 +840,6 @@ public class CppGenerator implements CodeGenerator
             "#endif\n\n" +
             "#if __cplusplus >= 201103L\n" +
             "#  include <cstdint>\n" +
-            "#  include <functional>\n" +
             "#  include <string>\n" +
             "#  include <cstring>\n" +
             "#endif\n\n" +


### PR DESCRIPTION
Faster at runtime, less includes.