### PR TITLE
[Java] add new convenience methods to get char arrays as string.

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -1621,6 +1621,23 @@ public class JavaGenerator implements CodeGenerator
                 fieldLength,
                 generateArrayFieldNotPresentCondition(token.version(), indent),
                 offset));
+
+            sb.append(String.format(
+                "\n" +
+                indent + "    public String %s()\n" +
+                indent + "    {\n" +
+                "%s" +
+                indent + "        final byte[] dst = new byte[%d];\n" +
+                indent + "        buffer.getBytes(this.offset + %d, dst, 0, %d);\n\n" +
+                indent + "        int end = 0;\n" +
+                indent + "        for (; end < %d && dst[end] != 0; ++end);\n\n" +
+                indent + "        return new String(dst, 0, end, %s);\n" +
+                indent + "    }\n\n",
+                formatPropertyName(propertyName),
+                generateStringNotPresentCondition(token.version(), indent),
+                fieldLength, offset,
+                fieldLength, fieldLength,
+                charset(encoding.characterEncoding())));
         }
 
         return sb;
@@ -1694,6 +1711,30 @@ public class JavaGenerator implements CodeGenerator
                 formatClassName(containingClassName),
                 toUpperFirstChar(propertyName),
                 fieldLength,
+                offset));
+
+            sb.append(String.format(
+                indent + "    public %s put%s(final String src)\n" +
+                indent + "    {\n" +
+                indent + "        final int length = %d;\n" +
+                indent + "        final byte[] bytes = src.getBytes(%s);\n" +
+                indent + "        if (bytes.length > length)\n" +
+                indent + "        {\n" +
+                indent + "            throw new IndexOutOfBoundsException(" +
+                                          "\"string too large for copy: byte length=\" + bytes.length);\n" +
+                indent + "        }\n\n" +
+                indent + "        buffer.putBytes(this.offset + %d, bytes, 0, bytes.length);\n\n" +
+                indent + "        for (int start = bytes.length; start < length; ++start)\n" +
+                indent + "        {\n" +
+                indent + "            buffer.putByte(this.offset + %d + start, (byte) 0);\n" +
+                indent + "        }\n\n" +
+                indent + "        return this;\n" +
+                indent + "    }\n",
+                formatClassName(containingClassName),
+                toUpperFirstChar(propertyName),
+                fieldLength,
+                charset(encoding.characterEncoding()),
+                offset,
                 offset));
         }
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -1714,7 +1714,7 @@ public class JavaGenerator implements CodeGenerator
                 offset));
 
             sb.append(String.format(
-                indent + "    public %s put%s(final String src)\n" +
+                indent + "    public %s %s(final String src)\n" +
                 indent + "    {\n" +
                 indent + "        final int length = %d;\n" +
                 indent + "        final byte[] bytes = src.getBytes(%s);\n" +
@@ -1731,7 +1731,7 @@ public class JavaGenerator implements CodeGenerator
                 indent + "        return this;\n" +
                 indent + "    }\n",
                 formatClassName(containingClassName),
-                toUpperFirstChar(propertyName),
+                propertyName,
                 fieldLength,
                 charset(encoding.characterEncoding()),
                 offset,

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
@@ -351,6 +351,25 @@ public class JavaGeneratorTest
         assertThat(get(decoder, "code"), hasToString("B"));
     }
 
+    @Test
+    public void shouldGenerateGetString() throws Exception
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);
+        generator().generate();
+
+        final Object encoder = wrap(buffer, compileCarEncoder().newInstance());
+        final Object decoder = getCarDecoder(buffer, encoder);
+
+        putString(encoder, "vehicleCode", "R11");
+        assertThat(get(decoder, "vehicleCode"), is("R11"));
+
+        putString(encoder, "vehicleCode", "");
+        assertThat(get(decoder, "vehicleCode"), is(""));
+
+        putString(encoder, "vehicleCode", "R11R12");
+        assertThat(get(decoder, "vehicleCode"), is("R11R12"));
+    }
+
     private Class<?> getModelClass(final Object encoder) throws ClassNotFoundException
     {
         final String className = "Model";

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
@@ -360,13 +360,13 @@ public class JavaGeneratorTest
         final Object encoder = wrap(buffer, compileCarEncoder().newInstance());
         final Object decoder = getCarDecoder(buffer, encoder);
 
-        putString(encoder, "vehicleCode", "R11");
+        set(encoder, "vehicleCode", String.class, "R11");
         assertThat(get(decoder, "vehicleCode"), is("R11"));
 
-        putString(encoder, "vehicleCode", "");
+        set(encoder, "vehicleCode", String.class, "");
         assertThat(get(decoder, "vehicleCode"), is(""));
 
-        putString(encoder, "vehicleCode", "R11R12");
+        set(encoder, "vehicleCode", String.class, "R11R12");
         assertThat(get(decoder, "vehicleCode"), is("R11R12"));
     }
 

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ReflectionUtil.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ReflectionUtil.java
@@ -15,6 +15,8 @@
  */
 package uk.co.real_logic.sbe.generation.java;
 
+import static uk.co.real_logic.sbe.generation.java.JavaUtil.toUpperFirstChar;
+
 public final class ReflectionUtil
 {
     static int getSbeSchemaVersion(final Object encoder) throws Exception
@@ -121,5 +123,10 @@ public final class ReflectionUtil
     static int getCount(Object groupFlyweight) throws Exception
     {
         return getInt(groupFlyweight, "count");
+    }
+
+    static void putString(Object object, String name, String value) throws Exception
+    {
+        object.getClass().getMethod("put" + toUpperFirstChar(name), String.class).invoke(object, value);
     }
 }

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ReflectionUtil.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ReflectionUtil.java
@@ -15,8 +15,6 @@
  */
 package uk.co.real_logic.sbe.generation.java;
 
-import static uk.co.real_logic.sbe.generation.java.JavaUtil.toUpperFirstChar;
-
 public final class ReflectionUtil
 {
     static int getSbeSchemaVersion(final Object encoder) throws Exception
@@ -123,10 +121,5 @@ public final class ReflectionUtil
     static int getCount(Object groupFlyweight) throws Exception
     {
         return getInt(groupFlyweight, "count");
-    }
-
-    static void putString(Object object, String name, String value) throws Exception
-    {
-        object.getClass().getMethod("put" + toUpperFirstChar(name), String.class).invoke(object, value);
     }
 }


### PR DESCRIPTION
Convenience methods for extracting char arrays as String in decoders (and also the symmetric setter in encoders). Declared encoding is used and zero bytes are removed.