### PR TITLE
[C++]: make constant fields static constexpr

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -1176,6 +1176,11 @@ public class CppGenerator implements CodeGenerator
                 indent + "    {\n" +
                 indent + "        return %3$s;\n" +
                 indent + "    }\n",
+                "\n" +
+                indent + "    static SBE_CONSTEXPR const %1$s %2$sConst(void)\n" +
+                indent + "    {\n" +
+                indent + "        return %3$s;\n" +
+                indent + "    }\n",
                 cppTypeName,
                 propertyName,
                 generateLiteral(token.encoding().primitiveType(), token.encoding().constValue().toString())


### PR DESCRIPTION
Constant properties now are truly constant, which allows us to perform compile-time usage of them.