### PR TITLE
[C++]: Add rewind() function to reset flyweight to the message start

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -1388,6 +1388,10 @@ public class CppGenerator implements CodeGenerator
             "    {\n" +
             "        return m_buffer;\n" +
             "    }\n\n" +
+            "    void rewind(void)\n" +
+            "    {\n" +
+            "        m_position = m_offset + m_actingBlockLength;\n" +
+            "    }\n\n" +
             "    std::uint64_t actingVersion(void) const\n" +
             "    {\n" +
             "        return m_actingVersion;\n" +


### PR DESCRIPTION
It's useful when you run a two-pass algorithm on the data from message, and don't want to re-create a flyweight (or copy data).