### PR TITLE
[C++]: Expose buffer in fixed flyweights

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -1299,6 +1299,14 @@ public class CppGenerator implements CodeGenerator
             "    static SBE_CONSTEXPR const std::uint64_t encodedLength(void)\n" +
             "    {\n" +
             "        return %2$s;\n" +
+            "    }\n\n" +
+            "    std::uint64_t offset(void) const\n" +
+            "    {\n" +
+            "        return m_offset;\n" +
+            "    }\n\n" +
+            "    char *buffer(void)\n" +
+            "    {\n" +
+            "        return m_buffer;\n" +
             "    }\n\n",
             className,
             size


### PR DESCRIPTION
We already expose them for messages, so this shouldn't pose problems.