### PR TITLE
[C++]: Make constant fields static constexpr

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -1172,7 +1172,7 @@ public class CppGenerator implements CodeGenerator
         {
             return String.format(
                 "\n" +
-                indent + "    %1$s %2$s(void) const\n" +
+                indent + "    static SBE_CONSTEXPR const %1$s %2$s(void)\n" +
                 indent + "    {\n" +
                 indent + "        return %3$s;\n" +
                 indent + "    }\n",


### PR DESCRIPTION
Constant properties now are truly constant, which allows us to perform compile-time usage of them.

Old PR: https://github.com/real-logic/simple-binary-encoding/pull/376. This should be good now.