### PR TITLE
Add golang generation support (snapshot 1) 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,6 +16,7 @@ build-local.properties
 deps
 /bin
 build
+classes
 .gradle
 target
 GTAGS
@@ -30,7 +31,7 @@ CMakeFiles
 lib
 gtest-prefix
 CMakeCache.txt
-Makefile
+./Makefile
 binaries
 codecs
 Testing
@@ -60,6 +61,24 @@ cppbuild/*.cache
 cppbuild/Debug
 cppbuild/Release
 cppbuild/Win32
+
+# golang
+gocode/pkg
+gocode/src/baseline/*.go
+!gocode/src/baseline/*_test.go
+gocode/src/composite/*.go
+!gocode/src/composite/*_test.go
+gocode/src/composite_elements/*.go
+!gocode/src/composite_elements/*_test.go
+gocode/src/group_with_data/*.go
+!gocode/src/group_with_data/*_test.go
+gocode/src/mktdata/*.go
+!gocode/src/mktdata/*_test.go
+gocode/src/simple/*.go
+!gocode/src/simple/*_test.go
+gocode/src/*/*/*.go
+!gocode/src/*/*/*_test.go
+gocode/src/example-schema/example-schema
 
 # Mac
 .DS_Store

--- a/build.gradle
+++ b/build.gradle
@@ -479,9 +479,19 @@ task(generateCppIrCodecs, type: JavaExec) {
     args = ['sbe-tool/src/main/resources/sbe-ir.xml']
 }
 
+task(generateGolangIrCodecs, type: JavaExec) {
+    main = 'uk.co.real_logic.sbe.SbeTool'
+    classpath = project(':sbe-all').sourceSets.main.runtimeClasspath
+    systemProperties(
+        'sbe.output.dir': 'sbe-tool/src/main/golang',
+        'sbe.target.language': 'golang',
+        'sbe.validation.xsd': validationXsdPath)
+    args = ['sbe-tool/src/main/resources/sbe-ir.xml']
+}
+
 task generateIrCodecs {
-    description = 'Generate Java and C++ IR Codecs'
-    dependsOn 'generateJavaIrCodecs', 'generateCppIrCodecs'
+    description = 'Generate Java, C++ and golang IR Codecs'
+    dependsOn 'generateJavaIrCodecs', 'generateCppIrCodecs', 'generateGolangIrCodecs'
 }
 
 task runBenchmarks(type: Exec) {

--- a/config/checkstyle.xml
+++ b/config/checkstyle.xml
@@ -133,7 +133,7 @@
             <property name="legalAbstractClassNames"
                       value="AbstractBeanDefinition, AbstractAccountEvInstruction, AbstractEmsInstruction, AbstractEvInstruction, AbstractEmsAction, AbstractInstrumentAction, AbstractEntry"/>
             <property name="illegalClassNames"
-                      value="java.util.GregorianCalendar, java.util.Hashtable, java.util.HashSet, java.util.HashMap, java.util.ArrayList, java.util.LinkedHashSet, java.util.TreeSet, java.util.TreeMap, java.util.Vector"/>
+                      value="java.util.GregorianCalendar, java.util.Hashtable, java.util.HashSet, java.util.HashMap, java.util.ArrayList, java.util.LinkedHashSet, ava.util.TreeMap, java.util.Vector"/>
         </module>
 
         <module name="DescendantToken">

--- a/gocode/Makefile
+++ b/gocode/Makefile
@@ -1,0 +1,188 @@
+ROOT=..
+SBE_TOOL_VERSION=`cat $(ROOT)/version.txt`
+SBE_JAR=$(ROOT)/sbe-all/build/libs/sbe-all-${SBE_TOOL_VERSION}.jar
+
+SCHEMA_DIR=$(ROOT)/sbe-samples/src/main/resources
+EXAMPLES_SCHEMA=$(SCHEMA_DIR)/example-schema.xml
+EXAMPLES_OUTPUT=EXAMPLES_OUTPUT
+
+#JAVA=/usr/lib/jvm/java-8-openjdk-amd64/bin/java
+JAVA=java
+
+TESTDIR=$(ROOT)/sbe-tool/src/test/golang
+
+JAVA_FILES="-jar ${SBE_JAR}"
+
+# During development we can speed up a build by selective building and
+# using this but it needs periodic refresh for agrona version
+#JAVA_FILES="-cp ${$CP}"
+#CP=$(ROOT)/sbe-all/build/classes/main:$(ROOT)/sbe-all/build/resources/main:$(ROOT)/sbe-tool/build/libs/sbe-tool-$(SBE_TOOL_VERSION).jar:/home/bill/.gradle/caches/modules-2/files-2.1/org.agrona/Agrona/0.5.5/5a576d17c57c5c85b9a1ce19f030746e214e281b/Agrona-0.5.5.jar
+
+# FIXME: Go doesn't like relative paths so us a gnumake extension for now
+GOPATH=$(realpath $(ROOT)/gocode)
+OUTPUTDIR=$(GOPATH)/src
+
+# Local examples to get started
+SIMPLE=$(GOPATH)/resources/simple.xml
+COMPOSITE=$(GOPATH)/resources/example-composite.xml
+
+# Existing test cases
+XMLTESTDIR=$(ROOT)/sbe-tool/src/test/resources
+BASIC_TYPES=$(XMLTESTDIR)/basic-types-schema.xml
+BASIC_GROUP=$(XMLTESTDIR)/basic-group-schema.xml
+BASIC_VARDATA=$(XMLTESTDIR)/basic-variable-length-schema.xml
+COMPOSITE4=$(XMLTESTDIR)/composite-elements-schema-rc4.xml
+NESTED_GROUP=$(XMLTESTDIR)/group-with-data-schema.xml
+FIX_BINARY=$(XMLTESTDIR)/FixBinary.xml
+
+# Convenience during development
+#SAVE_FORMAT=mkdir -p fmt && cp *.go fmt &&
+SAVE_FORMAT=
+
+
+GeneratedStubExample: $(STUB_EXAMPLE)
+	$(JAVA) \
+	-Dsbe.output.dir=$(OUTPUTDIR) \
+	-Dsbe.generate.ir="false" \
+	-Dsbe.target.language="golang" \
+	-jar ${SBE_JAR} \
+	$(EXAMPLES_SCHEMA)
+	(export GOPATH=$(GOPATH) && \
+        cd $(OUTPUTDIR)/baseline && \
+	go build && \
+	go test && \
+	go install && \
+	cd $(OUTPUTDIR)/example-schema && \
+	go build && \
+	./example-schema)
+
+test: fix-binary nested-group basic-vardata basic-group basic-types simple composite composite-elements
+
+fix-binary:
+	$(JAVA) \
+	-Dsbe.output.dir=$(OUTPUTDIR) \
+	-Dsbe.target.language=golang \
+	-Dfile.encoding=US-ASCII \
+	-Duser.country=US \
+	-Duser.langimuage=en \
+	-Duser.variant \
+	-jar ${SBE_JAR} \
+	$(FIX_BINARY)
+	(cd $(OUTPUTDIR)/mktdata && \
+	go build && \
+	$(SAVE_FORMAT) \
+	go fmt && echo && \
+	go test)
+
+nested-group:
+	$(JAVA) \
+	-Dsbe.output.dir=$(OUTPUTDIR) \
+	-Dsbe.target.language=golang \
+	-Dfile.encoding=US-ASCII \
+	-Duser.country=US \
+	-Duser.langimuage=en \
+	-Duser.variant \
+	-jar ${SBE_JAR} \
+	$(NESTED_GROUP)
+	(cd $(OUTPUTDIR)/group_with_data && \
+	go build && \
+	$(SAVE_FORMAT) \
+	go fmt && echo && \
+	go test)
+
+composite-elements:
+	$(JAVA) \
+	-Dsbe.output.dir=$(OUTPUTDIR) \
+	-Dsbe.target.language=golang \
+	-Dfile.encoding=US-ASCII \
+	-Duser.country=US \
+	-Duser.langimuage=en \
+	-Duser.variant \
+	-jar ${SBE_JAR} \
+	$(COMPOSITE4)
+	(cd $(OUTPUTDIR)/composite_elements && \
+	go build && \
+	$(SAVE_FORMAT) \
+	go fmt && echo && \
+	go test)
+
+basic-vardata:
+	$(JAVA) \
+	-Dsbe.output.dir=$(OUTPUTDIR)/vardata \
+	-Dsbe.target.language=golang \
+	-Dfile.encoding=US-ASCII \
+	-Duser.country=US \
+	-Duser.langimuage=en \
+	-Duser.variant \
+	-jar ${SBE_JAR} \
+	$(BASIC_VARDATA)
+	(cd $(OUTPUTDIR)/vardata/'SBE tests' && \
+	go build && \
+	$(SAVE_FORMAT) \
+	go fmt && echo && \
+	go test)
+
+basic-group:
+	$(JAVA) \
+	-Dsbe.output.dir=$(OUTPUTDIR)/group \
+	-Dsbe.target.language=golang \
+	-Dfile.encoding=US-ASCII \
+	-Duser.country=US \
+	-Duser.language=en \
+	-Duser.variant \
+	-jar ${SBE_JAR} \
+	$(BASIC_GROUP)
+	(cd $(OUTPUTDIR)/group/'SBE tests' && \
+	go build && \
+	$(SAVE_FORMAT) \
+	go fmt && echo && \
+	go test)
+
+basic-types:
+	$(JAVA) \
+	-Dsbe.output.dir=$(OUTPUTDIR)/basic \
+	-Dsbe.target.language=golang \
+	-Dfile.encoding=US-ASCII \
+	-Duser.country=US \
+	-Duser.language=en \
+	-Duser.variant \
+	-jar ${SBE_JAR} \
+	$(BASIC_TYPES)
+	(cd $(OUTPUTDIR)/basic/'SBE tests' && \
+	go build && \
+	$(SAVE_FORMAT) \
+	go fmt && echo && \
+	go test)
+
+
+composite:
+	$(JAVA) \
+	-Dsbe.output.dir=$(OUTPUTDIR) \
+	-Dsbe.target.language=golang \
+	-Dfile.encoding=US-ASCII \
+	-Duser.country=US \
+	-Duser.language=en \
+	-Duser.variant \
+	-jar ${SBE_JAR} \
+	$(COMPOSITE)
+	(cd $(OUTPUTDIR)/composite && \
+	go build && \
+	$(SAVE_FORMAT) \
+	go fmt && echo && \
+	go test)
+
+simple:
+	$(JAVA) \
+	-Dsbe.output.dir=$(OUTPUTDIR) \
+	-Dsbe.target.language=golang \
+	-Dfile.encoding=US-ASCII \
+	-Duser.country=US \
+	-Duser.language=en \
+	-Duser.variant \
+	-jar ${SBE_JAR} \
+	$(SIMPLE)
+	(cd $(OUTPUTDIR)/simple && \
+	go build && \
+	$(SAVE_FORMAT) \
+	go fmt && echo && \
+	go test)

--- a/gocode/README.md
+++ b/gocode/README.md
@@ -1,0 +1,134 @@
+Overview
+========
+
+The generated golang code attempts to match golang idioms where such
+choices are both possible and reasonable.
+
+The golang SBE backend represents FIX messages as golang types and
+provides Encode and Decode methods for these types and their embedded
+elements. This differs from the Java and C++ implementations that provide a
+flyweight idiom and has some important ramifications.
+
+Firstly, any semantic checking of values is not performed by a
+Getter/Setter method but is instead performed in the Encode and Decode
+<<<<<<< HEAD
+methods. In general the Encode methods attempt to be strictly and
+=======
+methods. In general the Encode methods attempt to be stricty and
+>>>>>>> e5b9a0dda1fbbf83172d5653e32637d48ec6fdad
+enforcing to ensure only valid SBE is emitted. Where it remains within
+the standard the Decode methods attempt to be forgiving in their
+interpretation.
+
+Secondly, constant values are not set when an object is created. As
+golang does not provide constructors, we instead have each support
+type Foo provide a FooInit() function which will fill out constant
+values.
+
+Some design decisions are based around the structure of sbe-tool
+itself. sbe-tool parses the XML into an internal representation (IR)
+and then passes this to the language specific generator. As a result
+some information on the xml structure has been lost.
+
+An examples of this include the use of the <ref> tag which if used to
+the same underlying type in a composite will create two differently
+named definitions of the type in the IR.
+
+<<<<<<< HEAD
+A second example is if a field references a type definition that is
+=======
+A second exmaple is if a field references a type definition that is
+>>>>>>> e5b9a0dda1fbbf83172d5653e32637d48ec6fdad
+primitive then we lose the type name in the IR so it is unreferenced.
+
+
+Primitive Types
+---------------
+Most Primitive types map well to golang basic types. Character arrays
+<<<<<<< HEAD
+are represented as either fixed or variable sized byte arrays.
+
+[FIXME: Unicode]
+=======
+are represented as either fixed or vriable sized byte arrays.
+
+[FIXME: unicode]
+>>>>>>> e5b9a0dda1fbbf83172d5653e32637d48ec6fdad
+
+Enumerations and Choices
+------------------------
+golang does not have an enumeration type and so enums are represented
+as a type and a variable with the known constant values is
+provided. To preserve name uniqueness within a message the const
+values contain the enum type name.
+
+Messages and Composites
+-----------------------
+Messages and composites are both represented as golang structures with
+Encode() and Decode() methods amongst others.
+
+Groups and VarData
+------------------
+Groups and VarData are represented as arrays with their NumInGroup
+being implicit in len()
+
+Semantic Types
+--------------
+
+The Boolean semantic type is not represented as a golang bool as the
+spec requires that discrepancies between SinceVersion and
+ActingVersion can be resolved using the Null Value.
+
+The String semantic type is simply represented as a byte array as
+golang Strings are immutable and hence they are not useful in
+structures.
+
+[FIXME: insert more here]
+
+
+Code Layout
+-----------
+To match golang's requirement on directory structure and file layout,
+<<<<<<< HEAD
+the build environment, example and test code are structured into a top
+level gocode directory hierarchy.
+=======
+the build enevinment, example and test code are structured into a top
+level gocode directory heirarchy.
+>>>>>>> e5b9a0dda1fbbf83172d5653e32637d48ec6fdad
+
+Code is generated into this structure with pre-existing test code in place.
+
+For the example, the code is generated into a library and the matching
+example code lives in it's own directory at the same level. For
+<<<<<<< HEAD
+example the example-schema generates the baseline library code into
+=======
+example teh example-schema generates the baseline library code into
+>>>>>>> e5b9a0dda1fbbf83172d5653e32637d48ec6fdad
+gocode/src/baseline and example code lives in gocode/src/example-schema.
+
+To use this layout you will need to set GOPATH=/path/to/gocode or use
+the supplied Makefile which does this for you.
+
+Roadmap
+-------
+ * Deprecated support
+ * Support full Range checking on both Encode and Decode
+ * Car example-extension-schema works
+ * Examples documented
+ * Restructure recursive group generation as it's currently somewhat broken
+ * Chase up Ennn error message meanings with Real Logic and support?
+ * go format fixes
+<<<<<<< HEAD
+ * Windows developer support (currently tested on Linux/MacOS)
+ * Enhance Design/Rationale document (this one)
+=======
+ * Enhaance Design/Rationale document (this one)
+>>>>>>> e5b9a0dda1fbbf83172d5653e32637d48ec6fdad
+ * presence=optional
+ * Unnecessary code removal (e.g., GroupSizeEncoding)
+ * Unicode
+ * Testing/Bug fixes
+ * Semantic types (perhaps just date/time, possibly more)
+ * Benchmarking & Performance Enhancements

--- a/gocode/README.md
+++ b/gocode/README.md
@@ -11,19 +11,16 @@ flyweight idiom and has some important ramifications.
 
 Firstly, any semantic checking of values is not performed by a
 Getter/Setter method but is instead performed in the Encode and Decode
-<<<<<<< HEAD
-methods. In general the Encode methods attempt to be strictly and
-=======
-methods. In general the Encode methods attempt to be stricty and
->>>>>>> e5b9a0dda1fbbf83172d5653e32637d48ec6fdad
+methods. In general the Encode methods attempt to be strictly
 enforcing to ensure only valid SBE is emitted. Where it remains within
 the standard the Decode methods attempt to be forgiving in their
-interpretation.
+interpretation and range checking can be disabled via the the use of
+the 'strict' parameter.
 
 Secondly, constant values are not set when an object is created. As
 golang does not provide constructors, we instead have each support
 type Foo provide a FooInit() function which will fill out constant
-values.
+values. Decoding does fill out constant values.
 
 Some design decisions are based around the structure of sbe-tool
 itself. sbe-tool parses the XML into an internal representation (IR)
@@ -34,26 +31,24 @@ An examples of this include the use of the <ref> tag which if used to
 the same underlying type in a composite will create two differently
 named definitions of the type in the IR.
 
-<<<<<<< HEAD
-A second example is if a field references a type definition that is
-=======
-A second exmaple is if a field references a type definition that is
->>>>>>> e5b9a0dda1fbbf83172d5653e32637d48ec6fdad
-primitive then we lose the type name in the IR so it is unreferenced.
+A second example occurs where a field references an aliased primitive
+type definition in which case we lose the aliaed type name in the IR
+as it is unreferenced.
 
 
 Primitive Types
 ---------------
 Most Primitive types map well to golang basic types. Character arrays
-<<<<<<< HEAD
 are represented as either fixed or variable sized byte arrays.
 
-[FIXME: Unicode]
-=======
-are represented as either fixed or vriable sized byte arrays.
-
-[FIXME: unicode]
->>>>>>> e5b9a0dda1fbbf83172d5653e32637d48ec6fdad
+Unicode
+-------
+The SBE spec allows character arrays and vardata elements to specify a
+character encoding such as "ASCII" or "UTF-8". For vardata this is
+additionally allowed on integral types such as uint8. The spec does
+not mandate a set of supported encodings but golang currently supports:
+ * ASCII
+ * UTF-8
 
 Enumerations and Choices
 ------------------------
@@ -80,8 +75,7 @@ spec requires that discrepancies between SinceVersion and
 ActingVersion can be resolved using the Null Value.
 
 The String semantic type is simply represented as a byte array as
-golang Strings are immutable and hence they are not useful in
-structures.
+golang Strings are immutable and are not useful in structures.
 
 [FIXME: insert more here]
 
@@ -89,23 +83,14 @@ structures.
 Code Layout
 -----------
 To match golang's requirement on directory structure and file layout,
-<<<<<<< HEAD
 the build environment, example and test code are structured into a top
 level gocode directory hierarchy.
-=======
-the build enevinment, example and test code are structured into a top
-level gocode directory heirarchy.
->>>>>>> e5b9a0dda1fbbf83172d5653e32637d48ec6fdad
 
 Code is generated into this structure with pre-existing test code in place.
 
 For the example, the code is generated into a library and the matching
 example code lives in it's own directory at the same level. For
-<<<<<<< HEAD
 example the example-schema generates the baseline library code into
-=======
-example teh example-schema generates the baseline library code into
->>>>>>> e5b9a0dda1fbbf83172d5653e32637d48ec6fdad
 gocode/src/baseline and example code lives in gocode/src/example-schema.
 
 To use this layout you will need to set GOPATH=/path/to/gocode or use
@@ -120,12 +105,8 @@ Roadmap
  * Restructure recursive group generation as it's currently somewhat broken
  * Chase up Ennn error message meanings with Real Logic and support?
  * go format fixes
-<<<<<<< HEAD
  * Windows developer support (currently tested on Linux/MacOS)
  * Enhance Design/Rationale document (this one)
-=======
- * Enhaance Design/Rationale document (this one)
->>>>>>> e5b9a0dda1fbbf83172d5653e32637d48ec6fdad
  * presence=optional
  * Unnecessary code removal (e.g., GroupSizeEncoding)
  * Unicode

--- a/gocode/resources/example-composite.xml
+++ b/gocode/resources/example-composite.xml
@@ -1,0 +1,40 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   package="composite"
+                   id="1"
+                   version="0"
+                   semanticVersion="5.2"
+                   description="Example Simple4"
+                   byteOrder="littleEndian">
+  <types>
+    <composite name="messageHeader" description="Message identifiers and length of message root">
+      <type name="blockLength" primitiveType="uint16"/>
+      <type name="templateId" primitiveType="uint16"/>
+      <type name="schemaId" primitiveType="uint16"/>
+      <type name="version" primitiveType="uint16"/>
+    </composite>
+  </types>
+
+  <types>
+
+    <enum name="booleanEnum" encodingType="uint8" semanticType="Boolean">
+      <validValue name="F">0</validValue>
+      <validValue name="T">1</validValue>
+    </enum>
+
+    <composite name="point">
+      <type name="name" primitiveType="char" length="5" />
+      <type name="d" primitiveType="double" />
+      <type name="i" primitiveType="int32" />
+      <type name="u" primitiveType="uint8" length="2" />
+      <ref name="truthval1" type="booleanEnum"/>
+      <ref name="truthval2" type="booleanEnum"/>
+    </composite>
+
+  </types>
+
+  <sbe:message name="Composite" id="1" description="A very simple composite example">
+    <field name="start" id="2" type="point" />
+    <field name="end" id="3" type="point" />
+  </sbe:message>
+</sbe:messageSchema>

--- a/gocode/resources/simple.xml
+++ b/gocode/resources/simple.xml
@@ -1,0 +1,41 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   package="simple"
+                   id="3"
+                   version="2"
+                   semanticVersion="5.2"
+                   description="insert_type_here"
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader" description="Message identifiers and length of message root">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+    </types>
+    <types>
+      <type name="ascii6" primitiveType="char" semanticType="String" length="6" characterEncoding="ASCII"/>
+      <type name="ascii1" primitiveType="char" semanticType="String" length="1" characterEncoding="ASCII"/>
+      <type name="int2" primitiveType="int32" length="2"/>
+      <!-- not yet
+      <type name="utf86" primitiveType="char" semanticType="String" length="6" characterEncoding="UTF-8"/>
+      <type name="utf166" primitiveType="char" semanticType="String" length="6" characterEncoding="UTF-8"/>
+      -->
+    </types>
+    <sbe:message name="Simple0" id="11" semanticType="womble" description="A very simple first example" blockLength="76">
+        <field name="U64"     id="1"  type="uint64"/>
+        <field name="U32"     id="2"  type="uint32"/>
+        <field name="U16"     id="3"  type="uint16"/>
+        <field name="U8"      id="4"  type="uint8"/>
+        <field name="S8"      id="5"  type="int8" offset="31"/>
+        <field name="S16"     id="6"  type="int16"/>
+        <field name="S32"     id="7"  type="int32"/>
+        <field name="S64"     id="8"  type="int64"/>
+        <field name="F32"     id="9"  type="float"/>
+        <field name="D64"     id="10" type="double"/>
+        <field name="String6ASCII" id="11" type="ascii6"/>
+        <field name="String1ASCII" id="12" type="ascii1"/>
+        <field name="Int2"    id="13" type="int2"/>
+    </sbe:message>
+</sbe:messageSchema>

--- a/gocode/src/baseline/Car_test.go
+++ b/gocode/src/baseline/Car_test.go
@@ -22,7 +22,7 @@ func TestEncodeDecodeCar(t *testing.T) {
 	var engine Engine
 	engine = Engine{2000, 4, 0, manufacturerCode, [6]byte{}, EngineBooster{BoostType.NITROUS, 200}}
 
-	brand := []uint8("Honda")
+	manufacturer := []uint8("Honda")
 	model := []uint8("Civic VTi")
 	activationCode := []uint8("deadbeef")
 
@@ -46,7 +46,7 @@ func TestEncodeDecodeCar(t *testing.T) {
 	pf = append(pf, CarPerformanceFigures{99, acc2})
 
 
-	in := Car{1234, 2013, BooleanType.T, Model.A, [5]uint32{0, 1, 2, 3, 4}, vehicleCode, optionalExtras, Model.A, engine, fuel, pf, brand, model, activationCode}
+	in := Car{1234, 2013, BooleanType.T, Model.A, [5]uint32{0, 1, 2, 3, 4}, vehicleCode, optionalExtras, Model.A, engine, fuel, pf, manufacturer, model, activationCode}
 
 	var buf = new(bytes.Buffer)
 	if err := in.Encode(buf, binary.LittleEndian); err != nil {

--- a/gocode/src/baseline/Car_test.go
+++ b/gocode/src/baseline/Car_test.go
@@ -1,0 +1,140 @@
+package baseline
+
+import (
+	"bytes"
+	"encoding/binary"
+	_ "fmt"
+	"testing"
+)
+
+func TestEncodeDecodeCar(t *testing.T) {
+
+	var vehicleCode [6]byte
+	copy(vehicleCode[:], "abcdef")
+
+	var manufacturerCode [3]byte
+	copy(manufacturerCode[:], "123")
+
+	var optionalExtras [8]bool
+	optionalExtras[OptionalExtrasChoice.CruiseControl] = true
+	optionalExtras[OptionalExtrasChoice.SportsPack] = true
+
+	var engine Engine
+	engine = Engine{2000, 4, 0, manufacturerCode, [6]byte{}, EngineBooster{BoostType.NITROUS, 200}}
+
+	brand := []uint8("Honda")
+	model := []uint8("Civic VTi")
+	activationCode := []uint8("deadbeef")
+
+	var fuel []CarFuelFigures
+	fuel = append(fuel, CarFuelFigures{30, 35.9, []uint8("Urban Cycle")})
+	fuel = append(fuel, CarFuelFigures{55, 49.0, []uint8("Combined Cycle")})
+	fuel = append(fuel, CarFuelFigures{75, 40.0, []uint8("Highway Cycle")})
+
+	var acc1 []CarPerformanceFiguresAcceleration
+	acc1 = append(acc1, CarPerformanceFiguresAcceleration{30, 3.8})
+	acc1 = append(acc1, CarPerformanceFiguresAcceleration{60, 7.5})
+	acc1 = append(acc1, CarPerformanceFiguresAcceleration{100, 12.2})
+
+	var acc2 []CarPerformanceFiguresAcceleration
+	acc2 = append(acc2, CarPerformanceFiguresAcceleration{30, 3.8})
+	acc2 = append(acc2, CarPerformanceFiguresAcceleration{60, 7.5})
+	acc2 = append(acc2, CarPerformanceFiguresAcceleration{100, 12.2})
+
+	var pf []CarPerformanceFigures
+	pf = append(pf, CarPerformanceFigures{95, acc1})
+	pf = append(pf, CarPerformanceFigures{99, acc2})
+
+
+	in := Car{1234, 2013, BooleanType.T, Model.A, [5]uint32{0, 1, 2, 3, 4}, vehicleCode, optionalExtras, Model.A, engine, fuel, pf, brand, model, activationCode}
+
+	var buf = new(bytes.Buffer)
+	if err := in.Encode(buf, binary.LittleEndian); err != nil {
+		t.Logf("Encoding Error", err)
+		t.Fail()
+	}
+
+	var out Car = *new(Car)
+	if err := out.Decode(buf, binary.LittleEndian, 0, true); err != nil {
+		t.Logf("Decoding Error", err)
+		t.Fail()
+	}
+
+	if in.SerialNumber != out.SerialNumber {
+		t.Logf("in.SerialNumber != out.SerialNumber:\n", in.SerialNumber, out.SerialNumber)
+		t.Fail()
+	}
+	if in.ModelYear != out.ModelYear {
+		t.Logf("in.ModelYear != out.ModelYear:\n", in.ModelYear, out.ModelYear)
+		t.Fail()
+	}
+	if in.Available != out.Available {
+		t.Logf("in.Available != out.Available:\n", in.Available, out.Available)
+		t.Fail()
+	}
+	if in.Code != out.Code {
+		t.Logf("in.Code != out.Code:\n", in.Code, out.Code)
+		t.Fail()
+	}
+	if in.SomeNumbers != out.SomeNumbers {
+		t.Logf("in.SomeNumbers != out.SomeNumbers:\n", in.SomeNumbers, out.SomeNumbers)
+		t.Fail()
+	}
+	if in.VehicleCode != out.VehicleCode {
+		t.Logf("in.VehicleCode != out.VehicleCode:\n", in.VehicleCode, out.VehicleCode)
+		t.Fail()
+	}
+	if in.Extras != out.Extras {
+		t.Logf("in.Extras != out.Extras:\n", in.Extras, out.Extras)
+		t.Fail()
+	}
+
+	// DiscountedModel is constant
+	if Model.C != out.DiscountedModel {
+		t.Logf("in.DiscountedModel != out.DiscountedModel:\n", in.DiscountedModel, out.DiscountedModel)
+		t.Fail()
+	}
+
+	// Engine has two constant values which should come back filled in
+	if in.Engine == out.Engine {
+		t.Logf("in.Engine == out.Engine (and they should be different):\n", in.Engine, out.Engine)
+		t.Fail()
+	}
+
+	copy(in.Engine.Fuel[:], "Petrol")
+	in.Engine.MaxRpm = 9000
+	if in.Engine != out.Engine {
+		t.Logf("in.Engine != out.Engine:\n", in.Engine, out.Engine)
+		t.Fail()
+	}
+
+	return
+
+}
+
+func TestDecodeJavaBuffer(t *testing.T) {
+
+	// The byte array is from the java example for interop test
+	data := []byte{47, 0, 1, 0, 1, 0, 0, 0, 210, 4, 0, 0, 0, 0, 0, 0, 221, 7, 1, 65, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 97, 98, 99, 100, 101, 102, 6, 208, 7, 4, 49, 50, 51, 78, 200, 6, 0, 3, 0, 30, 0, 154, 153, 15, 66, 11, 0, 0, 0, 85, 114, 98, 97, 110, 32, 67, 121, 99, 108, 101, 55, 0, 0, 0, 68, 66, 14, 0, 0, 0, 67, 111, 109, 98, 105, 110, 101, 100, 32, 67, 121, 99, 108, 101, 75, 0, 0, 0, 32, 66, 13, 0, 0, 0, 72, 105, 103, 104, 119, 97, 121, 32, 67, 121, 99, 108, 101, 1, 0, 2, 0, 95, 6, 0, 3, 0, 30, 0, 0, 0, 128, 64, 60, 0, 0, 0, 240, 64, 100, 0, 51, 51, 67, 65, 99, 6, 0, 3, 0, 30, 0, 51, 51, 115, 64, 60, 0, 51, 51, 227, 64, 100, 0, 205, 204, 60, 65, 5, 0, 0, 0, 72, 111, 110, 100, 97, 9, 0, 0, 0, 67, 105, 118, 105, 99, 32, 86, 84, 105, 6, 0, 0, 0, 97, 98, 99, 100, 101, 102, 0, 0, 0, 0, 0, 0, 0, 0}
+
+	buf := bytes.NewBuffer(data)
+
+	var m MessageHeader
+	if err := m.Decode(buf, binary.LittleEndian, 0, true); err != nil {
+		t.Logf("Failed to decode message header", err)
+		t.Fail()
+	}
+
+	// fmt.Println("BlockLength = ", m.BlockLength)
+	// fmt.Println("TemplateId = ", m.TemplateId)
+	// fmt.Println("SchemaId = ", m.SchemaId)
+	// fmt.Println("Version = ", m.Version)
+	// fmt.Println("bytes: ", buf.Len())
+	var c Car
+	if err := c.Decode(buf, binary.LittleEndian, m.Version, true); err != nil {
+		t.Logf("Failed to decode car", err)
+		t.Fail()
+	}
+	// fmt.Println(c)
+	return
+}

--- a/gocode/src/basic/SBE tests/ENUM_test.go
+++ b/gocode/src/basic/SBE tests/ENUM_test.go
@@ -1,0 +1,55 @@
+package sbe_tests
+
+import (
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"reflect"
+	"testing"
+)
+
+func TestEncodeDecodeEnum(t *testing.T) {
+
+	// var e ENUMEnum = Value1;
+	var in ENUMEnum = ENUM.Value10
+	var buf = new(bytes.Buffer)
+	if err := in.Encode(buf, binary.LittleEndian); err != nil {
+		t.Logf("Encoding Error", err)
+		t.Fail()
+	}
+
+	var out ENUMEnum = *new(ENUMEnum)
+	if err := out.Decode(buf, binary.LittleEndian, 0, true); err != nil {
+		t.Logf("Decoding Error", err)
+		t.Fail()
+	}
+
+	if in != out {
+		t.Logf("in != out:\n", in, out)
+		t.Fail()
+	}
+
+	return
+
+	// xmain()
+}
+
+func xmain() {
+	// var e ENUMEnum = ENUME.Value1;
+	var e ENUMEnum = 9
+	var buf = new(bytes.Buffer)
+	if err := e.Encode(buf, binary.LittleEndian); err != nil {
+		fmt.Println("Encoding Error", err)
+		return
+	}
+
+	var out ENUMEnum = *new(ENUMEnum)
+	if err := out.Decode(buf, binary.LittleEndian, 0, true); err != nil {
+		fmt.Println("Decoding Error", err)
+		return
+	}
+
+	fmt.Println(e, out, reflect.TypeOf(out))
+	return
+
+}

--- a/gocode/src/basic/SBE tests/Message1_test.go
+++ b/gocode/src/basic/SBE tests/Message1_test.go
@@ -1,0 +1,57 @@
+package sbe_tests
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestEncodeDecodeMessage1(t *testing.T) {
+
+	var in Message1
+	copy(in.EDTField[:], "abcdefghijklmnopqrst")
+	in.Header = MessageHeader{in.SbeBlockLength(), in.SbeTemplateId(), in.SbeSchemaId(), in.SbeSchemaVersion()}
+	in.ENUMField = ENUM.Value10
+
+	var buf = new(bytes.Buffer)
+	if err := in.Encode(buf, binary.LittleEndian); err != nil {
+		t.Logf("Encoding Error", err)
+		t.Fail()
+	}
+
+	var out Message1 = *new(Message1)
+	if err := out.Decode(buf, binary.LittleEndian, in.SbeSchemaVersion(), true); err != nil {
+		t.Logf("Decoding Error", err)
+		t.Fail()
+	}
+
+	if in != out {
+		t.Logf("in != out:\n", in, out)
+		t.Fail()
+	}
+
+	// Now let's see that if we pass in an unknown enum value
+	// we get a Nullvalue if strict and the unknown value if lax.
+	in.ENUMField = 77
+	in.Encode(buf, binary.LittleEndian)
+	if err := out.Decode(buf, binary.LittleEndian, in.SbeSchemaVersion(), true); err != nil {
+		t.Logf("Decoding Error", err)
+		t.Fail()
+	}
+	if out.ENUMField != ENUM.NullValue {
+		t.Logf("out.ENUMField != ENUM.NullValue\n", in, out)
+		t.Fail()
+	}
+
+	in.Encode(buf, binary.LittleEndian)
+	if err := out.Decode(buf, binary.LittleEndian, in.SbeSchemaVersion(), false); err != nil {
+		t.Logf("Decoding Error:", err)
+		t.Fail()
+	}
+	if out.ENUMField != in.ENUMField {
+		t.Logf("in out.ENUMField != in.ENUMField")
+		t.Fail()
+	}
+
+	return
+}

--- a/gocode/src/basic/SBE tests/SET_test.go
+++ b/gocode/src/basic/SBE tests/SET_test.go
@@ -1,0 +1,34 @@
+package sbe_tests
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestEncodeDecodeSet(t *testing.T) {
+
+	// var e SET = Value1;
+	var in SET
+	in[SETChoice.Bit16] = true
+
+	var buf = new(bytes.Buffer)
+	if err := in.Encode(buf, binary.LittleEndian); err != nil {
+		t.Logf("Encoding Error", err)
+		t.Fail()
+	}
+
+	var out SET = *new(SET)
+	if err := out.Decode(buf, binary.LittleEndian, 0, true); err != nil {
+		t.Logf("Decoding Error", err)
+		t.Fail()
+	}
+
+	if in != out {
+		t.Logf("in != out:\n", in, out)
+		t.Fail()
+	}
+
+	return
+
+}

--- a/gocode/src/composite/Composite_test.go
+++ b/gocode/src/composite/Composite_test.go
@@ -1,0 +1,58 @@
+package composite
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestEncodeDecode(t *testing.T) {
+
+	var s1, s2 [5]byte
+	copy(s1[:], "start")
+	copy(s2[:], "  end")
+	p1 := Point{s1, 3.14, 1, [2]uint8{66, 77}, Truthval1.NullValue, Truthval2.T}
+	p2 := Point{s2, 0.31, 2, [2]uint8{77, 88}, Truthval1.T, Truthval2.F}
+	c := Composite{p1, p2}
+
+	var cbuf = new(bytes.Buffer)
+	if err := c.Encode(cbuf, binary.LittleEndian); err != nil {
+		t.Log("Composite Encoding Error", err)
+		t.Fail()
+	}
+	t.Log(c, " -> ", cbuf.Bytes())
+	t.Log("Cap() = ", cbuf.Cap(), "Len() = \n", cbuf.Len())
+
+	m := MessageHeader{c.SbeBlockLength(), c.SbeTemplateId(), c.SbeSchemaId(), c.SbeSchemaVersion()}
+	var mbuf = new(bytes.Buffer)
+	if err := m.Encode(mbuf, binary.LittleEndian); err != nil {
+		t.Log("MessageHeader Encoding Error", err)
+		t.Fail()
+	}
+	t.Log(m, " -> ", mbuf.Bytes())
+	t.Log("Cap() = ", mbuf.Cap(), "Len() = \n", mbuf.Len())
+
+	// Create a new empty MessageHeader and Composite
+	m = *new(MessageHeader)
+	var c2 Composite = *new(Composite)
+
+	if err := m.Decode(mbuf, binary.LittleEndian, c.SbeSchemaVersion(), true); err != nil {
+		t.Log("MessageHeader Decoding Error", err)
+		t.Fail()
+	}
+	t.Log("MessageHeader Decodes as: ", m)
+	t.Log("Cap() = ", mbuf.Cap(), "Len() = \n", mbuf.Len())
+
+	if err := c2.Decode(cbuf, binary.LittleEndian, c.SbeSchemaVersion(), true); err != nil {
+		t.Log("Composite Decoding Error", err)
+		t.Fail()
+	}
+	t.Log("Composite decodes as: ", c2)
+	t.Log("Cap() = ", cbuf.Cap(), "Len() = \n", cbuf.Len())
+
+	// c2.End.I = 18
+	if c != c2 {
+		t.Logf("c != c2\n%s\n%s", c, c2)
+		t.Fail()
+	}
+}

--- a/gocode/src/composite_elements/Message_test.go
+++ b/gocode/src/composite_elements/Message_test.go
@@ -1,0 +1,96 @@
+package composite_elements
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestEncodeDecodeMsg(t *testing.T) {
+
+	var set SetOne
+	var in Msg
+
+	set[SetOneChoice.Bit0] = true
+	in.Structure = Outer{EnumOne.Value10, 0, set, OuterInner{1, 2}}
+
+	var buf = new(bytes.Buffer)
+	if err := in.Encode(buf, binary.LittleEndian); err != nil {
+		t.Logf("Encoding Error", err)
+		t.Fail()
+	}
+
+	var out Msg = *new(Msg)
+	if err := out.Decode(buf, binary.LittleEndian, 0, true); err != nil {
+		t.Logf("Decoding Error", err)
+		t.Fail()
+	}
+
+	if in != out {
+		t.Logf("in != out\n", in, out)
+		t.Fail()
+	}
+
+	return
+
+}
+
+func TestEncodeDecodeMsg2(t *testing.T) {
+
+	var set SetOne
+	var in Msg2
+
+	set[SetOneChoice.Bit16] = true
+	in.Structure = OuterWithOffsets{EnumOne.Value10, 0, set, OuterWithOffsetsInner{1, 2}}
+
+	var buf = new(bytes.Buffer)
+	if err := in.Encode(buf, binary.LittleEndian); err != nil {
+		t.Logf("Encoding Error", err)
+		t.Fail()
+	}
+	if int(in.SbeBlockLength()) != buf.Len() {
+		t.Logf("in.SbeBlockLength(%d) != buf.len(%d)", in.SbeBlockLength(), buf.Len())
+		t.Fail()
+	}
+
+	var out Msg2 = *new(Msg2)
+	if err := out.Decode(buf, binary.LittleEndian, 0, true); err != nil {
+		t.Logf("Decoding Error", err)
+		t.Fail()
+	}
+
+	if in != out {
+		t.Logf("in != out\n", in, out)
+		t.Fail()
+	}
+
+	return
+
+}
+
+func TestEncodeDecodeMsg3(t *testing.T) {
+
+	var in Msg3
+
+	in.Structure = FuturesPrice{65, 3, IsSettlement.T}
+
+	var buf = new(bytes.Buffer)
+	if err := in.Encode(buf, binary.LittleEndian); err != nil {
+		t.Logf("Encoding Error", err)
+		t.Fail()
+	}
+
+	var out Msg3 = *new(Msg3)
+	if err := out.Decode(buf, binary.LittleEndian, 0, true); err != nil {
+		t.Logf("Decoding Error", err)
+		t.Fail()
+	}
+
+	if in != out {
+		t.Logf("in != out\n", in, out)
+		t.Fail()
+	}
+
+	return
+
+}

--- a/gocode/src/example-schema/CarExample.go
+++ b/gocode/src/example-schema/CarExample.go
@@ -256,7 +256,7 @@ func makeCar() baseline.Car {
 	var engine baseline.Engine
 	engine = baseline.Engine{2000, 4, 0, manufacturerCode, [6]byte{}, baseline.EngineBooster{baseline.BoostType.NITROUS, 200}}
 
-	brand := []uint8("Honda")
+	manufacturer := []uint8("Honda")
 	model := []uint8("Civic VTi")
 	activationCode := []uint8("deadbeef")
 
@@ -280,7 +280,7 @@ func makeCar() baseline.Car {
 	pf = append(pf, baseline.CarPerformanceFigures{99, acc2})
 
 
-	car := baseline.Car{1234, 2013, baseline.BooleanType.T, baseline.Model.A, [5]uint32{0, 1, 2, 3, 4}, vehicleCode, optionalExtras, baseline.Model.A, engine, fuel, pf, brand, model, activationCode}
+	car := baseline.Car{1234, 2013, baseline.BooleanType.T, baseline.Model.A, [5]uint32{0, 1, 2, 3, 4}, vehicleCode, optionalExtras, baseline.Model.A, engine, fuel, pf, manufacturer, model, activationCode}
 
 	return car
 }

--- a/gocode/src/example-schema/CarExample.go
+++ b/gocode/src/example-schema/CarExample.go
@@ -1,0 +1,304 @@
+// golang example code for SBE's example-schema.xml
+
+package main
+
+import (
+	"baseline"
+	"bytes"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"time"
+)
+
+func main() {
+
+	fmt.Println("Example encode and decode")
+	ExampleEncodeDecode()
+
+	fmt.Println("Example decode using bytes.buffer")
+	ExampleDecodeBuffer()
+
+	fmt.Println("Example decode using io.Pipe")
+	ExampleDecodePipe()
+
+	fmt.Println("Example decode using socket")
+	ExampleDecodeSocket()
+
+	return
+
+}
+
+func ExampleEncodeDecode() bool {
+	in := makeCar()
+
+	var buf = new(bytes.Buffer)
+	if err := in.Encode(buf, binary.LittleEndian); err != nil {
+		fmt.Println("Encoding Error", err)
+		os.Exit(1)
+	}
+
+	var out baseline.Car = *new(baseline.Car)
+	if err := out.Decode(buf, binary.LittleEndian, 0, true); err != nil {
+		fmt.Println("Decoding Error", err)
+		os.Exit(1)
+	}
+
+	if in.SerialNumber != out.SerialNumber {
+		fmt.Println("in.SerialNumber != out.SerialNumber:\n", in.SerialNumber, out.SerialNumber)
+		os.Exit(1)
+	}
+	if in.ModelYear != out.ModelYear {
+		fmt.Println("in.ModelYear != out.ModelYear:\n", in.ModelYear, out.ModelYear)
+		os.Exit(1)
+	}
+	if in.Available != out.Available {
+		fmt.Println("in.Available != out.Available:\n", in.Available, out.Available)
+		os.Exit(1)
+	}
+	if in.Code != out.Code {
+		fmt.Println("in.Code != out.Code:\n", in.Code, out.Code)
+		os.Exit(1)
+	}
+	if in.SomeNumbers != out.SomeNumbers {
+		fmt.Println("in.SomeNumbers != out.SomeNumbers:\n", in.SomeNumbers, out.SomeNumbers)
+		os.Exit(1)
+	}
+	if in.VehicleCode != out.VehicleCode {
+		fmt.Println("in.VehicleCode != out.VehicleCode:\n", in.VehicleCode, out.VehicleCode)
+		os.Exit(1)
+	}
+	if in.Extras != out.Extras {
+		fmt.Println("in.Extras != out.Extras:\n", in.Extras, out.Extras)
+		os.Exit(1)
+	}
+
+	// DiscountedModel is constant
+	if baseline.Model.C != out.DiscountedModel {
+		fmt.Println("in.DiscountedModel != out.DiscountedModel:\n", in.DiscountedModel, out.DiscountedModel)
+		os.Exit(1)
+	}
+
+	// Engine has two constant values which should come back filled in
+	if in.Engine == out.Engine {
+		fmt.Println("in.Engine == out.Engine (and they should be different):\n", in.Engine, out.Engine)
+		os.Exit(1)
+	}
+
+	// Engine has constant elements so We should have used our the
+	// EngineInit() function to fill those in when we created the
+	// object, and then they will correctly compare
+	baseline.EngineInit(&in.Engine)
+	if in.Engine != out.Engine {
+		fmt.Println("in.Engine != out.Engine:\n", in.Engine, out.Engine)
+		os.Exit(1)
+	}
+
+	return true
+}
+
+func ExampleDecodeBuffer() bool {
+	buf := bytes.NewBuffer(data)
+	var m baseline.MessageHeader
+	if err := m.Decode(buf, binary.LittleEndian, 0, true); err != nil {
+		fmt.Println("Failed to decode message header", err)
+		os.Exit(1)
+	}
+
+	// fmt.Println("\tbuffer is length:", buf.Len())
+	var c baseline.Car
+	if err := c.Decode(buf, binary.LittleEndian, m.Version, true); err != nil {
+		fmt.Println("Failed to decode car", err)
+		os.Exit(1)
+	}
+	return true
+}
+
+func ExampleDecodePipe() bool {
+	var r,w = io.Pipe()
+
+	go func() {
+		defer w.Close()
+
+		// By way of test, stream the bytes into the pipe 32 at a time
+		msg := data[0:]
+		for ;len(msg) > 0; {
+			min := MinInt(len(msg), 64)
+			// fmt.Println("writing: ", msg[0:min])
+			n, err := w.Write(msg[0:min])
+			if err != nil {
+				fmt.Println("write error is", err)
+				os.Exit(1)
+			}
+			if (n < 8) {
+				fmt.Println("short write of", n, "bytes")
+				os.Exit(1)
+			}
+			msg = msg[n:]
+			time.Sleep(time.Second)
+		}
+	}()
+
+	var m baseline.MessageHeader
+	m.Decode(r, binary.LittleEndian, 0, true);
+
+	var c baseline.Car
+	if err := c.Decode(r, binary.LittleEndian, m.Version, true); err != nil {
+		fmt.Println("Failed to decode car", err)
+		os.Exit(1)
+	}
+	r.Close()
+	return true
+}
+
+
+func ExampleDecodeSocket() bool {
+	addr := "127.0.0.1:15678"
+	writerDone := make(chan bool)
+	readerDone := make(chan bool)
+
+	// Reader
+	go func() {
+		// fmt.Println("resolve")
+		tcpAddr, err := net.ResolveTCPAddr("tcp", addr)
+		if err != nil {
+			fmt.Println("Resolve failed", err.Error())
+			os.Exit(1)
+		}
+
+		// fmt.Println("create listener")
+		listener, err := net.ListenTCP("tcp", tcpAddr)
+		if err != nil {
+			fmt.Println("Listen failed", err.Error())
+			os.Exit(1)
+		}
+		defer listener.Close()
+
+		// fmt.Println("listen")
+		conn, err := listener.Accept()
+		if err != nil {
+			fmt.Println("Accept failed", err.Error())
+			os.Exit(1)
+		}
+		defer conn.Close()
+
+
+		// fmt.Println("reading messageheader")
+		var m baseline.MessageHeader
+		m.Decode(conn, binary.LittleEndian, 0, true);
+
+		// fmt.Println("reading car")
+		var c baseline.Car
+		if err := c.Decode(conn, binary.LittleEndian, m.Version, true); err != nil {
+			fmt.Println("Failed to decode car", err)
+			os.Exit(1)
+		}
+
+		// fmt.Printf("%+v\n", c)
+		readerDone <- true
+	}()
+
+	// Let that get started
+	time.Sleep(time.Second)
+
+	// Writer
+	go func() {
+		//fmt.Println("dial")
+		conn, err := net.Dial("tcp", addr)
+		if err != nil {
+			fmt.Println("Dial failed", err.Error())
+			os.Exit(1)
+		}
+		defer conn.Close()
+
+		// By way of test, stream the bytes into the pipe 32 at a time
+		msg := data[0:]
+		for ;len(msg) > 0; {
+			min := MinInt(len(msg), 64)
+			// fmt.Println("writing: ", msg[0:min])
+			n, err := conn.Write(msg[0:min])
+			if err != nil {
+				fmt.Println("write error is", err)
+				os.Exit(1)
+			}
+			if (n < 8) {
+				fmt.Println("short write of", n, "bytes")
+				os.Exit(1)
+			}
+			// fmt.Println("wrote", n, "bytes")
+			msg = msg[n:]
+			time.Sleep(time.Second)
+		}
+		<- readerDone
+		writerDone <- true
+	}()
+
+	<- writerDone
+
+	return true
+}
+
+
+// Helper to make a Car object as per the Java example
+func makeCar() baseline.Car {
+	var vehicleCode [6]byte
+	copy(vehicleCode[:], "abcdef")
+
+	var manufacturerCode [3]byte
+	copy(manufacturerCode[:], "123")
+
+	var optionalExtras [8]bool
+	optionalExtras[baseline.OptionalExtrasChoice.CruiseControl] = true
+	optionalExtras[baseline.OptionalExtrasChoice.SportsPack] = true
+
+	var engine baseline.Engine
+	engine = baseline.Engine{2000, 4, 0, manufacturerCode, [6]byte{}, baseline.EngineBooster{baseline.BoostType.NITROUS, 200}}
+
+	brand := []uint8("Honda")
+	model := []uint8("Civic VTi")
+	activationCode := []uint8("deadbeef")
+
+	var fuel []baseline.CarFuelFigures
+	fuel = append(fuel, baseline.CarFuelFigures{30, 35.9, []uint8("Urban Cycle")})
+	fuel = append(fuel, baseline.CarFuelFigures{55, 49.0, []uint8("Combined Cycle")})
+	fuel = append(fuel, baseline.CarFuelFigures{75, 40.0, []uint8("Highway Cycle")})
+
+	var acc1 []baseline.CarPerformanceFiguresAcceleration
+	acc1 = append(acc1, baseline.CarPerformanceFiguresAcceleration{30, 3.8})
+	acc1 = append(acc1, baseline.CarPerformanceFiguresAcceleration{60, 7.5})
+	acc1 = append(acc1, baseline.CarPerformanceFiguresAcceleration{100, 12.2})
+
+	var acc2 []baseline.CarPerformanceFiguresAcceleration
+	acc2 = append(acc2, baseline.CarPerformanceFiguresAcceleration{30, 3.8})
+	acc2 = append(acc2, baseline.CarPerformanceFiguresAcceleration{60, 7.5})
+	acc2 = append(acc2, baseline.CarPerformanceFiguresAcceleration{100, 12.2})
+
+	var pf []baseline.CarPerformanceFigures
+	pf = append(pf, baseline.CarPerformanceFigures{95, acc1})
+	pf = append(pf, baseline.CarPerformanceFigures{99, acc2})
+
+
+	car := baseline.Car{1234, 2013, baseline.BooleanType.T, baseline.Model.A, [5]uint32{0, 1, 2, 3, 4}, vehicleCode, optionalExtras, baseline.Model.A, engine, fuel, pf, brand, model, activationCode}
+
+	return car
+}
+
+// MaxInt returns the larger of two ints.
+func MaxInt(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}
+// MinInt returns the larger of two ints.
+func MinInt(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// The byte array is from the java example for interop test
+var data []byte = []byte{47, 0, 1, 0, 1, 0, 0, 0, 210, 4, 0, 0, 0, 0, 0, 0, 221, 7, 1, 65, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 97, 98, 99, 100, 101, 102, 6, 208, 7, 4, 49, 50, 51, 78, 200, 6, 0, 3, 0, 30, 0, 154, 153, 15, 66, 11, 0, 0, 0, 85, 114, 98, 97, 110, 32, 67, 121, 99, 108, 101, 55, 0, 0, 0, 68, 66, 14, 0, 0, 0, 67, 111, 109, 98, 105, 110, 101, 100, 32, 67, 121, 99, 108, 101, 75, 0, 0, 0, 32, 66, 13, 0, 0, 0, 72, 105, 103, 104, 119, 97, 121, 32, 67, 121, 99, 108, 101, 1, 0, 2, 0, 95, 6, 0, 3, 0, 30, 0, 0, 0, 128, 64, 60, 0, 0, 0, 240, 64, 100, 0, 51, 51, 67, 65, 99, 6, 0, 3, 0, 30, 0, 51, 51, 115, 64, 60, 0, 51, 51, 227, 64, 100, 0, 205, 204, 60, 65, 5, 0, 0, 0, 72, 111, 110, 100, 97, 9, 0, 0, 0, 67, 105, 118, 105, 99, 32, 86, 84, 105, 6, 0, 0, 0, 97, 98, 99, 100, 101, 102}

--- a/gocode/src/group/SBE tests/TestMessage1_test.go
+++ b/gocode/src/group/SBE tests/TestMessage1_test.go
@@ -1,0 +1,53 @@
+package sbe_tests
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestEncodeDecodeTestMessage1(t *testing.T) {
+
+	var s [20]byte
+	copy(s[:], "abcdefghijklmnopqrst")
+
+	group := TestMessage1Entries{s, 7}
+	var in TestMessage1
+
+	in.Tag1 = 44
+	in.Entries = append(in.Entries, group)
+
+	var buf = new(bytes.Buffer)
+	if err := in.Encode(buf, binary.LittleEndian); err != nil {
+		t.Logf("Encoding Error", err)
+		t.Fail()
+	}
+
+	var out TestMessage1 = *new(TestMessage1)
+	if err := out.Decode(buf, binary.LittleEndian, 0, true); err != nil {
+		t.Logf("Decoding Error", err)
+		t.Fail()
+	}
+
+	t.Logf("len=%d, cap=%d, in=%v\n", len(in.Entries), cap(in.Entries), in.Entries)
+
+	t.Logf("len=%d, cap=%d, out=%v\n", len(out.Entries), cap(out.Entries), out.Entries)
+
+	if in.Tag1 != out.Tag1 {
+		t.Logf("in != out:\n", in, out)
+		t.Fail()
+	}
+	if len(in.Entries) != len(out.Entries) {
+		t.Logf("len(in.Entries)(%d) != len(out.Entries)(%d):\n", len(in.Entries), len(out.Entries))
+		t.Fail()
+	}
+	for i := 0; i < len(in.Entries); i++ {
+		if in.Entries[i] != out.Entries[i] {
+			t.Logf("in.Entries[%d] != out.Entries[%d]:\n", in.Entries[i], out.Entries[i])
+			t.Fail()
+		}
+	}
+
+	return
+
+}

--- a/gocode/src/group_with_data/TestMessages_test.go
+++ b/gocode/src/group_with_data/TestMessages_test.go
@@ -1,0 +1,212 @@
+package group_with_data
+
+import (
+	"bytes"
+	"encoding/binary"
+	_ "fmt"
+	"testing"
+)
+
+func TestEncodeDecodeTestMessage1(t *testing.T) {
+
+	var tm1e TestMessage1Entries
+	copy(tm1e.TagGroup1[:], "123456789")
+	tm1e.TagGroup2 = 123456789
+	tm1e.VarDataField = []byte("abcdef")
+
+	var in TestMessage1
+	in.Tag1 = 1234
+	in.Entries = append(in.Entries, tm1e)
+
+	var buf = new(bytes.Buffer)
+	if err := in.Encode(buf, binary.LittleEndian); err != nil {
+		t.Logf("Encoding Error", err)
+		t.Fail()
+	}
+
+	var out TestMessage1 = *new(TestMessage1)
+	if err := out.Decode(buf, binary.LittleEndian, 0, true); err != nil {
+		t.Logf("Decoding Error", err)
+		t.Fail()
+	}
+
+	// fmt.Printf("%+v\n", in)
+	// fmt.Printf("%+v\n", out)
+
+	if in.Tag1 != out.Tag1 {
+		t.Logf("in.Tag1 != out.Tag1")
+		t.Fail()
+	}
+	if in.Entries[0].TagGroup1 != out.Entries[0].TagGroup1 {
+		t.Logf("in.Entries[0].TagGroup1 != out.Entries[0].TagGroup1")
+		t.Fail()
+	}
+	if in.Entries[0].TagGroup2 != out.Entries[0].TagGroup2 {
+		t.Logf("in.Entries[0].TagGroup2 != out.Entries[0].TagGroup2")
+		t.Fail()
+	}
+	if !bytes.Equal(in.Entries[0].VarDataField, out.Entries[0].VarDataField) {
+		t.Logf("in.Entries[0].VarDataField != out.Entries[0].VarDataField", in.Entries[0].VarDataField, out.Entries[0].VarDataField)
+		t.Fail()
+	}
+	return
+}
+
+func TestEncodeDecodeTestMessage2(t *testing.T) {
+
+	var tm2e TestMessage2Entries
+	copy(tm2e.TagGroup1[:], "123456789")
+	tm2e.TagGroup2 = 123456789
+	tm2e.VarDataField1 = []byte("abcdef")
+	tm2e.VarDataField2 = []byte("ghij")
+
+	var in TestMessage2
+	in.Tag1 = 1234
+	in.Entries = append(in.Entries, tm2e)
+	in.Entries = append(in.Entries, tm2e)
+
+	var buf = new(bytes.Buffer)
+	if err := in.Encode(buf, binary.LittleEndian); err != nil {
+		t.Logf("Encoding Error", err)
+		t.Fail()
+	}
+
+	var out TestMessage2 = *new(TestMessage2)
+	if err := out.Decode(buf, binary.LittleEndian, 0, true); err != nil {
+		t.Logf("Decoding Error", err)
+		t.Fail()
+	}
+
+	// fmt.Printf("%+v\n", in)
+	// fmt.Printf("%+v\n", out)
+
+	if in.Tag1 != out.Tag1 {
+		t.Logf("in.Tag1 != out.Tag1")
+		t.Fail()
+	}
+
+	for i := 0; i < len(in.Entries); i++ {
+		if in.Entries[0].TagGroup1 != out.Entries[0].TagGroup1 {
+			t.Logf("in.Entries[0].TagGroup1 != out.Entries[0].TagGroup1")
+			t.Fail()
+		}
+		if in.Entries[0].TagGroup2 != out.Entries[0].TagGroup2 {
+			t.Logf("in.Entries[0].TagGroup2 != out.Entries[0].TagGroup2")
+			t.Fail()
+		}
+		if !bytes.Equal(in.Entries[i].VarDataField1, out.Entries[i].VarDataField1) {
+			t.Logf("in.Entries[%d].VarDataField != out.Entries[%d].VarDataField", i, i, in.Entries[i].VarDataField1, out.Entries[i].VarDataField1)
+			t.Fail()
+		}
+		if !bytes.Equal(in.Entries[i].VarDataField2, out.Entries[i].VarDataField2) {
+			t.Logf("in.Entries[%d].VarDataField != out.Entries[%d].VarDataField", i, i, in.Entries[i].VarDataField2, out.Entries[i].VarDataField2)
+			t.Fail()
+		}
+	}
+	return
+}
+
+func TestEncodeDecodeTestMessage3(t *testing.T) {
+
+	var tm3en TestMessage3EntriesNestedEntries
+	tm3en.TagGroup2 = 99887766
+	tm3en.VarDataFieldNested = []byte("nested")
+
+	var tm3e TestMessage3Entries
+	copy(tm3e.TagGroup1[:], "123456789")
+	tm3e.NestedEntries = append(tm3e.NestedEntries, tm3en)
+	tm3e.VarDataField = []byte("middle")
+
+	var in TestMessage3
+	in.Tag1 = 1234
+	in.Entries = append(in.Entries, tm3e)
+	in.Entries = append(in.Entries, tm3e)
+
+	var buf = new(bytes.Buffer)
+	if err := in.Encode(buf, binary.LittleEndian); err != nil {
+		t.Logf("Encoding Error", err)
+		t.Fail()
+	}
+
+	var out TestMessage3 = *new(TestMessage3)
+	if err := out.Decode(buf, binary.LittleEndian, 0, true); err != nil {
+		t.Logf("Decoding Error", err)
+		t.Fail()
+	}
+
+	// fmt.Printf("%+v\n", in)
+	// fmt.Printf("%+v\n", out)
+
+	if in.Tag1 != out.Tag1 {
+		t.Logf("in.Tag1 != out.Tag1")
+		t.Fail()
+	}
+
+	for i := 0; i < len(in.Entries); i++ {
+		if in.Entries[0].TagGroup1 != out.Entries[0].TagGroup1 {
+			t.Logf("in.Entries[0].TagGroup1 != out.Entries[0].TagGroup1")
+			t.Fail()
+		}
+		if !bytes.Equal(in.Entries[i].VarDataField, out.Entries[i].VarDataField) {
+			t.Logf("in.Entries[%d].VarDataField != out.Entries[%d].VarDataField", i, i, in.Entries[i].VarDataField, out.Entries[i].VarDataField)
+			t.Fail()
+		}
+
+		if in.Entries[0].NestedEntries[0].TagGroup2 != out.Entries[0].NestedEntries[0].TagGroup2 {
+			t.Logf("if in.Entries[0].NestedEntries[0].TagGroup2 != out.Entries[0].NestedEntries[0].TagGroup2")
+			t.Fail()
+		}
+
+		if !bytes.Equal(in.Entries[0].NestedEntries[0].VarDataFieldNested, out.Entries[0].NestedEntries[0].VarDataFieldNested) {
+			t.Logf("in.Entries[0].NestedEntries[0].VarDataFieldNested != out.Entries[0].NestedEntries[0].VarDataFieldNested")
+			t.Fail()
+		}
+
+	}
+	return
+}
+
+func TestEncodeDecodeTestMessage4(t *testing.T) {
+
+	var tm4e TestMessage4Entries
+	tm4e.VarDataField1 = []byte("abcdef")
+	tm4e.VarDataField2 = []byte("ghij")
+
+	var in TestMessage4
+	in.Tag1 = 9876
+	in.Entries = append(in.Entries, tm4e)
+	in.Entries = append(in.Entries, tm4e)
+	in.Entries = append(in.Entries, tm4e)
+
+	var buf = new(bytes.Buffer)
+	if err := in.Encode(buf, binary.LittleEndian); err != nil {
+		t.Logf("Encoding Error", err)
+		t.Fail()
+	}
+
+	var out TestMessage4 = *new(TestMessage4)
+	if err := out.Decode(buf, binary.LittleEndian, 0, true); err != nil {
+		t.Logf("Decoding Error", err)
+		t.Fail()
+	}
+
+	// fmt.Printf("%+v\n", in)
+	// fmt.Printf("%+v\n", out)
+
+	if in.Tag1 != out.Tag1 {
+		t.Logf("in.Tag1 != out.Tag1")
+		t.Fail()
+	}
+
+	for i := 0; i < len(in.Entries); i++ {
+		if !bytes.Equal(in.Entries[i].VarDataField1, out.Entries[i].VarDataField1) {
+			t.Logf("in.Entries[%d].VarDataField != out.Entries[%d].VarDataField", i, i, in.Entries[i].VarDataField1, out.Entries[i].VarDataField1)
+			t.Fail()
+		}
+		if !bytes.Equal(in.Entries[i].VarDataField2, out.Entries[i].VarDataField2) {
+			t.Logf("in.Entries[%d].VarDataField != out.Entries[%d].VarDataField", i, i, in.Entries[i].VarDataField2, out.Entries[i].VarDataField2)
+			t.Fail()
+		}
+	}
+	return
+}

--- a/gocode/src/mktdata/fixme_test.go
+++ b/gocode/src/mktdata/fixme_test.go
@@ -1,0 +1,10 @@
+package mktdata
+
+import (
+	"fmt"
+	"testing"
+)
+
+func TestFixme(t *testing.T) {
+	fmt.Println("FIXME")
+}

--- a/gocode/src/simple/simple_test.go
+++ b/gocode/src/simple/simple_test.go
@@ -1,0 +1,52 @@
+package simple
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestEncodeDecode(t *testing.T) {
+	s := Simple0{2863311530, 123456, 7890, 63, -8, -16, -32, -64, 3.14, -3.14e7, [6]byte{'a', 'b', 'c', 'd', 'e', 'f'}, 'A', [2]int32{254, 255}}
+
+	var sbuf = new(bytes.Buffer)
+	if err := s.Encode(sbuf, binary.LittleEndian); err != nil {
+		t.Log("Simple0 Encoding Error", err)
+		t.Fail()
+	}
+	t.Log(s, " -> ", sbuf.Bytes())
+	t.Log("Cap() = ", sbuf.Cap(), "Len() = ", sbuf.Len())
+
+	m := MessageHeader{s.SbeBlockLength(), s.SbeTemplateId(), s.SbeSchemaId(), s.SbeSchemaVersion()}
+	var mbuf = new(bytes.Buffer)
+	if err := m.Encode(mbuf, binary.LittleEndian); err != nil {
+		t.Log("MessageHeader Encoding Error", err)
+		t.Fail()
+	}
+	t.Log(m, " -> ", mbuf.Bytes())
+	t.Log("Cap() = ", mbuf.Cap(), "Len() = ", mbuf.Len())
+
+	// Create a new empty MessageHeader and Simple0
+	m = *new(MessageHeader)
+	var s2 Simple0 = *new(Simple0)
+
+	if err := m.Decode(mbuf, binary.LittleEndian, 0, true); err != nil {
+		t.Log("MessageHeader Decoding Error", err)
+		t.Fail()
+	}
+	t.Log("MessageHeader Decodes as: ", m)
+	t.Log("Cap() = ", mbuf.Cap(), "Len() = ", mbuf.Len())
+
+	if err := s2.Decode(sbuf, binary.LittleEndian, 0, true); err != nil {
+		t.Log("Simple0 Decoding Error", err)
+		t.Fail()
+	}
+	t.Log("Simple0 decodes as: ", s2)
+	t.Log("Cap() = ", sbuf.Cap(), "Len() = ", sbuf.Len())
+
+	// s2.Int2[0] = 18
+	if s != s2 {
+		t.Logf("s != s2\n%s\n%s", s, s2)
+		t.Fail()
+	}
+}

--- a/gocode/src/vardata/SBE tests/TestMessage1_test.go
+++ b/gocode/src/vardata/SBE tests/TestMessage1_test.go
@@ -1,0 +1,43 @@
+package sbe_tests
+
+import (
+	"bytes"
+	"encoding/binary"
+	"testing"
+)
+
+func TestEncodeDecodeTestMessage1(t *testing.T) {
+
+	var in TestMessage1
+
+	in.EncryptedNewPassword = []byte("abcdefghijklmnopqrst")
+
+	var buf = new(bytes.Buffer)
+	if err := in.Encode(buf, binary.LittleEndian); err != nil {
+		t.Logf("Encoding Error", err)
+		t.Fail()
+	}
+
+	var out TestMessage1 = *new(TestMessage1)
+	if err := out.Decode(buf, binary.LittleEndian, 0, true); err != nil {
+		t.Logf("Decoding Error", err)
+		t.Fail()
+	}
+
+	t.Logf("in:  len=%d, cap=%d, in=%v\n", len(in.EncryptedNewPassword), cap(in.EncryptedNewPassword), in.EncryptedNewPassword)
+	t.Logf("out: len=%d, cap=%d, out=%v\n", len(out.EncryptedNewPassword), cap(out.EncryptedNewPassword), out.EncryptedNewPassword)
+
+	if len(in.EncryptedNewPassword) != len(out.EncryptedNewPassword) {
+		t.Logf("len(in.EncryptedNewPassword)(%d) != len(out.EncryptedNewPassword)(%d):\n", len(in.EncryptedNewPassword), len(out.EncryptedNewPassword))
+		t.Fail()
+	}
+	for i := 0; i < len(in.EncryptedNewPassword); i++ {
+		if in.EncryptedNewPassword[i] != out.EncryptedNewPassword[i] {
+			t.Logf("in.EncryptedNewPassword[%d] != out.EncryptedNewPassword)[%d]:\n", len(in.EncryptedNewPassword), len(out.EncryptedNewPassword))
+			t.Fail()
+		}
+	}
+
+	return
+
+}

--- a/sbe-benchmarks/src/main/cpp/SbeCarCodecBench.h
+++ b/sbe-benchmarks/src/main/cpp/SbeCarCodecBench.h
@@ -24,8 +24,8 @@ using namespace uk::co::real_logic::sbe::benchmarks;
 char VEHICLE_CODE[] = {'a', 'b', 'c', 'd', 'e', 'f'};
 uint32_t SOMENUMBERS[] = { 1, 2, 3, 4, 5 };
 char MANUFACTURER_CODE[] = {'1', '2', '3'};
-const char *MAKE = "Honda";
-int MAKELEN = strlen(MAKE);
+const char *BRAND = "Honda";
+int BRANDLEN = strlen(BRAND);
 const char *MODEL = "Civic VTi";
 int MODELLEN = strlen(MODEL);
 
@@ -73,7 +73,7 @@ public:
                 .next().mph(60).seconds(7.1f)
                 .next().mph(100).seconds(11.8f);
 
-        car.putMake(MAKE, MAKELEN);
+        car.putBrand(BRAND, BRANDLEN);
         car.putModel(MODEL, MODELLEN);
 
         return car.encodedLength();
@@ -130,7 +130,7 @@ public:
             }
         }
 
-        tmpChar = car.make();
+        tmpChar = car.brand();
         tmpChar = car.model();
 
         return car.encodedLength();

--- a/sbe-benchmarks/src/main/cpp/SbeCarCodecBench.h
+++ b/sbe-benchmarks/src/main/cpp/SbeCarCodecBench.h
@@ -24,8 +24,8 @@ using namespace uk::co::real_logic::sbe::benchmarks;
 char VEHICLE_CODE[] = {'a', 'b', 'c', 'd', 'e', 'f'};
 uint32_t SOMENUMBERS[] = { 1, 2, 3, 4, 5 };
 char MANUFACTURER_CODE[] = {'1', '2', '3'};
-const char *BRAND = "Honda";
-int BRANDLEN = strlen(BRAND);
+const char *MANUFACTURER = "Honda";
+int MANUFACTURERLEN = strlen(MANUFACTURER);
 const char *MODEL = "Civic VTi";
 int MODELLEN = strlen(MODEL);
 
@@ -73,7 +73,7 @@ public:
                 .next().mph(60).seconds(7.1f)
                 .next().mph(100).seconds(11.8f);
 
-        car.putBrand(BRAND, BRANDLEN);
+        car.putManufacturer(MANUFACTURER, MANUFACTURERLEN);
         car.putModel(MODEL, MODELLEN);
 
         return car.encodedLength();
@@ -130,7 +130,7 @@ public:
             }
         }
 
-        tmpChar = car.brand();
+        tmpChar = car.manufacturer();
         tmpChar = car.model();
 
         return car.encodedLength();

--- a/sbe-benchmarks/src/main/java/uk/co/real_logic/sbe/CarBenchmark.java
+++ b/sbe-benchmarks/src/main/java/uk/co/real_logic/sbe/CarBenchmark.java
@@ -24,7 +24,7 @@ import java.nio.ByteBuffer;
 
 public class CarBenchmark
 {
-    private static final byte[] MAKE;
+    private static final byte[] BRAND;
     private static final byte[] MODEL;
     private static final byte[] ENG_MAN_CODE;
     private static final byte[] VEHICLE_CODE;
@@ -33,7 +33,7 @@ public class CarBenchmark
     {
         try
         {
-            MAKE = "MAKE".getBytes(CarEncoder.makeCharacterEncoding());
+            BRAND = "BRAND".getBytes(CarEncoder.brandCharacterEncoding());
             MODEL = "MODEL".getBytes(CarEncoder.modelCharacterEncoding());
             ENG_MAN_CODE = "abc".getBytes(EngineEncoder.manufacturerCodeCharacterEncoding());
             VEHICLE_CODE = "abcdef".getBytes(CarEncoder.vehicleCodeCharacterEncoding());
@@ -141,7 +141,7 @@ public class CarBenchmark
                    .next().mph(60).seconds(7.1f)
                    .next().mph(100).seconds(11.8f);
 
-        car.putMake(MAKE, 0, MAKE.length);
+        car.putBrand(BRAND, 0, BRAND.length);
         car.putModel(MODEL, 0, MODEL.length);
     }
 
@@ -207,7 +207,7 @@ public class CarBenchmark
             }
         }
 
-        car.getMake(tempBuffer, 0, tempBuffer.length);
+        car.getBrand(tempBuffer, 0, tempBuffer.length);
         car.getModel(tempBuffer, 0, tempBuffer.length);
     }
 

--- a/sbe-benchmarks/src/main/java/uk/co/real_logic/sbe/CarBenchmark.java
+++ b/sbe-benchmarks/src/main/java/uk/co/real_logic/sbe/CarBenchmark.java
@@ -24,7 +24,7 @@ import java.nio.ByteBuffer;
 
 public class CarBenchmark
 {
-    private static final byte[] BRAND;
+    private static final byte[] MANUFACTURER;
     private static final byte[] MODEL;
     private static final byte[] ENG_MAN_CODE;
     private static final byte[] VEHICLE_CODE;
@@ -33,7 +33,7 @@ public class CarBenchmark
     {
         try
         {
-            BRAND = "BRAND".getBytes(CarEncoder.brandCharacterEncoding());
+            MANUFACTURER = "MANUFACTURER".getBytes(CarEncoder.manufacturerCharacterEncoding());
             MODEL = "MODEL".getBytes(CarEncoder.modelCharacterEncoding());
             ENG_MAN_CODE = "abc".getBytes(EngineEncoder.manufacturerCodeCharacterEncoding());
             VEHICLE_CODE = "abcdef".getBytes(CarEncoder.vehicleCodeCharacterEncoding());
@@ -141,7 +141,7 @@ public class CarBenchmark
                    .next().mph(60).seconds(7.1f)
                    .next().mph(100).seconds(11.8f);
 
-        car.putBrand(BRAND, 0, BRAND.length);
+        car.putManufacturer(MANUFACTURER, 0, MANUFACTURER.length);
         car.putModel(MODEL, 0, MODEL.length);
     }
 
@@ -207,7 +207,7 @@ public class CarBenchmark
             }
         }
 
-        car.getBrand(tempBuffer, 0, tempBuffer.length);
+        car.getManufacturer(tempBuffer, 0, tempBuffer.length);
         car.getModel(tempBuffer, 0, tempBuffer.length);
     }
 

--- a/sbe-benchmarks/src/main/resources/car.xml
+++ b/sbe-benchmarks/src/main/resources/car.xml
@@ -69,7 +69,7 @@
                 <field name="seconds" id="16" type="float"/>
             </group>
         </group>
-        <data name="brand" id="17" type="varDataEncoding"/>
+        <data name="manufacturer" id="17" type="varDataEncoding"/>
         <data name="model" id="18" type="varDataEncoding"/>
     </sbe:message>
 </sbe:messageSchema>

--- a/sbe-benchmarks/src/main/resources/car.xml
+++ b/sbe-benchmarks/src/main/resources/car.xml
@@ -69,7 +69,7 @@
                 <field name="seconds" id="16" type="float"/>
             </group>
         </group>
-        <data name="make" id="17" type="varDataEncoding"/>
+        <data name="brand" id="17" type="varDataEncoding"/>
         <data name="model" id="18" type="varDataEncoding"/>
     </sbe:message>
 </sbe:messageSchema>

--- a/sbe-samples/src/main/cpp/GeneratedStubExample.cpp
+++ b/sbe-samples/src/main/cpp/GeneratedStubExample.cpp
@@ -32,7 +32,7 @@ using namespace baseline;
 
 char VEHICLE_CODE[] = {'a', 'b', 'c', 'd', 'e', 'f'};
 char MANUFACTURER_CODE[] = {'1', '2', '3'};
-const char *MAKE = "Honda";
+const char *BRAND = "Honda";
 const char *MODEL = "Civic VTi";
 const int messageHeaderVersion = 0;
 
@@ -117,7 +117,7 @@ std::size_t encodeCar(Car &car, char *buffer, std::uint64_t offset, std::uint64_
             .next().mph(60).seconds(7.1f)
             .next().mph(100).seconds(11.8f);
 
-    car.putMake(MAKE, 5)
+    car.putBrand(BRAND, 5)
         .putModel(MODEL, 9)
         .putActivationCode("deadbeef", 8);
 
@@ -198,8 +198,8 @@ std::size_t decodeCar(
     std::cout << "\ncar.performanceFigures.accelerationId=" << Car::PerformanceFigures::accelerationId();
     std::cout << "\ncar.performanceFigures.acceleration.mphId=" << Car::PerformanceFigures::Acceleration::mphId();
     std::cout << "\ncar.performanceFigures.acceleration.secondsId=" << Car::PerformanceFigures::Acceleration::secondsId();
-    std::cout << "\ncar.makeId=" << Car::makeId();
-    std::cout << "\ncar.makeCharacterEncoding=" << Car::makeCharacterEncoding();
+    std::cout << "\ncar.brandId=" << Car::brandId();
+    std::cout << "\ncar.brandCharacterEncoding=" << Car::brandCharacterEncoding();
     std::cout << "\ncar.modelId=" << Car::modelId();
     std::cout << "\ncar.modelCharacterEncoding=" << Car::modelCharacterEncoding();
     std::cout << "\ncar.activationCodeId=" << Car::activationCodeId();
@@ -282,9 +282,9 @@ std::size_t decodeCar(
         }
     }
 
-    bytesCopied = car.getMake(tmp, sizeof(tmp));
-    std::cout << "\ncar.makeLength=" << bytesCopied;
-    std::cout << "\ncar.make=" << std::string(tmp, bytesCopied);
+    bytesCopied = car.getBrand(tmp, sizeof(tmp));
+    std::cout << "\ncar.brandLength=" << bytesCopied;
+    std::cout << "\ncar.brand=" << std::string(tmp, bytesCopied);
 
     bytesCopied = car.getModel(tmp, sizeof(tmp));
     std::cout << "\ncar.modelLength=" << bytesCopied;

--- a/sbe-samples/src/main/cpp/GeneratedStubExample.cpp
+++ b/sbe-samples/src/main/cpp/GeneratedStubExample.cpp
@@ -32,7 +32,7 @@ using namespace baseline;
 
 char VEHICLE_CODE[] = {'a', 'b', 'c', 'd', 'e', 'f'};
 char MANUFACTURER_CODE[] = {'1', '2', '3'};
-const char *BRAND = "Honda";
+const char *MANUFACTURER = "Honda";
 const char *MODEL = "Civic VTi";
 const int messageHeaderVersion = 0;
 
@@ -117,7 +117,7 @@ std::size_t encodeCar(Car &car, char *buffer, std::uint64_t offset, std::uint64_
             .next().mph(60).seconds(7.1f)
             .next().mph(100).seconds(11.8f);
 
-    car.putBrand(BRAND, 5)
+    car.putManufacturer(MANUFACTURER, 5)
         .putModel(MODEL, 9)
         .putActivationCode("deadbeef", 8);
 
@@ -198,8 +198,8 @@ std::size_t decodeCar(
     std::cout << "\ncar.performanceFigures.accelerationId=" << Car::PerformanceFigures::accelerationId();
     std::cout << "\ncar.performanceFigures.acceleration.mphId=" << Car::PerformanceFigures::Acceleration::mphId();
     std::cout << "\ncar.performanceFigures.acceleration.secondsId=" << Car::PerformanceFigures::Acceleration::secondsId();
-    std::cout << "\ncar.brandId=" << Car::brandId();
-    std::cout << "\ncar.brandCharacterEncoding=" << Car::brandCharacterEncoding();
+    std::cout << "\ncar.manufacturerId=" << Car::manufacturerId();
+    std::cout << "\ncar.manufacturerCharacterEncoding=" << Car::manufacturerCharacterEncoding();
     std::cout << "\ncar.modelId=" << Car::modelId();
     std::cout << "\ncar.modelCharacterEncoding=" << Car::modelCharacterEncoding();
     std::cout << "\ncar.activationCodeId=" << Car::activationCodeId();
@@ -282,9 +282,9 @@ std::size_t decodeCar(
         }
     }
 
-    bytesCopied = car.getBrand(tmp, sizeof(tmp));
-    std::cout << "\ncar.brandLength=" << bytesCopied;
-    std::cout << "\ncar.brand=" << std::string(tmp, bytesCopied);
+    bytesCopied = car.getManufacturer(tmp, sizeof(tmp));
+    std::cout << "\ncar.manufacturerLength=" << bytesCopied;
+    std::cout << "\ncar.manufacturer=" << std::string(tmp, bytesCopied);
 
     bytesCopied = car.getModel(tmp, sizeof(tmp));
     std::cout << "\ncar.modelLength=" << bytesCopied;

--- a/sbe-samples/src/main/cpp/OtfExample.cpp
+++ b/sbe-samples/src/main/cpp/OtfExample.cpp
@@ -315,7 +315,7 @@ static char MANUFACTURER_CODE[] = { '1', '2', '3' };
 static const char *FUEL_FIGURES_1_USAGE_DESCRIPTION = "Urban Cycle";
 static const char *FUEL_FIGURES_2_USAGE_DESCRIPTION = "Combined Cycle";
 static const char *FUEL_FIGURES_3_USAGE_DESCRIPTION = "Highway Cycle";
-static const char *MAKE = "Honda";
+static const char *BRAND = "Honda";
 static const char *MODEL = "Civic VTi";
 static const char *ACTIVATION_CODE = "deadbeef";
 
@@ -417,7 +417,7 @@ std::uint64_t encodeHdrAndCar(char *buffer, std::uint64_t length)
         .next().mph(perf2bMph).seconds(perf2bSeconds)
         .next().mph(perf2cMph).seconds(perf2cSeconds);
 
-    car.putMake(MAKE, static_cast<int>(strlen(MAKE)))
+    car.putBrand(BRAND, static_cast<int>(strlen(BRAND)))
         .putModel(MODEL, static_cast<int>(strlen(MODEL)))
         .putActivationCode(ACTIVATION_CODE, static_cast<int>(strlen(ACTIVATION_CODE)));
 

--- a/sbe-samples/src/main/cpp/OtfExample.cpp
+++ b/sbe-samples/src/main/cpp/OtfExample.cpp
@@ -315,7 +315,7 @@ static char MANUFACTURER_CODE[] = { '1', '2', '3' };
 static const char *FUEL_FIGURES_1_USAGE_DESCRIPTION = "Urban Cycle";
 static const char *FUEL_FIGURES_2_USAGE_DESCRIPTION = "Combined Cycle";
 static const char *FUEL_FIGURES_3_USAGE_DESCRIPTION = "Highway Cycle";
-static const char *BRAND = "Honda";
+static const char *MANUFACTURER = "Honda";
 static const char *MODEL = "Civic VTi";
 static const char *ACTIVATION_CODE = "deadbeef";
 
@@ -417,7 +417,7 @@ std::uint64_t encodeHdrAndCar(char *buffer, std::uint64_t length)
         .next().mph(perf2bMph).seconds(perf2bSeconds)
         .next().mph(perf2cMph).seconds(perf2cSeconds);
 
-    car.putBrand(BRAND, static_cast<int>(strlen(BRAND)))
+    car.putManufacturer(MANUFACTURER, static_cast<int>(strlen(MANUFACTURER)))
         .putModel(MODEL, static_cast<int>(strlen(MODEL)))
         .putActivationCode(ACTIVATION_CODE, static_cast<int>(strlen(ACTIVATION_CODE)));
 

--- a/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleUsingGeneratedStub.java
+++ b/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleUsingGeneratedStub.java
@@ -30,7 +30,7 @@ public class ExampleUsingGeneratedStub
     private static final String ENCODING_FILENAME = "sbe.encoding.filename";
     private static final byte[] VEHICLE_CODE;
     private static final byte[] MANUFACTURER_CODE;
-    private static final byte[] MAKE;
+    private static final byte[] BRAND;
     private static final byte[] MODEL;
     private static final UnsafeBuffer ACTIVATION_CODE;
 
@@ -45,7 +45,7 @@ public class ExampleUsingGeneratedStub
         {
             VEHICLE_CODE = "abcdef".getBytes(CarEncoder.vehicleCodeCharacterEncoding());
             MANUFACTURER_CODE = "123".getBytes(EngineEncoder.manufacturerCodeCharacterEncoding());
-            MAKE = "Honda".getBytes(CarEncoder.makeCharacterEncoding());
+            BRAND = "Honda".getBytes(CarEncoder.brandCharacterEncoding());
             MODEL = "Civic VTi".getBytes(CarEncoder.modelCharacterEncoding());
             ACTIVATION_CODE = new UnsafeBuffer("abcdef".getBytes(CarEncoder.activationCodeCharacterEncoding()));
         }
@@ -158,7 +158,7 @@ public class ExampleUsingGeneratedStub
 
         // An exception will be raised if the string length is larger than can be encoded in the varDataEncoding length field
         // Please use a suitable schema type for varDataEncoding.length: uint8 <= 254, uint16 <= 65534
-        car.make(new String(MAKE, StandardCharsets.UTF_8))
+        car.brand(new String(BRAND, StandardCharsets.UTF_8))
             .putModel(MODEL, srcOffset, MODEL.length)
             .putActivationCode(ACTIVATION_CODE, 0, ACTIVATION_CODE.capacity());
 
@@ -238,7 +238,7 @@ public class ExampleUsingGeneratedStub
             }
         }
 
-        sb.append("\ncar.make=").append(car.make());
+        sb.append("\ncar.brand=").append(car.brand());
 
         sb.append("\ncar.model=").append(
             new String(buffer, 0, car.getModel(buffer, 0, buffer.length), CarEncoder.modelCharacterEncoding()));

--- a/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleUsingGeneratedStub.java
+++ b/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleUsingGeneratedStub.java
@@ -30,7 +30,7 @@ public class ExampleUsingGeneratedStub
     private static final String ENCODING_FILENAME = "sbe.encoding.filename";
     private static final byte[] VEHICLE_CODE;
     private static final byte[] MANUFACTURER_CODE;
-    private static final byte[] BRAND;
+    private static final byte[] MANUFACTURER;
     private static final byte[] MODEL;
     private static final UnsafeBuffer ACTIVATION_CODE;
 
@@ -45,7 +45,7 @@ public class ExampleUsingGeneratedStub
         {
             VEHICLE_CODE = "abcdef".getBytes(CarEncoder.vehicleCodeCharacterEncoding());
             MANUFACTURER_CODE = "123".getBytes(EngineEncoder.manufacturerCodeCharacterEncoding());
-            BRAND = "Honda".getBytes(CarEncoder.brandCharacterEncoding());
+            MANUFACTURER = "Honda".getBytes(CarEncoder.manufacturerCharacterEncoding());
             MODEL = "Civic VTi".getBytes(CarEncoder.modelCharacterEncoding());
             ACTIVATION_CODE = new UnsafeBuffer("abcdef".getBytes(CarEncoder.activationCodeCharacterEncoding()));
         }
@@ -158,7 +158,7 @@ public class ExampleUsingGeneratedStub
 
         // An exception will be raised if the string length is larger than can be encoded in the varDataEncoding length field
         // Please use a suitable schema type for varDataEncoding.length: uint8 <= 254, uint16 <= 65534
-        car.brand(new String(BRAND, StandardCharsets.UTF_8))
+        car.manufacturer(new String(MANUFACTURER, StandardCharsets.UTF_8))
             .putModel(MODEL, srcOffset, MODEL.length)
             .putActivationCode(ACTIVATION_CODE, 0, ACTIVATION_CODE.capacity());
 
@@ -238,7 +238,7 @@ public class ExampleUsingGeneratedStub
             }
         }
 
-        sb.append("\ncar.brand=").append(car.brand());
+        sb.append("\ncar.manufacturer=").append(car.manufacturer());
 
         sb.append("\ncar.model=").append(
             new String(buffer, 0, car.getModel(buffer, 0, buffer.length), CarEncoder.modelCharacterEncoding()));

--- a/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleUsingGeneratedStubExtension.java
+++ b/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleUsingGeneratedStubExtension.java
@@ -31,7 +31,7 @@ public class ExampleUsingGeneratedStubExtension
     private static final String ENCODING_FILENAME = "sbe.encoding.filename";
     private static final byte[] VEHICLE_CODE;
     private static final byte[] MANUFACTURER_CODE;
-    private static final byte[] BRAND;
+    private static final byte[] MANUFACTURER;
     private static final byte[] MODEL;
     private static final UnsafeBuffer ACTIVATION_CODE;
 
@@ -46,7 +46,7 @@ public class ExampleUsingGeneratedStubExtension
         {
             VEHICLE_CODE = "abcdef".getBytes(baseline.CarEncoder.vehicleCodeCharacterEncoding());
             MANUFACTURER_CODE = "123".getBytes(baseline.EngineEncoder.manufacturerCodeCharacterEncoding());
-            BRAND = "Honda".getBytes(baseline.CarEncoder.brandCharacterEncoding());
+            MANUFACTURER = "Honda".getBytes(baseline.CarEncoder.manufacturerCharacterEncoding());
             MODEL = "Civic VTi".getBytes(baseline.CarEncoder.modelCharacterEncoding());
             ACTIVATION_CODE = new UnsafeBuffer("abcdef".getBytes(baseline.CarEncoder.activationCodeCharacterEncoding()));
         }
@@ -157,7 +157,7 @@ public class ExampleUsingGeneratedStubExtension
             .next().mph(60).seconds(7.1f)
             .next().mph(100).seconds(11.8f);
 
-        car.putBrand(BRAND, srcOffset, BRAND.length)
+        car.putManufacturer(MANUFACTURER, srcOffset, MANUFACTURER.length)
             .putModel(MODEL, srcOffset, MODEL.length)
             .putActivationCode(ACTIVATION_CODE, 0, ACTIVATION_CODE.capacity());
 
@@ -240,8 +240,9 @@ public class ExampleUsingGeneratedStubExtension
             }
         }
 
-        sb.append("\ncar.brand=").append(
-            new String(buffer, 0, car.getBrand(buffer, 0, buffer.length), extension.CarEncoder.brandCharacterEncoding()));
+        sb.append("\ncar.manufacturer=").append(
+            new String(buffer, 0, car.getManufacturer(
+               buffer, 0, buffer.length), extension.CarEncoder.manufacturerCharacterEncoding()));
 
         sb.append("\ncar.model=").append(
             new String(buffer, 0, car.getModel(buffer, 0, buffer.length), extension.CarEncoder.modelCharacterEncoding()));

--- a/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleUsingGeneratedStubExtension.java
+++ b/sbe-samples/src/main/java/uk/co/real_logic/sbe/examples/ExampleUsingGeneratedStubExtension.java
@@ -31,7 +31,7 @@ public class ExampleUsingGeneratedStubExtension
     private static final String ENCODING_FILENAME = "sbe.encoding.filename";
     private static final byte[] VEHICLE_CODE;
     private static final byte[] MANUFACTURER_CODE;
-    private static final byte[] MAKE;
+    private static final byte[] BRAND;
     private static final byte[] MODEL;
     private static final UnsafeBuffer ACTIVATION_CODE;
 
@@ -46,7 +46,7 @@ public class ExampleUsingGeneratedStubExtension
         {
             VEHICLE_CODE = "abcdef".getBytes(baseline.CarEncoder.vehicleCodeCharacterEncoding());
             MANUFACTURER_CODE = "123".getBytes(baseline.EngineEncoder.manufacturerCodeCharacterEncoding());
-            MAKE = "Honda".getBytes(baseline.CarEncoder.makeCharacterEncoding());
+            BRAND = "Honda".getBytes(baseline.CarEncoder.brandCharacterEncoding());
             MODEL = "Civic VTi".getBytes(baseline.CarEncoder.modelCharacterEncoding());
             ACTIVATION_CODE = new UnsafeBuffer("abcdef".getBytes(baseline.CarEncoder.activationCodeCharacterEncoding()));
         }
@@ -157,7 +157,7 @@ public class ExampleUsingGeneratedStubExtension
             .next().mph(60).seconds(7.1f)
             .next().mph(100).seconds(11.8f);
 
-        car.putMake(MAKE, srcOffset, MAKE.length)
+        car.putBrand(BRAND, srcOffset, BRAND.length)
             .putModel(MODEL, srcOffset, MODEL.length)
             .putActivationCode(ACTIVATION_CODE, 0, ACTIVATION_CODE.capacity());
 
@@ -240,8 +240,8 @@ public class ExampleUsingGeneratedStubExtension
             }
         }
 
-        sb.append("\ncar.make=").append(
-            new String(buffer, 0, car.getMake(buffer, 0, buffer.length), extension.CarEncoder.makeCharacterEncoding()));
+        sb.append("\ncar.brand=").append(
+            new String(buffer, 0, car.getBrand(buffer, 0, buffer.length), extension.CarEncoder.brandCharacterEncoding()));
 
         sb.append("\ncar.model=").append(
             new String(buffer, 0, car.getModel(buffer, 0, buffer.length), extension.CarEncoder.modelCharacterEncoding()));

--- a/sbe-samples/src/main/resources/example-extension-schema.xml
+++ b/sbe-samples/src/main/resources/example-extension-schema.xml
@@ -83,7 +83,7 @@
                 <field name="seconds" id="17" type="float"/>
             </group>
         </group>
-        <data name="make" id="18" type="varDataEncoding"/>
+        <data name="brand" id="18" type="varDataEncoding"/>
         <data name="model" id="19" type="varDataEncoding"/>
         <data name="activationCode" id="20" type="varDataEncoding"/>
     </sbe:message>

--- a/sbe-samples/src/main/resources/example-extension-schema.xml
+++ b/sbe-samples/src/main/resources/example-extension-schema.xml
@@ -83,7 +83,7 @@
                 <field name="seconds" id="17" type="float"/>
             </group>
         </group>
-        <data name="brand" id="18" type="varDataEncoding"/>
+        <data name="manufacturer" id="18" type="varDataEncoding"/>
         <data name="model" id="19" type="varDataEncoding"/>
         <data name="activationCode" id="20" type="varDataEncoding"/>
     </sbe:message>

--- a/sbe-samples/src/main/resources/example-schema.xml
+++ b/sbe-samples/src/main/resources/example-schema.xml
@@ -81,7 +81,7 @@
                 <field name="seconds" id="17" type="float"/>
             </group>
         </group>
-        <data name="make" id="18" type="varDataEncoding"/>
+        <data name="brand" id="18" type="varDataEncoding"/>
         <data name="model" id="19" type="varDataEncoding"/>
         <data name="activationCode" id="20" type="varDataEncoding"/>
     </sbe:message>

--- a/sbe-samples/src/main/resources/example-schema.xml
+++ b/sbe-samples/src/main/resources/example-schema.xml
@@ -81,7 +81,7 @@
                 <field name="seconds" id="17" type="float"/>
             </group>
         </group>
-        <data name="brand" id="18" type="varDataEncoding"/>
+        <data name="manufacturer" id="18" type="varDataEncoding"/>
         <data name="model" id="19" type="varDataEncoding"/>
         <data name="activationCode" id="20" type="varDataEncoding"/>
     </sbe:message>

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/TargetCodeGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/TargetCodeGenerator.java
@@ -18,6 +18,8 @@ package uk.co.real_logic.sbe.generation;
 import org.agrona.generation.PackageOutputManager;
 import uk.co.real_logic.sbe.generation.cpp.CppGenerator;
 import uk.co.real_logic.sbe.generation.cpp.NamespaceOutputManager;
+import uk.co.real_logic.sbe.generation.golang.GolangGenerator;
+import uk.co.real_logic.sbe.generation.golang.GolangOutputManager;
 import uk.co.real_logic.sbe.generation.java.JavaGenerator;
 import uk.co.real_logic.sbe.ir.Ir;
 
@@ -51,8 +53,15 @@ public enum TargetCodeGenerator
         {
             return new CppGenerator(ir, new NamespaceOutputManager(outputDir, ir.applicableNamespace()));
         }
-    };
+    },
 
+    GOLANG()
+    {
+        public CodeGenerator newInstance(final Ir ir, final String outputDir) throws IOException
+        {
+            return new GolangGenerator(ir, new GolangOutputManager(outputDir, ir.applicableNamespace()));
+        }
+    };
 
     /**
      * Get a new {@link CodeGenerator} for the given target language.

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangGenerator.java
@@ -1,0 +1,1868 @@
+/*
+ * Copyright (C) 2016 MarketFactory, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.sbe.generation.golang;
+
+import uk.co.real_logic.sbe.PrimitiveType;
+import uk.co.real_logic.sbe.generation.CodeGenerator;
+import org.agrona.generation.OutputManager;
+import uk.co.real_logic.sbe.ir.*;
+import org.agrona.Verify;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.TreeSet;
+
+import static uk.co.real_logic.sbe.PrimitiveType.CHAR;
+import static uk.co.real_logic.sbe.generation.golang.GolangUtil.*;
+import static uk.co.real_logic.sbe.ir.GenerationUtil.collectVarData;
+import static uk.co.real_logic.sbe.ir.GenerationUtil.collectGroups;
+import static uk.co.real_logic.sbe.ir.GenerationUtil.collectFields;
+
+public class GolangGenerator implements CodeGenerator
+{
+    private static final String BASE_INDENT = "";
+    private static final String INDENT = "\t";
+
+    private final Ir ir;
+    private final OutputManager outputManager;
+
+    private static TreeSet<String> imports;
+
+
+    public GolangGenerator(final Ir ir, final OutputManager outputManager)
+        throws IOException
+    {
+        Verify.notNull(ir, "ir");
+        Verify.notNull(outputManager, "outputManager");
+
+        this.ir = ir;
+        this.outputManager = outputManager;
+        this.imports = imports;
+
+    }
+
+    public void generateMessageHeaderStub() throws IOException
+    {
+        final String messageHeader = "MessageHeader";
+        try (Writer out = outputManager.createOutput(messageHeader))
+        {
+            // Initialize the imports
+            imports = new TreeSet<String>();
+            imports.add("io");
+            imports.add("encoding/binary");
+
+            final StringBuilder sb = new StringBuilder();
+
+            final List<Token> tokens = ir.headerStructure().tokens();
+
+            generateTypeDeclaration(sb, messageHeader);
+            sb.append(generateTypeBodyComposite(messageHeader, tokens.subList(1, tokens.size() - 1)));
+            generateEncodeDecode(sb, messageHeader, tokens.subList(1, tokens.size() - 1));
+            generateEncodedLength(sb, messageHeader, tokens.get(0).encodedLength());
+            sb.append(generateCompositePropertyElements(
+                messageHeader, tokens.subList(1, tokens.size() - 1)));
+
+            out.append(generateFileHeader(ir.namespaces(), messageHeader));
+            out.append(sb);
+        }
+    }
+
+    public void generateTypeStubs() throws IOException
+    {
+        for (final List<Token> tokens : ir.types())
+        {
+            switch (tokens.get(0).signal())
+            {
+                case BEGIN_ENUM:
+                    generateEnum(tokens);
+                    break;
+
+                case BEGIN_SET:
+                    generateChoiceSet(tokens);
+                    break;
+
+                case BEGIN_COMPOSITE:
+                    generateComposite(tokens, "");
+                    break;
+
+                case BEGIN_MESSAGE:
+                    break;
+
+                default:
+                    break;
+            }
+        }
+    }
+
+    public void generate() throws IOException
+    {
+        generateMessageHeaderStub();
+        generateTypeStubs();
+
+        for (final List<Token> tokens : ir.messages())
+        {
+            final Token msgToken = tokens.get(0);
+            final String typeName = formatTypeName(msgToken.name());
+
+            try (Writer out = outputManager.createOutput(typeName))
+            {
+                final StringBuilder sb = new StringBuilder();
+
+                // Initialize the imports
+                imports = new TreeSet<String>();
+                this.imports.add("io");
+                this.imports.add("encoding/binary");
+
+                generateTypeDeclaration(sb, typeName);
+                generateTypeBody(sb, typeName, tokens.subList(1, tokens.size() - 1));
+
+                sb.append(generateMessageCode(typeName, tokens));
+
+                final List<Token> messageBody = tokens.subList(1, tokens.size() - 1);
+                int i = 0;
+
+                final List<Token> fields = new ArrayList<>();
+                i = collectFields(messageBody, i, fields);
+
+                final List<Token> groups = new ArrayList<>();
+                i = collectGroups(messageBody, i, groups);
+
+                final List<Token> varData = new ArrayList<>();
+                collectVarData(messageBody, i, varData);
+
+                sb.append(generateFields(typeName, fields, ""));
+                generateGroups(sb, groups, typeName);
+                generateGroupProperties(sb, groups, typeName);
+                generateVarData(sb, typeName, varData, "");
+
+                out.append(generateFileHeader(ir.namespaces(), typeName));
+                out.append(sb);
+
+            }
+        }
+    }
+
+    private String generateEncodeOffset(final int gap, final String indent)
+    {
+        if (gap > 0)
+        {
+            return String.format(
+                "\n" +
+                "%1$s\tfor i := 0; i < %2$d; i++ {\n" +
+                "%1$s\t\tif err := binary.Write(writer, order, uint8(0)); err != nil {\n" +
+                "%1$s\t\t\treturn err\n" +
+                "%1$s\t\t}\n" +
+                "%1$s\t}\n",
+                indent,
+                gap);
+        }
+        return "";
+    }
+
+    private String generateDecodeOffset(final int gap, final String indent)
+    {
+        if (gap > 0)
+        {
+            this.imports.add("io");
+            this.imports.add("io/ioutil");
+            return String.format("%1$s\tio.CopyN(ioutil.Discard, reader, %2$d)\n", indent, gap);
+        }
+        return "";
+    }
+
+    private String generateEncodePrimitive(final String varName, final Token token)
+    {
+        return String.format(
+            "\tif err := binary.Write(writer, order, %1$s.%2$s); err != nil {\n" +
+            "\t\treturn err\n" +
+            "\t}\n",
+            varName,
+            formatPropertyName(token.name()));
+    }
+
+    private String generateDecodePrimitive(final String varName, final Token token)
+    {
+        // FIXME: add range checking
+        this.imports.add("fmt");
+        final String rangeCheck;
+        final String versionCheck;
+        final String binaryRead;
+
+        // Decode of a constant is simply assignment
+        if (token.isConstantEncoding())
+        {
+            // if primitiveType="char" this is a character array
+            if (token.encoding().primitiveType() == CHAR)
+            {
+                if (token.encoding().constValue().size() > 1)
+                {
+                    // constValue is a string
+                    return String.format(
+                        "\tcopy(%1$s[:], \"%2$s\")\n",
+                        varName,
+                        token.encoding().constValue());
+                }
+                else
+                {
+                    // constValue is a char
+                    return String.format(
+                        "\t%1$s[0] = %2$s\n",
+                        varName,
+                        token.encoding().constValue());
+                }
+            }
+            else
+            {
+                return String.format(
+                    "\t%1$s = %2$s\n",
+                    varName,
+                    generateLiteral(token.encoding().primitiveType(), token.encoding().constValue().toString()));
+            }
+        }
+
+        binaryRead = "\tif err := binary.Read(reader, order, &%1$s); err != nil {\n" +
+            "\t\treturn err\n" +
+            "\t}\n";
+
+
+        if (token.arrayLength() > 1)
+        {
+            versionCheck = "\tif !%1$sInActingVersion(actingVersion) {\n" +
+                "\t\tfor idx := 0; idx < %2$s; idx++ {\n" +
+                "\t\t\t%1$s[idx] = %1$sNullValue()\n" +
+                "\t\t}\n" +
+                "\t\treturn nil\n" +
+                "\t}\n";
+
+            rangeCheck = "\tfor idx := 0; idx < %2$s; idx++ {\n" +
+                "\t\tif %1$s[idx] < %1$sMinValue() || %1$s[idx] > %1$sMaxValue() {\n" +
+                "\t\t\treturn fmt.Errorf(\"Range check failed on %1$s[%%d]\", idx)\n" +
+                "\t\t}\n" +
+                "\t}\n";
+        }
+        else
+        {
+            versionCheck = "\tif !%1$sInActingVersion(actingVersion) {\n" +
+                "\t\t%1$s = %1$sNullValue()\n" +
+                "\t\treturn nil\n" +
+                "\t}\n";
+
+            rangeCheck = "\tif %1$s < %1$sMinValue() || %1$s > %1$sMaxValue() {\n" +
+                "\t\treturn fmt.Errorf(\"Range check failed on %1$s\")\n" +
+                "\t}\n";
+        }
+
+        return String.format(
+            versionCheck +
+            binaryRead +
+            rangeCheck,
+            varName,
+            token.arrayLength());
+    }
+
+    private String generateInitPrimitive(final String varName, final Token token)
+    {
+        // Decode of a constant is simply assignment
+        if (token.isConstantEncoding())
+        {
+            // if primitiveType="char" this is a character array
+            if (token.encoding().primitiveType() == CHAR)
+            {
+                if (token.encoding().constValue().size() > 1)
+                {
+                    // constValue is a string
+                    return String.format(
+                        "\tcopy(%1$s[:], \"%2$s\")\n",
+                        varName,
+                        token.encoding().constValue());
+                }
+                else
+                {
+                    // constValue is a char
+                    return String.format(
+                        "\t%1$s[0] = %2$s\n",
+                        varName,
+                        token.encoding().constValue());
+                }
+            }
+            else
+            {
+                return String.format(
+                    "\t%1$s = %2$s\n",
+                    varName,
+                    generateLiteral(token.encoding().primitiveType(), token.encoding().constValue().toString()));
+            }
+        }
+        return "";
+    }
+
+    // Returns the size of the last Message/Group
+    private int generateEncodeDecode(final StringBuilder sb, final String typeName, final List<Token> tokens)
+    {
+        final char varName = Character.toLowerCase(typeName.charAt(0));
+        final StringBuilder encode = new StringBuilder();
+        final StringBuilder decode = new StringBuilder();
+        final StringBuilder init = new StringBuilder();
+        final StringBuilder nested = new StringBuilder();
+        int currentOffset = 0;
+        int gap = 0;
+        generateEncodeHeader(encode, varName, typeName);
+        generateDecodeHeader(decode, varName, typeName);
+        generateInitHeader(init, varName, typeName);
+
+        for (int i = 0; i < tokens.size(); i++)
+        {
+            final Token signalToken = tokens.get(i);
+            final String propertyName = formatPropertyName(signalToken.name());
+
+            switch (signalToken.signal())
+            {
+                case BEGIN_ENUM:
+                case BEGIN_SET:
+                case BEGIN_COMPOSITE:
+                    currentOffset += generateSimpleEncodeDecode(
+                        signalToken,
+                        typeName,
+                        encode, decode, currentOffset);
+                    i = i + signalToken.componentTokenCount() - 1;
+                    break;
+                case BEGIN_FIELD:
+                    if (tokens.size() >= i + 1)
+                    {
+                        currentOffset += generateFieldEncodeDecode(
+                            tokens.subList(i, tokens.size() - 1),
+                            varName, currentOffset, encode, decode, init);
+
+                        // For encodings we need to move an additional one
+                        // token, otherwise we need the count
+                        if (tokens.get(i + 1).signal() == Signal.ENCODING)
+                        {
+                            i += 1;
+                        }
+                        else
+                        {
+                            i += signalToken.componentTokenCount() - 1;
+                        }
+                    }
+                    break;
+                case ENCODING:
+                    gap = signalToken.offset() - currentOffset;
+                    encode.append(generateEncodeOffset(gap, ""));
+                    decode.append(generateDecodeOffset(gap, ""));
+                    currentOffset += signalToken.encodedLength() + gap;
+
+                    // Encode of a constant is a nullop
+                    if (!signalToken.isConstantEncoding())
+                    {
+                        encode.append(generateEncodePrimitive(
+                                          Character.toString(varName),
+                                          signalToken));
+                    }
+                    decode.append(generateDecodePrimitive(
+                        Character.toString(varName) + "." +  propertyName,
+                        signalToken));
+                    init.append(generateInitPrimitive(
+                        Character.toString(varName) + "." +  propertyName,
+                        signalToken));
+                    break;
+                case BEGIN_GROUP:
+                    // generateGroupEncodeDecode can recurse back here
+                    // for nested groups which is why we have the offset
+                    // calculation
+                    gap = generateGroupEncodeDecode(
+                        tokens.subList(i, tokens.size() - 1),
+                        typeName,
+                        encode, decode, init, nested, currentOffset);
+
+                    if (gap > 0)
+                    {
+                        currentOffset += gap;
+                    }
+
+                    // And we can move over this group to the END_GROUP
+                    i = i + signalToken.componentTokenCount() - 1;
+                    break;
+                case END_GROUP:
+                    // Close out this group and unwind
+                    encode.append("\treturn nil\n}\n");
+                    decode.append("\treturn nil\n}\n");
+                    init.append("\treturn\n}\n");
+                    sb.append(encode);
+                    sb.append(decode);
+                    sb.append(init);
+                    sb.append(nested);
+                    return currentOffset; // for gap calculations
+                case BEGIN_VAR_DATA:
+                    currentOffset += generateVarDataEncodeDecode(
+                        tokens.subList(i, tokens.size() - 1),
+                        typeName,
+                        encode, decode, currentOffset);
+                    // And we can move over this group
+                    i = i + signalToken.componentTokenCount() - 1;
+                    break;
+            }
+        }
+
+        // You can use blockLength on both messages and groups (handled above)
+        // to leave some space (akin to an offset).
+        final Token endToken = tokens.get(tokens.size() - 1);
+        if (endToken.signal() == Signal.END_MESSAGE)
+        {
+            gap = endToken.encodedLength() - currentOffset;
+            encode.append(generateEncodeOffset(gap, ""));
+            decode.append(generateDecodeOffset(gap, ""));
+        }
+
+        // Close the Encode/Decode methods
+        encode.append("\treturn nil\n}\n");
+        decode.append("\treturn nil\n}\n");
+        init.append("\treturn\n}\n");
+
+        sb.append(encode);
+        sb.append(decode);
+        sb.append(init);
+        sb.append(nested);
+
+        return currentOffset;
+    }
+
+    private void generateEnumEncodeDecode(
+        final StringBuilder sb,
+        final String enumName,
+        final Token token)
+    {
+        final char varName = Character.toLowerCase(enumName.charAt(0));
+
+        // Encode
+        sb.append(String.format(
+            "\nfunc (%1$s %2$sEnum) Encode(writer io.Writer, order binary.ByteOrder) (err error) {\n",
+            varName,
+            enumName));
+
+        sb.append(String.format(
+            "\tif err := binary.Write(writer, order, %1$s); err != nil {\n" +
+            "\t\treturn err\n" +
+            "\t}\n",
+            varName));
+
+        sb.append("\treturn nil\n}\n");
+
+        // Decode
+        sb.append(String.format(
+            "\nfunc (%1$s *%2$sEnum) Decode(reader io.Reader, " +
+            "order binary.ByteOrder, actingVersion uint16, strict bool) error {\n",
+            varName,
+            enumName));
+
+        imports.add("reflect");
+
+        sb.append(String.format(
+            "\tif err := binary.Read(reader, order, %1$s); err != nil {\n" +
+            "\t\treturn err\n" +
+            "\t}\n",
+            varName,
+            enumName));
+
+        // We use golang's reflect to range of the values in the struct
+        // to check which are legitimate
+        sb.append(String.format(
+            "\tif strict {\n" +
+            "\t\tvalue := reflect.ValueOf(%2$s)\n" +
+            "\t\tfor idx := 0; idx < value.NumField(); idx++ {\n" +
+            "\t\t\tif *%1$s == value.Field(idx).Interface() {\n" +
+            "\t\t\t\treturn nil\n" +
+            "\t\t\t}\n" +
+            "\t\t}\n" +
+            "\t\t*%1$s = %2$s.NullValue\n" +
+            "\t}\n",
+            varName,
+            enumName));
+
+        sb.append("\treturn nil\n}\n");
+    }
+
+    private void generateChoiceEncodeDecode(
+        final StringBuilder sb,
+        final String choiceName,
+        final Token token)
+    {
+        final char varName = Character.toLowerCase(choiceName.charAt(0));
+
+        // Encode
+        sb.append(String.format(
+            "\nfunc (%1$s %2$s) Encode(writer io.Writer, order binary.ByteOrder) error {\n",
+            varName,
+            choiceName));
+
+        sb.append(String.format(
+            "\tvar wireval uint%1$d = 0\n" +
+            "\tfor k, v := range %2$s {\n" +
+            "\t\tif v {\n" +
+            "\t\t\twireval |= (1 << uint(k))\n" +
+            "\t\t}\n\t}\n" +
+            "\treturn binary.Write(writer, order, wireval)\n" +
+            "}\n",
+            token.encodedLength() * 8,
+            varName));
+
+        // Decode
+        sb.append(String.format(
+            "\nfunc (%1$s *%2$s) Decode(reader io.Reader, order binary.ByteOrder, actingVersion uint16, strict bool) error {\n",
+            varName,
+            choiceName));
+
+        sb.append(String.format(
+            "\tvar wireval uint%1$d\n\n" +
+            "\tif err := binary.Read(reader, order, &wireval); err != nil {\n" +
+            "\t\treturn err\n" +
+            "\t}\n" +
+            "\n" +
+            "\tvar idx uint\n" +
+            "\tfor idx = 0; idx < %1$d; idx++ {\n" +
+            "\t\t%2$s[idx] = (wireval & (1 << idx)) > 0\n" +
+            "\t}\n",
+            token.encodedLength() * 8,
+            varName));
+
+        sb.append("\treturn nil\n}\n");
+    }
+
+    private void generateEncodeHeader(
+        final StringBuilder sb,
+        final char varName,
+        final String typeName)
+    {
+        sb.append(String.format(
+            "\nfunc (%1$s %2$s) Encode(writer io.Writer, order binary.ByteOrder) error {\n",
+            varName,
+            typeName));
+    }
+
+    private void generateDecodeHeader(
+        final StringBuilder sb,
+        final char varName,
+        final String typeName)
+    {
+        sb.append(String.format(
+            "\nfunc (%1$s *%2$s) Decode(reader io.Reader, order binary.ByteOrder, actingVersion uint16, strict bool) error {\n",
+            varName,
+            typeName));
+    }
+
+    private void generateInitHeader(
+        final StringBuilder sb,
+        final char varName,
+        final String typeName)
+    {
+        // Init is a function rather than a method to guarantee uniqueness
+        // as a field of a structure may collide
+        sb.append(String.format(
+            "\nfunc %1$sInit(%2$s *%1$s) {\n",
+            typeName,
+            varName));
+    }
+
+    // Returns how many extra tokens to skip over
+    private int generateFieldEncodeDecode(
+        final List<Token> tokens,
+        final char varName,
+        final int currentOffset,
+        StringBuilder encode,
+        StringBuilder decode,
+        StringBuilder init)
+    {
+        final Token signalToken = tokens.get(0);
+        final Token encodingToken = tokens.get(1);
+        final String propertyName = formatPropertyName(signalToken.name());
+
+        final String golangType = golangTypeName(encodingToken.encoding().primitiveType());
+        int gap = 0; // for offset calculations
+
+        switch (encodingToken.signal())
+        {
+            case BEGIN_COMPOSITE:
+            case BEGIN_ENUM:
+            case BEGIN_SET:
+                gap = signalToken.offset() - currentOffset;
+                encode.append(generateEncodeOffset(gap, ""));
+                decode.append(generateDecodeOffset(gap, ""));
+
+                // Encode of a constant is a nullop, decode is assignment
+                if (signalToken.isConstantEncoding())
+                {
+                    decode.append(String.format(
+                        "\t%1$s.%2$s = %3$s\n",
+                        varName, propertyName, signalToken.encoding().constValue()));
+                    init.append(String.format(
+                        "\t%1$s.%2$s = %3$s\n",
+                        varName, propertyName, signalToken.encoding().constValue()));
+                }
+                else
+                {
+                    encode.append(String.format(
+                        "\tif err := %1$s.%2$s.Encode(writer, order); err != nil {\n" +
+                        "\t\treturn err\n" +
+                        "\t}\n",
+                        varName, propertyName));
+
+                    decode.append(String.format(
+                        "\tif %1$s.%2$sInActingVersion(actingVersion) {\n" +
+                        "\t\tif err := %1$s.%2$s.Decode(reader, order, actingVersion, strict); err != nil {\n" +
+                        "\t\t\treturn err\n" +
+                        "\t\t}\n" +
+                        "\t}\n",
+                        varName, propertyName));
+                }
+                break;
+
+            case ENCODING:
+                gap = encodingToken.offset() - currentOffset;
+                encode.append(generateEncodeOffset(gap, ""));
+                decode.append(generateDecodeOffset(gap, ""));
+
+                // Encode of a constant is a nullop
+                if (!encodingToken.isConstantEncoding())
+                {
+                    encode.append(generateEncodePrimitive(
+                                      Character.toString(varName),
+                                      signalToken));
+                }
+
+                decode.append(generateDecodePrimitive(
+                    Character.toString(varName) + "." +  propertyName,
+                    encodingToken));
+                init.append(generateInitPrimitive(
+                    Character.toString(varName) + "." +  propertyName,
+                    encodingToken));
+                break;
+        }
+
+        return encodingToken.encodedLength() + gap;
+    }
+
+    // returns how much to add to offset
+    private int generateSimpleEncodeDecode(
+        final Token token,
+        final String typeName,
+        final StringBuilder encode,
+        final StringBuilder decode,
+        final int currentOffset)
+    {
+
+        final char varName = Character.toLowerCase(typeName.charAt(0));
+        final String propertyName = formatPropertyName(token.name());
+        final int gap = token.offset() - currentOffset;
+        encode.append(generateEncodeOffset(gap, ""));
+        decode.append(generateDecodeOffset(gap, ""));
+
+        encode.append(String.format(
+            "\tif err := %1$s.%2$s.Encode(writer, order); err != nil {\n" +
+            "\t\treturn err\n" +
+            "\t}\n",
+            varName, propertyName));
+
+        decode.append(String.format(
+            "\tif %1$s.%2$sInActingVersion(actingVersion) {\n" +
+            "\t\tif err := %1$s.%2$s.Decode(reader, order, actingVersion, strict); err != nil {\n" +
+            "\t\t\treturn err\n" +
+            "\t\t}\n" +
+            "\t}\n",
+            varName, propertyName));
+
+        return token.encodedLength() + gap;
+    }
+
+    // returns how much to add to offset
+    private int generateVarDataEncodeDecode(
+        final List<Token> tokens,
+        final String typeName,
+        final StringBuilder encode,
+        final StringBuilder decode,
+        final int currentOffset)
+    {
+        final Token signalToken = tokens.get(0);
+        final char varName = Character.toLowerCase(typeName.charAt(0));
+        final String propertyName = formatPropertyName(signalToken.name());
+        final int gap = signalToken.offset() - currentOffset;
+
+        encode.append(generateEncodeOffset(gap, ""));
+        decode.append(generateDecodeOffset(gap, ""));
+
+        // Write the group header (blocklength and numingroup)
+        final String golangTypeForLength = golangTypeName(tokens.get(2).encoding().primitiveType());
+        final String golangTypeForData = golangTypeName(tokens.get(3).encoding().primitiveType());
+
+        encode.append(String.format(
+            "\tif err := binary.Write(writer, order, %1$s(len(%2$s.%3$s))); err != nil {\n" +
+            "\t\treturn err\n" +
+            "\t}\n" +
+            "\tif err := binary.Write(writer, order, %2$s.%3$s); err != nil {\n" +
+            "\t\treturn err\n" +
+            "\t}\n",
+            golangTypeForLength,
+            varName,
+            propertyName));
+
+        decode.append(String.format(
+            "\n" +
+            "\tif !%1$s.%2$sInActingVersion(actingVersion) {\n" +
+            "\t\treturn nil\n" +
+            "\t}\n",
+            varName,
+            propertyName));
+
+        // FIXME:performance we might check capacity before make(),
+        decode.append(String.format(
+            "\tvar %4$sLength %1$s\n" +
+            "\tif err := binary.Read(reader, order, &%4$sLength); err != nil {\n" +
+            "\t\treturn err\n" +
+            "\t}\n" +
+            "\t%3$s.%4$s = make([]%2$s, %4$sLength)\n" +
+            "\tif err := binary.Read(reader, order, &%3$s.%4$s); err != nil {\n" +
+            "\t\treturn err\n" +
+            "\t}\n",
+            golangTypeForLength,
+            golangTypeForData,
+            varName,
+            propertyName));
+
+        if (gap > 0)
+        {
+            return gap;
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+    // returns how much to add to offset
+    private int generateGroupEncodeDecode(
+        final List<Token> tokens,
+        final String typeName,
+        final StringBuilder encode,
+        final StringBuilder decode,
+        final StringBuilder init,
+        final StringBuilder nested,
+        final int currentOffset)
+    {
+        final char varName = Character.toLowerCase(typeName.charAt(0));
+        final Token signalToken = tokens.get(0);
+        final String propertyName = formatPropertyName(signalToken.name());
+        final String blockLengthType = golangTypeName(tokens.get(2).encoding().primitiveType());
+        final String numInGroupType = golangTypeName(tokens.get(3).encoding().primitiveType());
+
+        // Offset handling
+        final int offsetGap = signalToken.offset() - currentOffset;
+        if (offsetGap > 0)
+        {
+            encode.append(generateEncodeOffset(offsetGap, ""));
+            decode.append(generateDecodeOffset(offsetGap, ""));
+        }
+
+        // Recurse for the group's Encode which we do here so we can
+        // write any gap in the Group Entry's BlockLength (group offset)
+        final int gap = signalToken.encodedLength() -
+            generateEncodeDecode(
+                nested,
+                typeName + toUpperFirstChar(signalToken.name()),
+                tokens.subList(5, tokens.size() - 1));
+
+        // Write/Read the group header
+        encode.append(String.format(
+            "\n\tvar %6$sBlockLength %1$s = %2$d\n" +
+            "\tvar %6$sNumInGroup %3$s = %3$s(len(%4$s.%5$s))\n" +
+            "\tif err := binary.Write(writer, order, %6$sBlockLength); err != nil {\n" +
+            "\t\treturn err\n" +
+            "\t}\n" +
+            "\tif err := binary.Write(writer, order, %6$sNumInGroup); err != nil {\n" +
+            "\t\treturn err\n" +
+            "\t}\n" +
+            "\n",
+            blockLengthType,
+            signalToken.encodedLength(),
+            numInGroupType,
+            varName,
+            toUpperFirstChar(signalToken.name()),
+            propertyName));
+
+        // Write/Read the group itself
+        encode.append(String.format(
+            "\tfor _, prop := range %1$s.%2$s {\n" +
+            "\t\tif err := prop.Encode(writer, order); err != nil {\n" +
+            "\t\t\treturn err\n" +
+            "\t\t}\n",
+            varName,
+            toUpperFirstChar(signalToken.name())));
+
+        // Group blocklength handling
+        encode.append(generateEncodeOffset(gap, "\t") + "\t}\n");
+
+        decode.append(String.format(
+            "\n" +
+            "\tif !%1$s.%2$sInActingVersion(actingVersion) {\n" +
+            "\t\treturn nil\n" +
+            "\t}\n",
+            varName,
+            propertyName));
+
+        decode.append(String.format(
+            "\n\tvar %3$sBlockLength %1$s\n" +
+            "\tvar %3$sNumInGroup %2$s\n" +
+            "\tif err := binary.Read(reader, order, &%3$sBlockLength); err != nil {\n" +
+            "\t\treturn err\n" +
+            "\t}\n" +
+            "\tif err := binary.Read(reader, order, &%3$sNumInGroup); err != nil {\n" +
+            "\t\treturn err\n" +
+            "\t}\n" +
+            "\n",
+            blockLengthType,
+            numInGroupType,
+            propertyName));
+
+        decode.append(String.format(
+            "\t%1$s.%2$s = make([]%4$s%2$s, %2$sNumInGroup)\n" +
+            "\tfor i, _ := range %1$s.%2$s {\n" +
+            "\t\tif err := %1$s.%2$s[i].Decode(reader, order, actingVersion, strict); err != nil {\n" +
+            "\t\t\treturn err\n" +
+            "\t\t}\n",
+            varName,
+            toUpperFirstChar(signalToken.name()),
+            numInGroupType,
+            typeName));
+
+        decode.append(generateDecodeOffset(gap, "\t") + "\t}\n");
+
+        if (offsetGap > 0)
+        {
+            return offsetGap; // We need to know we wrote extra bytes
+        }
+        else
+        {
+            return 0;
+        }
+    }
+
+
+    // Recursively traverse groups to create the group properties
+    private void generateGroupProperties(
+        final StringBuilder sb,
+        final List<Token> tokens,
+        final String prefix)
+    {
+        for (int i = 0, size = tokens.size(); i < size; i++)
+        {
+            final Token token = tokens.get(i);
+            if (token.signal() == Signal.BEGIN_GROUP)
+            {
+
+                final char varName = Character.toLowerCase(prefix.charAt(0));
+                final String propertyName = formatPropertyName(token.name());
+
+                sb.append(String.format(
+                    "\nfunc (%1$s %2$s) %3$sId() uint16 {\n" +
+                    "\treturn %4$s\n" +
+                    "}\n" +
+                    "\nfunc (%1$s %2$s) %3$sSinceVersion() uint16 {\n" +
+                    "\treturn %5$d\n" +
+                    "}\n" +
+                    "\nfunc (%1$s %2$s) %3$sInActingVersion(actingVersion uint16) bool {\n" +
+                    "\treturn actingVersion >= %1$s.%3$sSinceVersion()\n" +
+                    "}\n",
+                    varName,
+                    prefix,
+                    propertyName,
+                    token.id(),
+                    (long)token.version()));
+
+                // Look inside for nested groups with extra prefix
+                generateGroupProperties(
+                    sb,
+                    tokens.subList(i + 1, i + token.componentTokenCount() - 1),
+                    prefix + propertyName);
+                i += token.componentTokenCount() - 1;
+            }
+        }
+    }
+
+    private void generateGroups(final StringBuilder sb, final List<Token> tokens, final String prefix)
+    {
+        for (int i = 0, size = tokens.size(); i < size; i++)
+        {
+            final Token groupToken = tokens.get(i);
+            if (groupToken.signal() != Signal.BEGIN_GROUP)
+            {
+                throw new IllegalStateException("tokens must begin with BEGIN_GROUP: token=" + groupToken);
+            }
+
+            // Make a unique Group name by adding our parent
+            final String groupName = prefix + formatTypeName(groupToken.name());
+            final String golangTypeForNumInGroup = golangTypeName(tokens.get(i + 3).encoding().primitiveType());
+
+
+            ++i;
+            final int groupHeaderTokenCount = tokens.get(i).componentTokenCount();
+            i += groupHeaderTokenCount;
+
+            final List<Token> fields = new ArrayList<>();
+            i = collectFields(tokens, i, fields);
+            sb.append(generateFields(groupName, fields, prefix));
+
+            final List<Token> groups = new ArrayList<>();
+            i = collectGroups(tokens, i, groups);
+            generateGroups(sb, groups, groupName);
+
+            final List<Token> varData = new ArrayList<>();
+            i = collectVarData(tokens, i, varData);
+            generateVarData(sb, formatTypeName(groupName), varData, prefix);
+        }
+    }
+
+    private void generateVarData(
+        final StringBuilder sb,
+        final String typeName,
+        final List<Token> tokens,
+        final String prefix)
+    {
+        for (int i = 0, size = tokens.size(); i < size;)
+        {
+            final Token token = tokens.get(i);
+            if (token.signal() != Signal.BEGIN_VAR_DATA)
+            {
+                throw new IllegalStateException("tokens must begin with BEGIN_VAR_DATA: token=" + token);
+            }
+
+            final String propertyName = toUpperFirstChar(token.name());
+            final String characterEncoding = tokens.get(i + 3).encoding().characterEncoding();
+            final Token lengthToken = tokens.get(i + 2);
+            final int lengthOfLengthField = lengthToken.encodedLength();
+
+            generateFieldMetaAttributeMethod(typeName, sb, token, prefix);
+
+            generateVarDataDescriptors(
+                sb, token, typeName, propertyName, characterEncoding, lengthOfLengthField);
+
+            i += token.componentTokenCount();
+        }
+    }
+
+    private void generateVarDataDescriptors(
+        final StringBuilder sb,
+        final Token token,
+        final String typeName,
+        final String propertyName,
+        final String characterEncoding,
+        final Integer lengthOfLengthField)
+    {
+        final char varName = Character.toLowerCase(typeName.charAt(0));
+
+        sb.append(String.format(
+            "\nfunc (%1$s %2$s) %3$sCharacterEncoding() string {\n" +
+             "\treturn \"%4$s\"\n" +
+            "}\n" +
+            "\nfunc (%1$s %2$s) %3$sSinceVersion() uint16 {\n" +
+             "\treturn %5$s\n" +
+            "}\n" +
+            "\nfunc (%1$s %2$s) %3$sInActingVersion(actingVersion uint16) bool {\n" +
+            "\treturn actingVersion >= %1$s.%3$sSinceVersion()\n" +
+            "}\n" +
+            "\nfunc (%1$s %2$s) %3$sId() uint16 {\n" +
+            "\treturn %6$s\n" +
+            "}\n" +
+            "\nfunc (%1$s %2$s) %3$sHeaderLength() uint64 {\n" +
+            "\treturn %7$s\n" +
+            "}\n",
+            varName,
+            typeName,
+            propertyName,
+            characterEncoding,
+            (long)token.version(),
+            token.id(),
+            lengthOfLengthField));
+    }
+
+    private void generateChoiceSet(final List<Token> tokens) throws IOException
+    {
+        final Token token = tokens.get(0);
+        final String choiceName = formatTypeName(token.name());
+        final StringBuilder sb = new StringBuilder();
+
+        try (Writer out = outputManager.createOutput(choiceName))
+        {
+            // Initialize the imports
+            imports = new TreeSet<String>();
+            imports.add("io");
+            imports.add("encoding/binary");
+
+            sb.append(generateChoiceDecls(
+                choiceName,
+                tokens.subList(1, tokens.size() - 1),
+                token));
+
+            generateChoiceEncodeDecode(sb, choiceName, token);
+
+            // EncodedLength
+            sb.append(String.format(
+                          "\nfunc (%1$s %2$s) EncodedLength() int64 {\n" +
+                          "\treturn %3$s\n" +
+                          "}\n",
+                          choiceName,
+                          choiceName,
+                          token.encodedLength()));
+
+            out.append(generateFileHeader(ir.namespaces(), choiceName));
+            out.append(sb);
+        }
+    }
+
+    private void generateEnum(final List<Token> tokens) throws IOException
+    {
+        final Token enumToken = tokens.get(0);
+        final String enumName = formatTypeName(tokens.get(0).name());
+        final char varName = Character.toLowerCase(enumName.charAt(0));
+
+        final StringBuilder sb = new StringBuilder();
+
+        try (Writer out = outputManager.createOutput(enumName))
+        {
+            // Initialize the imports
+            imports = new TreeSet<String>();
+            imports.add("io");
+            imports.add("encoding/binary");
+
+            sb.append(generateEnumDecls(
+                enumName,
+                golangTypeName(tokens.get(0).encoding().primitiveType()),
+                tokens.subList(1, tokens.size() - 1),
+                enumToken));
+
+            generateEnumEncodeDecode(sb, enumName, enumToken);
+
+            // EncodedLength
+            sb.append(String.format(
+                "\nfunc (%1$s %2$sEnum) EncodedLength() int64 {\n" +
+                "\treturn %3$s\n" +
+                "}\n",
+                varName,
+                enumName,
+                enumToken.encodedLength()));
+
+            // All of our enumeration values can have a sinceVersion
+            for (final Token token : tokens.subList(1, tokens.size() - 1))
+            {
+                sb.append(String.format(
+                    "func (%1$s %2$sEnum) %3$sSinceVersion() uint16 {\n" +
+                    "\treturn %4$d\n" +
+                    "}\n" +
+                    "func (%1$s %2$sEnum) %3$sInActingVersion(actingVersion uint16) bool {\n" +
+                    "\treturn actingVersion >= %1$s.%3$sSinceVersion()\n" +
+                    "}\n",
+                    varName,
+                    enumName,
+                    token.name(),
+                    token.version()));
+
+            }
+
+            out.append(generateFileHeader(ir.namespaces(), enumName));
+            out.append(sb);
+        }
+    }
+
+    private void generateComposite(
+        final List<Token> tokens,
+        final String namePrefix) throws IOException
+    {
+        final String compositeName = namePrefix + formatTypeName(tokens.get(0).name());
+        final StringBuilder sb = new StringBuilder();
+
+        try (Writer out = outputManager.createOutput(compositeName))
+        {
+            // Initialize the imports
+            imports = new TreeSet<String>();
+            imports.add("io");
+            imports.add("encoding/binary");
+
+            generateTypeDeclaration(sb, compositeName);
+            sb.append(generateTypeBodyComposite(compositeName, tokens.subList(1, tokens.size() - 1)));
+
+            generateEncodeDecode(sb, compositeName, tokens.subList(1, tokens.size() - 1));
+            generateEncodedLength(sb, compositeName, tokens.get(0).encodedLength());
+
+            sb.append(generateCompositePropertyElements(compositeName, tokens.subList(1, tokens.size() - 1)));
+
+            out.append(generateFileHeader(ir.namespaces(), compositeName));
+            out.append(sb);
+        }
+    }
+
+    private CharSequence generateEnumDecls(
+        final String enumName,
+        final String golangType,
+        final List<Token> tokens,
+        final Token encodingToken)
+    {
+        final StringBuilder sb = new StringBuilder();
+        final Encoding encoding = encodingToken.encoding();
+
+
+        // gofmt lines up the types and we don't want it to have to rewrite
+        // our generated files. To line things up we need to know the longest
+        // string length and then fill with whitespace
+        final String nullValue = "NullValue";
+        int longest = nullValue.length();
+        for (final Token token : tokens)
+        {
+            longest = Math.max(longest, token.name().length());
+        }
+
+        // Enums are modelled as a struct and we export an instance so
+        // you can reference known values as expected.
+        sb.append(String.format(
+             "type %1$sEnum %2$s\n" +
+             "type %1$sValues struct {\n",
+                      enumName, golangType));
+
+        for (final Token token : tokens)
+        {
+            sb.append(String.format(
+                "\t%1$s%2$s%3$sEnum\n",
+                token.name(),
+                String.format(String.format("%%%ds", longest - token.name().length() + 1), " "),
+                enumName));
+        }
+
+        // Add the NullValue
+        sb.append(String.format(
+            "\t%1$s%2$s%3$sEnum\n" +
+            "}\n",
+            nullValue,
+            String.format(String.format("%%%ds", longest - nullValue.length() + 1), " "),
+            enumName));
+
+        // And now the Enum Values expressed as a variable
+        sb.append(String.format(
+             "\nvar %1$s = %1$sValues{",
+             enumName));
+        for (final Token token : tokens)
+        {
+            sb.append(
+                generateLiteral(token.encoding().primitiveType(), token.encoding().constValue().toString()) +
+                ", ");
+        }
+        // Add the NullValue and close
+        sb.append(encodingToken.encoding().applicableNullValue().toString() +
+            "}\n");
+
+        return sb;
+    }
+
+    private CharSequence generateChoiceDecls(
+        final String choiceName,
+        final List<Token> tokens,
+        final Token encodingToken)
+    {
+        final StringBuilder sb = new StringBuilder();
+        final Encoding encoding = encodingToken.encoding();
+
+        // gofmt lines up the types and we don't want it to have to rewrite
+        // our generated files. To line things up we need to know the longest
+        // string length and then fill with whitespace
+        int longest = 0;
+        for (final Token token : tokens)
+        {
+            longest = Math.max(longest, token.name().length());
+        }
+
+        // A ChoiceSet is modelled as an array of bool of size
+        // encodedLength in bits (akin to bits in a bitfield).
+        // Choice values are modelled as a struct and we export an
+        // instance so you can reference known values by name.
+        sb.append(String.format(
+            "type %1$s [%2$d]bool\n" +
+            "type %1$sChoiceValue uint8\n" +
+            "type %1$sChoiceValues struct {\n",
+            choiceName, encodingToken.encodedLength() * 8));
+
+        for (final Token token : tokens)
+        {
+            sb.append(String.format(
+                "\t%1$s%2$s%3$sChoiceValue\n",
+                toUpperFirstChar(token.name()),
+                String.format(String.format("%%%ds", longest - token.name().length() + 1), " "),
+                toUpperFirstChar(encodingToken.name()),
+                generateLiteral(token.encoding().primitiveType(), token.encoding().constValue().toString())));
+        }
+
+        sb.append("}\n");
+
+        // And now the Values expressed as a variable
+        sb.append(String.format(
+             "\nvar %1$sChoice = %1$sChoiceValues{",
+             choiceName));
+
+        String comma = "";
+        for (final Token token : tokens)
+        {
+            sb.append(comma +
+                      generateLiteral(token.encoding().primitiveType(), token.encoding().constValue().toString()));
+            comma = ", ";
+        }
+        sb.append("}\n");
+
+        return sb;
+    }
+    private static CharSequence generateFileHeader(
+        final CharSequence[] namespaces,
+        final String typeName)
+    {
+        final StringBuilder sb = new StringBuilder();
+
+        sb.append("// Generated SBE (Simple Binary Encoding) message codec\n\n");
+        sb.append(String.format(
+            "package %1$s\n" +
+            "\n" +
+            "import (\n",
+            String.join("_", namespaces).toLowerCase().replace('.', '_').replace(' ', '_')));
+
+        for (String s : imports)
+        {
+            sb.append("\t\"" + s + "\"\n");
+        }
+
+        sb.append(")\n\n");
+        return sb;
+    }
+
+    private static void generateTypeDeclaration(
+        final StringBuilder sb,
+        final String typeName)
+    {
+        sb.append(String.format("type %s struct {\n", typeName));
+    }
+
+    private void generateTypeBody(
+        final StringBuilder sb,
+        final String typeName,
+        final List<Token> tokens)
+    {
+        // gofmt lines up the types and we don't want it to have to rewrite
+        // our generated files. To line things up we need to know the longest
+        // string length and then fill with whitespace
+        int longest = 0;
+        for (int i = 0; i < tokens.size(); i++)
+        {
+            final Token token = tokens.get(i);
+            final String propertyName = formatPropertyName(token.name());
+
+            switch (token.signal())
+            {
+                case BEGIN_GROUP:
+                    longest = Math.max(longest, propertyName.length());
+                    i += token.componentTokenCount() - 1;
+                    break;
+                case BEGIN_FIELD:
+                case BEGIN_VAR_DATA:
+                    longest = Math.max(longest, propertyName.length());
+                    break;
+            }
+        }
+
+        final StringBuilder nested = new StringBuilder(); // For nested groups
+        for (int i = 0; i < tokens.size(); i++)
+        {
+            final Token signalToken = tokens.get(i);
+            final String propertyName = formatPropertyName(signalToken.name());
+
+            switch (signalToken.signal())
+            {
+                case BEGIN_FIELD:
+                    if (tokens.size() > i + 1)
+                    {
+                        final Token encodingToken = tokens.get(i + 1);
+                        final int arrayLength = encodingToken.arrayLength();
+                        switch (encodingToken.signal())
+                        {
+                            case BEGIN_ENUM:
+                                sb.append(
+                                    "\t" +
+                                    propertyName +
+                                    String.format(String.format("%%%ds", longest - propertyName.length() + 1), " ") +
+                                    ((arrayLength > 1) ? ("[" + arrayLength + "]") : "") +
+                                    encodingToken.name() +
+                                    "Enum\n");
+                                break;
+
+                            case BEGIN_SET:
+                                sb.append(
+                                    "\t" +
+                                    propertyName +
+                                    String.format(String.format("%%%ds", longest - propertyName.length() + 1), " ") +
+                                    ((arrayLength > 1) ? ("[" + arrayLength + "]") : "") +
+                                    encodingToken.name() +
+                                    "\n");
+                                break;
+
+                            default:
+                                // If the type is primitive then use the golang naming for it
+                                String golangType;
+                                golangType = golangTypeName(encodingToken.encoding().primitiveType());
+                                if (golangType == null)
+                                {
+                                    golangType = toUpperFirstChar(encodingToken.name());
+                                }
+                                // if a primitiveType="char" and presence="constant" then this is actually a character array
+                                String arrayspec = "";
+                                if (arrayLength > 1)
+                                {
+                                    arrayspec = "[" + arrayLength + "]";
+                                }
+                                if (encodingToken.isConstantEncoding() && encodingToken.encoding().primitiveType() == CHAR)
+                                {
+                                    arrayspec = "[" + encodingToken.encoding().constValue().size() + "]"; // can be 1
+                                }
+                                sb.append(
+                                    "\t" + propertyName +
+                                    String.format(String.format("%%%ds", longest - propertyName.length() + 1), " ") +
+                                    arrayspec +
+                                    golangType + "\n");
+                                break;
+                        }
+                        i++;
+                    }
+                    break;
+
+                case BEGIN_GROUP:
+                    sb.append(String.format(
+                        "\t%1$s%2$s[]%3$s%1$s\n",
+                        toUpperFirstChar(signalToken.name()),
+                        String.format(String.format("%%%ds", longest - propertyName.length() + 1), " "),
+                        typeName));
+                    generateTypeDeclaration(
+                        nested,
+                        typeName + toUpperFirstChar(signalToken.name()));
+                    generateTypeBody(
+                        nested,
+                        typeName + toUpperFirstChar(signalToken.name()),
+                        tokens.subList(i + 1, tokens.size() - 1));
+                    i = i + signalToken.componentTokenCount() - 1;
+                    break;
+
+                case END_GROUP:
+                    // Close the group and unwind
+                    sb.append("}\n");
+                    sb.append(nested);
+                    return;
+
+                case BEGIN_VAR_DATA:
+                    sb.append(String.format(
+                        "\t%1$s%2$s[]%3$s\n",
+                        toUpperFirstChar(signalToken.name()),
+                        String.format(String.format("%%%ds", longest - propertyName.length() + 1), " "),
+
+                        golangTypeName(tokens.get(i + 3).encoding().primitiveType())));
+                    break;
+
+                default:
+                    break;
+            }
+        }
+        sb.append("}\n");
+        sb.append(nested);
+    }
+
+
+    private CharSequence generateCompositePropertyElements(
+        final String containingTypeName, final List<Token> tokens)
+    {
+        final StringBuilder sb = new StringBuilder();
+
+        for (int i = 0; i < tokens.size();)
+        {
+            final Token token = tokens.get(i);
+            final String propertyName = formatPropertyName(token.name());
+
+            // Write {Min,Max,Null}Value
+            switch (token.signal())
+            {
+                case ENCODING:
+                    sb.append(generateMinMaxNull(containingTypeName, propertyName, token));
+                    break;
+
+                default:
+                    break;
+            }
+
+            // SinceVersion/ActingVersion
+            switch (token.signal())
+            {
+                case ENCODING:
+                case BEGIN_ENUM:
+                case BEGIN_SET:
+                case BEGIN_COMPOSITE:
+                    sb.append(String.format(
+                        "\nfunc (%1$s %2$s) %3$sSinceVersion() uint16 {\n" +
+                        "\treturn %4$s\n" +
+                        "}\n" +
+                        "\nfunc (%1$s %2$s) %3$sInActingVersion(actingVersion uint16) bool {\n" +
+                        "\treturn actingVersion >= %1$s.%3$sSinceVersion()\n" +
+                        "}\n",
+                        Character.toLowerCase(containingTypeName.charAt(0)),
+                        containingTypeName,
+                        propertyName,
+                        (long)token.version()));
+                    break;
+                default:
+                    break;
+            }
+            i += tokens.get(i).componentTokenCount();
+        }
+
+        return sb;
+    }
+
+    private CharSequence generateMinMaxNull(
+        final String typeName,
+        final String propertyName,
+        final Token token)
+    {
+        final StringBuilder sb = new StringBuilder();
+
+        final Encoding encoding = token.encoding();
+        final PrimitiveType primitiveType = encoding.primitiveType();
+        final String golangTypeName = golangTypeName(primitiveType);
+        final CharSequence nullValueString = generateNullValueLiteral(primitiveType, encoding);
+        final CharSequence maxValueString = generateMaxValueLiteral(primitiveType, encoding);
+        final CharSequence minValueString = generateMinValueLiteral(primitiveType, encoding);
+
+        // MinValue
+        sb.append(String.format(
+            "\nfunc (%1$s %2$s) %3$sMinValue() %4$s {\n" +
+            "\treturn %5$s\n" +
+            "}\n",
+            Character.toLowerCase(typeName.charAt(0)),
+            typeName,
+            propertyName,
+            golangTypeName,
+            minValueString));
+
+        // MaxValue
+        sb.append(String.format(
+            "\nfunc (%1$s %2$s) %3$sMaxValue() %4$s {\n" +
+            "\treturn %5$s\n" +
+            "}\n",
+            Character.toLowerCase(typeName.charAt(0)),
+            typeName,
+            propertyName,
+            golangTypeName,
+            maxValueString));
+
+        // NullValue
+        sb.append(String.format(
+            "\nfunc (%1$s %2$s) %3$sNullValue() %4$s {\n" +
+            "\treturn %5$s\n" +
+            "}\n",
+            Character.toLowerCase(typeName.charAt(0)),
+            typeName,
+            propertyName,
+            golangTypeName,
+            nullValueString));
+
+        return sb;
+    }
+
+    private CharSequence generateTypeBodyComposite(
+        final String typeName,
+        final List<Token> tokens) throws IOException
+    {
+        final StringBuilder sb = new StringBuilder();
+
+
+        // gofmt lines up the types and we don't want it to have to rewrite
+        // our generated files. To line things up we need to know the longest
+        // string length and then fill with whitespace
+        int longest = 0;
+        for (int i = 0; i < tokens.size(); i++)
+        {
+            final Token token = tokens.get(i);
+            final String propertyName = formatPropertyName(token.name());
+
+            switch (token.signal())
+            {
+                case BEGIN_GROUP:
+                    longest = Math.max(longest, propertyName.length());
+                    i += token.componentTokenCount() - 1;
+                    break;
+                default:
+                    longest = Math.max(longest, propertyName.length());
+                    break;
+            }
+        }
+
+        for (int i = 0; i < tokens.size(); i++)
+        {
+            final Token token = tokens.get(i);
+            final String propertyName = formatPropertyName(token.name());
+            int arrayLength = token.arrayLength();
+
+            switch (token.signal())
+            {
+                case ENCODING:
+                    // if a primitiveType="char" and presence="constant" then this is actually a character array
+                    if (token.isConstantEncoding() && token.encoding().primitiveType() == CHAR)
+                    {
+                        arrayLength = token.encoding().constValue().size(); // can be 1
+                        sb.append("\t" + propertyName +
+                            String.format(String.format("%%%ds", longest - propertyName.length() + 1), " ") +
+                            "[" + arrayLength + "]" +
+                            golangTypeName(token.encoding().primitiveType()) + "\n");
+                    }
+                    else
+                    {
+                        sb.append("\t" + propertyName +
+                            String.format(String.format("%%%ds", longest - propertyName.length() + 1), " ") +
+                            ((arrayLength > 1) ? ("[" + arrayLength + "]") : "") +
+                            golangTypeName(token.encoding().primitiveType()) + "\n");
+                    }
+                    break;
+
+                case BEGIN_ENUM:
+                    sb.append("\t" + propertyName +
+                            String.format(String.format("%%%ds", longest - propertyName.length() + 1), " ") +
+                            ((arrayLength > 1) ? ("[" + arrayLength + "]") : "") +
+                            propertyName + "Enum\n");
+                    break;
+
+                case BEGIN_SET:
+                    sb.append("\t" + propertyName +
+                            String.format(String.format("%%%ds", longest - propertyName.length() + 1), " ") +
+                            ((arrayLength > 1) ? ("[" + arrayLength + "]") : "") +
+                            propertyName + "\n");
+                    break;
+
+                case BEGIN_COMPOSITE:
+                    // recurse
+                    generateComposite(tokens.subList(i, tokens.size()), typeName);
+                    i = i + token.componentTokenCount() - 2;
+
+                    sb.append("\t" + propertyName +
+                            String.format(String.format("%%%ds", longest - propertyName.length() + 1), " ") +
+                            ((arrayLength > 1) ? ("[" + arrayLength + "]") : "") +
+                            typeName + propertyName + "\n");
+                    break;
+            }
+        }
+        sb.append("}\n");
+        return sb;
+    }
+
+    private CharSequence generateEncodedLength(final StringBuilder sb, final String typeName, final int size)
+    {
+        sb.append(String.format(
+            "\nfunc (%1$s %2$s) EncodedLength() int64 {\n" +
+            "\treturn %3$s\n" +
+            "}\n",
+            Character.toLowerCase(typeName.charAt(0)),
+            typeName,
+            size));
+
+        return sb;
+    }
+
+    private CharSequence generateMessageCode(final String typeName, final List<Token> tokens)
+    {
+        final Token token = tokens.get(0);
+        final String semanticType = token.encoding().semanticType() == null ? "" : token.encoding().semanticType();
+        final String blockLengthType = golangTypeName(ir.headerStructure().blockLengthType());
+        final String templateIdType = golangTypeName(ir.headerStructure().templateIdType());
+        final String schemaIdType = golangTypeName(ir.headerStructure().schemaIdType());
+        final String schemaVersionType = golangTypeName(ir.headerStructure().schemaVersionType());
+        final StringBuilder sb = new StringBuilder();
+
+
+        generateEncodeDecode(sb, typeName, tokens);
+
+        sb.append(String.format(
+            "\nfunc (%1$s %2$s) SbeBlockLength() (blockLength %3$s) {\n" +
+            "\treturn %4$s\n" +
+            "}\n" +
+            "\nfunc (%1$s %2$s) SbeTemplateId() (templateId %5$s) {\n" +
+            "\treturn %6$s\n" +
+            "}\n" +
+            "\nfunc (%1$s %2$s) SbeSchemaId() (schemaId %7$s) {\n" +
+            "\treturn %8$s\n" +
+            "}\n" +
+            "\nfunc (%1$s %2$s) SbeSchemaVersion() (schemaVersion %9$s) {\n" +
+            "\treturn %10$s\n" +
+            "}\n" +
+            "\nfunc (%1$s %2$s) SbeSemanticType() (semanticType []byte) {\n" +
+            "\treturn []byte(\"%11$s\")\n" +
+            "}\n",
+            Character.toLowerCase(typeName.charAt(0)),
+            typeName,
+            blockLengthType,
+            generateLiteral(ir.headerStructure().blockLengthType(), Integer.toString(token.encodedLength())),
+            templateIdType,
+            generateLiteral(ir.headerStructure().templateIdType(), Integer.toString(token.id())),
+            schemaIdType,
+            generateLiteral(ir.headerStructure().schemaIdType(), Integer.toString(ir.id())),
+            schemaVersionType,
+            generateLiteral(ir.headerStructure().schemaVersionType(), Integer.toString(token.version())),
+            semanticType));
+
+        return sb;
+    }
+
+    private CharSequence generateFields(final String containingTypeName, final List<Token> tokens, final String prefix)
+    {
+        final StringBuilder sb = new StringBuilder();
+
+        for (int i = 0, size = tokens.size(); i < size; i++)
+        {
+            final Token signalToken = tokens.get(i);
+            if (signalToken.signal() == Signal.BEGIN_FIELD)
+            {
+                final Token encodingToken = tokens.get(i + 1);
+                final String propertyName = formatPropertyName(signalToken.name());
+
+                sb.append(String.format(
+                    "\nfunc (%1$s %2$s) %3$sId() uint16 {\n" +
+                    "\treturn %4$s\n" +
+                    "}\n" +
+                    "\nfunc (%1$s %2$s) %3$sSinceVersion() uint16 {\n" +
+                    "\treturn %5$s\n" +
+                    "}\n" +
+                    "\nfunc (%1$s %2$s) %3$sInActingVersion(actingVersion uint16) bool {\n" +
+                    "\treturn actingVersion >= %1$s.%3$sSinceVersion()\n" +
+                    "}\n",
+                    Character.toLowerCase(containingTypeName.charAt(0)),
+                    containingTypeName,
+                    propertyName,
+                    signalToken.id(),
+                    (long)signalToken.version()));
+
+                generateFieldMetaAttributeMethod(containingTypeName, sb, signalToken, prefix);
+
+                switch (encodingToken.signal())
+                {
+                    case ENCODING:
+                        sb.append(generateMinMaxNull(containingTypeName, propertyName, encodingToken));
+                        break;
+
+                    case BEGIN_ENUM:
+                        break;
+
+                    case BEGIN_SET:
+                        break;
+
+                    case BEGIN_COMPOSITE:
+                        break;
+
+                    default:
+                        break;
+                }
+            }
+        }
+
+        return sb;
+    }
+
+    private static void generateFieldMetaAttributeMethod(
+        final String containingTypeName,
+        final StringBuilder sb,
+        final Token token,
+        final String prefix)
+    {
+        final Encoding encoding = token.encoding();
+        final String epoch = encoding.epoch() == null ? "" : encoding.epoch();
+        final String timeUnit = encoding.timeUnit() == null ? "" : encoding.timeUnit();
+        final String semanticType = encoding.semanticType() == null ? "" : encoding.semanticType();
+        sb.append(String.format(
+            "\nfunc (%1$s %2$s) %3$sMetaAttribute(meta int) string {\n" +
+            "\tswitch meta {\n" +
+            "\tcase 1:\n" +
+            "\t\treturn \"%4$s\"\n" +
+            "\tcase 2:\n" +
+            "\t\treturn \"%5$s\"\n" +
+            "\tcase 3:\n" +
+            "\t\treturn \"%6$s\"\n" +
+            "\t}\n" +
+            "\treturn \"\"\n" +
+            "}\n",
+            Character.toLowerCase(containingTypeName.charAt(0)),
+            containingTypeName,
+            toUpperFirstChar(token.name()),
+            epoch,
+            timeUnit,
+            semanticType));
+    }
+
+    private CharSequence generateMinValueLiteral(final PrimitiveType primitiveType, final Encoding encoding)
+    {
+        if (null == encoding.maxValue())
+        {
+            switch (primitiveType)
+            {
+                case CHAR:
+                    return "byte(32)";
+                case INT8:
+                    imports.add("math");
+                    return "math.MinInt8 + 1";
+                case INT16:
+                    imports.add("math");
+                    return "math.MinInt16 + 1";
+                case INT32:
+                    imports.add("math");
+                    return "math.MinInt32 + 1";
+                case INT64:
+                    imports.add("math");
+                    return "math.MinInt64 + 1";
+                case UINT8:
+                case UINT16:
+                case UINT32:
+                case UINT64:
+                    return "0";
+                case FLOAT:
+                    imports.add("math");
+                    return "-math.MaxFloat32";
+                case DOUBLE:
+                    imports.add("math");
+                    return "-math.MaxFloat64";
+
+            }
+        }
+
+        return generateLiteral(primitiveType, encoding.applicableMinValue().toString());
+    }
+
+    private CharSequence generateMaxValueLiteral(final PrimitiveType primitiveType, final Encoding encoding)
+    {
+        if (null == encoding.maxValue())
+        {
+            switch (primitiveType)
+            {
+                case CHAR:
+                    return "byte(126)";
+                case INT8:
+                    imports.add("math");
+                    return "math.MaxInt8";
+                case INT16:
+                    imports.add("math");
+                    return "math.MaxInt16";
+                case INT32:
+                    imports.add("math");
+                    return "math.MaxInt32";
+                case INT64:
+                    imports.add("math");
+                    return "math.MaxInt64";
+                case UINT8:
+                    imports.add("math");
+                    return "math.MaxUint8 - 1";
+                case UINT16:
+                    imports.add("math");
+                    return "math.MaxUint16 - 1";
+                case UINT32:
+                    imports.add("math");
+                    return "math.MaxUint32 - 1";
+                case UINT64:
+                    imports.add("math");
+                    return "math.MaxUint64 - 1";
+                case FLOAT:
+                    imports.add("math");
+                    return "math.MaxFloat32";
+                case DOUBLE:
+                    imports.add("math");
+                    return "math.MaxFloat64";
+            }
+        }
+
+        return generateLiteral(primitiveType, encoding.applicableMaxValue().toString());
+    }
+
+    private CharSequence generateNullValueLiteral(final PrimitiveType primitiveType, final Encoding encoding)
+    {
+        if (null == encoding.nullValue())
+        {
+            switch (primitiveType)
+            {
+                case INT8:
+                    imports.add("math");
+                    return "math.MinInt8";
+                case INT16:
+                    imports.add("math");
+                    return "math.MinInt16";
+                case INT32:
+                    imports.add("math");
+                    return "math.MinInt32";
+                case INT64:
+                    imports.add("math");
+                    return "math.MinInt64";
+                case UINT8:
+                    imports.add("math");
+                    return "math.MaxUint8";
+                case UINT16:
+                    imports.add("math");
+                    return "math.MaxUint16";
+                case UINT32:
+                    imports.add("math");
+                    return "math.MaxUint32";
+                case UINT64:
+                    imports.add("math");
+                    return "math.MaxUint64";
+            }
+        }
+
+        return generateLiteral(primitiveType, encoding.applicableNullValue().toString());
+    }
+
+    private CharSequence generateLiteral(final PrimitiveType type, final String value)
+    {
+        String literal = "";
+
+        final String castType = golangTypeName(type);
+        switch (type)
+        {
+            case CHAR:
+            case UINT8:
+            case UINT16:
+            case INT8:
+            case INT16:
+                literal = value;
+                break;
+
+            case UINT32:
+            case INT32:
+                literal = value;
+                break;
+            case INT64:
+            case UINT64:
+                literal = castType + "(" + value + ")";
+                break;
+
+            case FLOAT:
+                literal = "float32(" + (value.endsWith("NaN") ? "math.NaN()" : value) + ")";
+                break;
+
+            case DOUBLE:
+                literal = value.endsWith("NaN") ? "math.NaN()" : value;
+                break;
+        }
+
+        return literal;
+    }
+}

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangOutputManager.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangOutputManager.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016 MarketFactory, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.sbe.generation.golang;
+
+import org.agrona.generation.OutputManager;
+import org.agrona.Verify;
+
+import java.io.*;
+
+import static java.io.File.separatorChar;
+
+/**
+ * {@link OutputManager} for managing the creation of golang source files as the target of code generation.
+ * The character encoding for the {@link java.io.Writer} is UTF-8.
+ */
+public class GolangOutputManager implements OutputManager
+{
+    private final File outputDir;
+
+    /**
+     * Create a new {@link OutputManager} for generating golang source files into a given package.
+     *
+     * @param baseDirectoryName for the generated source code.
+     * @param namespaceName for the generated source code relative to the baseDirectoryName.
+     * @throws IOException if an error occurs during output
+     */
+    public GolangOutputManager(final String baseDirectoryName, final String namespaceName)
+        throws IOException
+    {
+        Verify.notNull(baseDirectoryName, "baseDirectoryName");
+        Verify.notNull(namespaceName, "applicableNamespace");
+
+        final String dirName =
+            (baseDirectoryName.endsWith("" + separatorChar) ? baseDirectoryName : baseDirectoryName + separatorChar) +
+                namespaceName.replace('.', '_');
+
+        outputDir = new File(dirName);
+        if (!outputDir.exists() && !outputDir.mkdirs())
+        {
+            throw new IllegalStateException("Unable to create directory: " + dirName);
+        }
+    }
+
+    /**
+     * Create a new output which will be a golang source file in the given package.
+     *
+     * The {@link java.io.Writer} should be closed once the caller has finished with it. The Writer is
+     * buffer for efficient IO operations.
+     *
+     * @param name the name of the C++ class.
+     * @return a {@link java.io.Writer} to which the source code should be written.
+     */
+    public Writer createOutput(final String name) throws IOException
+    {
+        final File targetFile = new File(outputDir, name + ".go");
+        return new BufferedWriter(new OutputStreamWriter(new FileOutputStream(targetFile), "UTF-8"));
+    }
+}

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangUtil.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangUtil.java
@@ -1,0 +1,149 @@
+/*
+ * Copyright (C) 2016 MarketFactory, Inc
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.sbe.generation.golang;
+
+import uk.co.real_logic.sbe.PrimitiveType;
+import uk.co.real_logic.sbe.SbeTool;
+import uk.co.real_logic.sbe.util.ValidationUtil;
+
+import java.nio.ByteOrder;
+import java.util.EnumMap;
+import java.util.Map;
+
+/**
+ * Utilities for mapping between IR and the Golang language.
+ */
+public class GolangUtil
+{
+    private static Map<PrimitiveType, String> typeNameByPrimitiveTypeMap = new EnumMap<>(PrimitiveType.class);
+
+    static
+    {
+        typeNameByPrimitiveTypeMap.put(PrimitiveType.CHAR, "byte");
+        typeNameByPrimitiveTypeMap.put(PrimitiveType.INT8, "int8");
+        typeNameByPrimitiveTypeMap.put(PrimitiveType.INT16, "int16");
+        typeNameByPrimitiveTypeMap.put(PrimitiveType.INT32, "int32");
+        typeNameByPrimitiveTypeMap.put(PrimitiveType.INT64, "int64");
+        typeNameByPrimitiveTypeMap.put(PrimitiveType.UINT8, "uint8");
+        typeNameByPrimitiveTypeMap.put(PrimitiveType.UINT16, "uint16");
+        typeNameByPrimitiveTypeMap.put(PrimitiveType.UINT32, "uint32");
+        typeNameByPrimitiveTypeMap.put(PrimitiveType.UINT64, "uint64");
+        typeNameByPrimitiveTypeMap.put(PrimitiveType.FLOAT, "float32");
+        typeNameByPrimitiveTypeMap.put(PrimitiveType.DOUBLE, "float64");
+    }
+
+
+    /* FIXME: Share across languages */
+    /**
+     * Map the name of a {@link uk.co.real_logic.sbe.PrimitiveType} to a Golang primitive type name.
+     *
+     * @param primitiveType to map.
+     * @return the name of the Java primitive that most closely maps.
+     */
+    public static String golangTypeName(final PrimitiveType primitiveType)
+    {
+        return typeNameByPrimitiveTypeMap.get(primitiveType);
+    }
+
+    /**
+     * Uppercase the first character of a given String.
+     *
+     * @param str to have the first character upper cased.
+     * @return a new String with the first character in uppercase.
+     */
+    public static String toUpperFirstChar(final String str)
+    {
+        return Character.toUpperCase(str.charAt(0)) + str.substring(1);
+    }
+
+    /**
+     * Lowercase the first character of a given String.
+     *
+     * @param str to have the first character upper cased.
+     * @return a new String with the first character in uppercase.
+     */
+    public static String toLowerFirstChar(final String str)
+    {
+        return Character.toLowerCase(str.charAt(0)) + str.substring(1);
+    }
+
+    /**
+     * Format a String as a property name.
+     *
+     * @param value to be formatted.
+     * @return the string formatted as a property name.
+     */
+    public static String formatPropertyName(final String value)
+    {
+        String formattedValue = toUpperFirstChar(value);
+
+        if (ValidationUtil.isGolangKeyword(formattedValue))
+        {
+            final String keywordAppendToken = System.getProperty(SbeTool.KEYWORD_APPEND_TOKEN);
+            if (null == keywordAppendToken)
+            {
+                throw new IllegalStateException(
+                    "Invalid property name='" + formattedValue +
+                    "' please correct the schema or consider setting system property: " + SbeTool.KEYWORD_APPEND_TOKEN);
+            }
+
+            formattedValue += keywordAppendToken;
+        }
+
+        return formattedValue;
+    }
+
+    /**
+     * Format a String as a type name.
+     *
+     * @param value to be formatted.
+     * @return the string formatted as an exported type name.
+     */
+    public static String formatTypeName(final String value)
+    {
+        return toUpperFirstChar(value);
+    }
+
+    /**
+     * Return the Golang formatted byte order encoding string to use for a given byte order and primitiveType
+     *
+     * @param byteOrder of the {@link uk.co.real_logic.sbe.ir.Token}
+     * @param primitiveType of the {@link uk.co.real_logic.sbe.ir.Token}
+     * @return the string formatted as the byte ordering encoding
+     */
+    public static String formatByteOrderEncoding(final ByteOrder byteOrder, final PrimitiveType primitiveType)
+    {
+        switch (primitiveType.size())
+        {
+            case 2:
+                return "binary.Write(buf, order, obj)";
+
+            case 4:
+                return "binary.Write(buf, order, obj)";
+
+            case 8:
+                return "binary.Write(buf, order, obj)";
+
+            default:
+                return "";
+        }
+    }
+
+    public static String closingBraces(final int count)
+    {
+        return new String(new char[count]).replace("\0", "}\n");
+    }
+}

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/util/ValidationUtil.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/util/ValidationUtil.java
@@ -198,4 +198,97 @@ public class ValidationUtil
 
         return true;
     }
+
+    private static final Set<String> GOLANG_KEYWORDS = new HashSet<>(
+        Arrays.asList(new String[]
+        {
+            /* https://golang.org/ref/spec#Keywords */
+            "break",    "default",     "func",   "interface", "select",
+            "case",     "defer",       "go",     "map",       "struct",
+            "chan",     "else",        "goto",   "package",   "switch",
+            "const",    "fallthrough", "if",     "range",     "type",
+            "continue", "for",         "import", "return",    "var",
+
+            /* https://golang.org/ref/spec#Predeclared_identifiers */
+            /* types */
+            "bool", "byte",  "complex64", "complex128", "error",  "float32", "float64",
+            "int",  "int8",  "int16",     "int32",      "int64",  "rune",    "string",
+            "uint", "uint8", "uint16",    "uint32",     "uint64", "uintptr",
+            /* constants */
+            "true", "false", "iota",
+            /* zero value */
+            "nil",
+            /* functions */
+            "append", "cap", "close", "complex", "copy",    "delete", "imag", "len",
+            "make",   "new", "panic", "print",   "println", "real",   "recover"
+        }));
+
+    /**
+     * "Check" value for validity of usage as a golang identifier. From:
+     * https://golang.org/ref/spec#Identifiers
+     *
+     * identifier = letter { letter | unicode_digit }
+     * letter        = unicode_letter | "_" .
+     *
+     * unicode_letter and unicode_digit are defined in section 4.5 of the the unicode
+     * standard at http://www.unicode.org/versions/Unicode8.0.0/ and
+     * the Java Character and Digit functions are unicode friendly
+     *
+     * @param value to check
+     * @return true for validity as a golang name. false if not.
+     */
+    public static boolean isSbeGolangName(final String value)
+    {
+        if (possibleGolangKeyword(value))
+        {
+            if (isGolangKeyword(value))
+            {
+                return false;
+            }
+        }
+        else
+        {
+            return false;
+        }
+
+        return true;
+    }
+
+    public static boolean isGolangKeyword(final String token)
+    {
+        return GOLANG_KEYWORDS.contains(token);
+    }
+
+    private static boolean possibleGolangKeyword(final String value)
+    {
+        for (int i = 0, size = value.length(); i < size; i++)
+        {
+            final char c = value.charAt(i);
+
+            if (i == 0 && isSbeGolangIdentifierStart(c))
+            {
+                continue;
+            }
+
+            if (isSbeGolangIdentifierPart(c))
+            {
+                continue;
+            }
+
+            return false;
+        }
+
+        return true;
+    }
+
+    private static boolean isSbeGolangIdentifierStart(final char c)
+    {
+        return Character.isLetter(c) || c == '_';
+    }
+
+    private static boolean isSbeGolangIdentifierPart(final char c)
+    {
+        return Character.isLetterOrDigit(c) || c == '_';
+    }
+
 }

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/XmlSchemaParser.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/XmlSchemaParser.java
@@ -310,6 +310,11 @@ public class XmlSchemaParser
         {
             handleError(node, "name is not valid for Java: " + name);
         }
+
+        if (!ValidationUtil.isSbeGolangName(name))
+        {
+            handleError(node, "name is not valid for Golang: " + name);
+        }
     }
 
     private static void addTypeWithNameCheck(final Map<String, Type> typeByNameMap, final Type type, final Node node)

--- a/sbe-tool/src/test/cpp/BoundsCheckTest.cpp
+++ b/sbe-tool/src/test/cpp/BoundsCheckTest.cpp
@@ -34,7 +34,7 @@ using namespace code::generation::test;
 
 static char VEHICLE_CODE[] = { 'a', 'b', 'c', 'd', 'e', 'f' };
 static char MANUFACTURER_CODE[] = { '1', '2', '3' };
-static const char *MAKE = "Honda";
+static const char *BRAND = "Honda";
 static const char *MODEL = "Civic VTi";
 static const char *ACTIVATION_CODE = "deadbeef";
 
@@ -136,9 +136,9 @@ public:
         return m_car.encodedLength();
     }
 
-    virtual std::uint64_t encodeCarMakeModelAndActivationCode()
+    virtual std::uint64_t encodeCarBrandModelAndActivationCode()
     {
-        m_car.putMake(MAKE, static_cast<int>(strlen(MAKE)));
+        m_car.putBrand(BRAND, static_cast<int>(strlen(BRAND)));
         m_car.putModel(MODEL, static_cast<int>(strlen(MODEL)));
         m_car.putActivationCode(ACTIVATION_CODE, static_cast<int>(strlen(ACTIVATION_CODE)));
 
@@ -259,11 +259,11 @@ public:
         return m_carDecoder.encodedLength();
     }
 
-    virtual std::uint64_t decodeCarMakeModelAndActivationCode()
+    virtual std::uint64_t decodeCarBrandModelAndActivationCode()
     {
         char tmp[256];
 
-        EXPECT_EQ(m_carDecoder.getMake(tmp, sizeof(tmp)), 5u);
+        EXPECT_EQ(m_carDecoder.getBrand(tmp, sizeof(tmp)), 5u);
         EXPECT_EQ(std::string(tmp, 5), "Honda");
 
         EXPECT_EQ(m_carDecoder.getModel(tmp, sizeof(tmp)), 9u);
@@ -332,7 +332,7 @@ TEST_P(MessageBoundsCheckTest, shouldExceptionWhenBufferTooShortForEncodeOfMessa
         encodeCarRoot(buffer.get(), 0, length);
         encodeCarFuelFigures();
         encodeCarPerformanceFigures();
-        encodeCarMakeModelAndActivationCode();
+        encodeCarBrandModelAndActivationCode();
     }, std::runtime_error);
 }
 
@@ -345,7 +345,7 @@ TEST_P(MessageBoundsCheckTest, shouldExceptionWhenBufferTooShortForDecodeOfMessa
     encodeCarRoot(encodeBuffer, 0, sizeof(encodeBuffer));
     encodeCarFuelFigures();
     encodeCarPerformanceFigures();
-    encodeCarMakeModelAndActivationCode();
+    encodeCarBrandModelAndActivationCode();
 
     EXPECT_THROW(
     {
@@ -353,7 +353,7 @@ TEST_P(MessageBoundsCheckTest, shouldExceptionWhenBufferTooShortForDecodeOfMessa
         decodeCarRoot(buffer.get(), 0, length);
         decodeCarFuelFigures();
         decodeCarPerformanceFigures();
-        decodeCarMakeModelAndActivationCode();
+        decodeCarBrandModelAndActivationCode();
     }, std::runtime_error);
 }
 

--- a/sbe-tool/src/test/cpp/BoundsCheckTest.cpp
+++ b/sbe-tool/src/test/cpp/BoundsCheckTest.cpp
@@ -34,7 +34,7 @@ using namespace code::generation::test;
 
 static char VEHICLE_CODE[] = { 'a', 'b', 'c', 'd', 'e', 'f' };
 static char MANUFACTURER_CODE[] = { '1', '2', '3' };
-static const char *BRAND = "Honda";
+static const char *MANUFACTURER = "Honda";
 static const char *MODEL = "Civic VTi";
 static const char *ACTIVATION_CODE = "deadbeef";
 
@@ -136,9 +136,9 @@ public:
         return m_car.encodedLength();
     }
 
-    virtual std::uint64_t encodeCarBrandModelAndActivationCode()
+    virtual std::uint64_t encodeCarManufacturerModelAndActivationCode()
     {
-        m_car.putBrand(BRAND, static_cast<int>(strlen(BRAND)));
+        m_car.putManufacturer(MANUFACTURER, static_cast<int>(strlen(MANUFACTURER)));
         m_car.putModel(MODEL, static_cast<int>(strlen(MODEL)));
         m_car.putActivationCode(ACTIVATION_CODE, static_cast<int>(strlen(ACTIVATION_CODE)));
 
@@ -259,11 +259,11 @@ public:
         return m_carDecoder.encodedLength();
     }
 
-    virtual std::uint64_t decodeCarBrandModelAndActivationCode()
+    virtual std::uint64_t decodeCarManufacturerModelAndActivationCode()
     {
         char tmp[256];
 
-        EXPECT_EQ(m_carDecoder.getBrand(tmp, sizeof(tmp)), 5u);
+        EXPECT_EQ(m_carDecoder.getManufacturer(tmp, sizeof(tmp)), 5u);
         EXPECT_EQ(std::string(tmp, 5), "Honda");
 
         EXPECT_EQ(m_carDecoder.getModel(tmp, sizeof(tmp)), 9u);
@@ -332,7 +332,7 @@ TEST_P(MessageBoundsCheckTest, shouldExceptionWhenBufferTooShortForEncodeOfMessa
         encodeCarRoot(buffer.get(), 0, length);
         encodeCarFuelFigures();
         encodeCarPerformanceFigures();
-        encodeCarBrandModelAndActivationCode();
+        encodeCarManufacturerModelAndActivationCode();
     }, std::runtime_error);
 }
 
@@ -345,7 +345,7 @@ TEST_P(MessageBoundsCheckTest, shouldExceptionWhenBufferTooShortForDecodeOfMessa
     encodeCarRoot(encodeBuffer, 0, sizeof(encodeBuffer));
     encodeCarFuelFigures();
     encodeCarPerformanceFigures();
-    encodeCarBrandModelAndActivationCode();
+    encodeCarManufacturerModelAndActivationCode();
 
     EXPECT_THROW(
     {
@@ -353,7 +353,7 @@ TEST_P(MessageBoundsCheckTest, shouldExceptionWhenBufferTooShortForDecodeOfMessa
         decodeCarRoot(buffer.get(), 0, length);
         decodeCarFuelFigures();
         decodeCarPerformanceFigures();
-        decodeCarBrandModelAndActivationCode();
+        decodeCarManufacturerModelAndActivationCode();
     }, std::runtime_error);
 }
 

--- a/sbe-tool/src/test/cpp/CodeGenTest.cpp
+++ b/sbe-tool/src/test/cpp/CodeGenTest.cpp
@@ -39,7 +39,7 @@ static char MANUFACTURER_CODE[] = { '1', '2', '3' };
 static const char *FUEL_FIGURES_1_USAGE_DESCRIPTION = "Urban Cycle";
 static const char *FUEL_FIGURES_2_USAGE_DESCRIPTION = "Combined Cycle";
 static const char *FUEL_FIGURES_3_USAGE_DESCRIPTION = "Highway Cycle";
-static const char *MAKE = "Honda";
+static const char *BRAND = "Honda";
 static const char *MODEL = "Civic VTi";
 static const char *ACTIVATION_CODE = "deadbeef";
 
@@ -48,7 +48,7 @@ static const std::uint64_t MANUFACTURER_CODE_LENGTH = sizeof(MANUFACTURER_CODE);
 static const std::uint64_t FUEL_FIGURES_1_USAGE_DESCRIPTION_LENGTH = 11;
 static const std::uint64_t FUEL_FIGURES_2_USAGE_DESCRIPTION_LENGTH = 14;
 static const std::uint64_t FUEL_FIGURES_3_USAGE_DESCRIPTION_LENGTH = 13;
-static const std::uint64_t MAKE_LENGTH = 5;
+static const std::uint64_t BRAND_LENGTH = 5;
 static const std::uint64_t MODEL_LENGTH = 9;
 static const std::uint64_t ACTIVATION_CODE_LENGTH = 8;
 static const std::uint8_t PERFORMANCE_FIGURES_COUNT = 2;
@@ -155,7 +155,7 @@ public:
                 .next().mph(perf2bMph).seconds(perf2bSeconds)
                 .next().mph(perf2cMph).seconds(perf2cSeconds);
 
-        car.putMake(MAKE, static_cast<int>(strlen(MAKE)))
+        car.putBrand(BRAND, static_cast<int>(strlen(BRAND)))
             .putModel(MODEL, static_cast<int>(strlen(MODEL)))
             .putActivationCode(ACTIVATION_CODE, static_cast<int>(strlen(ACTIVATION_CODE)));
 
@@ -243,7 +243,7 @@ static const uint8_t fieldIdPerfOctaneRating = 14;
 static const uint8_t fieldIdPerfAcceleration = 15;
 static const uint8_t fieldIdPerfAccMph = 16;
 static const uint8_t fieldIdPerfAccSeconds = 17;
-static const uint8_t fieldIdMake = 18;
+static const uint8_t fieldIdBrand = 18;
 static const uint8_t fieldIdModel = 19;
 static const uint8_t fieldIdActivationCode = 20;
 
@@ -268,10 +268,10 @@ TEST_F(CodeGenTest, shouldReturnCorrectValuesForCarFieldIdsAndCharacterEncoding)
     EXPECT_EQ(Car::PerformanceFigures::accelerationId(), fieldIdPerfAcceleration);
     EXPECT_EQ(Car::PerformanceFigures::Acceleration::mphId(), fieldIdPerfAccMph);
     EXPECT_EQ(Car::PerformanceFigures::Acceleration::secondsId(), fieldIdPerfAccSeconds);
-    EXPECT_EQ(Car::makeId(), fieldIdMake);
+    EXPECT_EQ(Car::brandId(), fieldIdBrand);
     EXPECT_EQ(Car::modelId(), fieldIdModel);
     EXPECT_EQ(Car::activationCodeId(), fieldIdActivationCode);
-    EXPECT_EQ(std::string(Car::makeCharacterEncoding()), std::string("UTF-8"));
+    EXPECT_EQ(std::string(Car::brandCharacterEncoding()), std::string("UTF-8"));
     EXPECT_EQ(std::string(Car::modelCharacterEncoding()), std::string("UTF-8"));
     EXPECT_EQ(std::string(Car::activationCodeCharacterEncoding()), std::string("UTF-8"));
 }
@@ -396,11 +396,11 @@ TEST_F(CodeGenTest, shouldBeAbleToEncodeCarCorrectly)
     EXPECT_EQ(*(float *)(bp + offset), perf2cSeconds);
     offset += sizeof(float);
 
-    // make & model
-    EXPECT_EQ(*(std::uint16_t *)(bp + offset), MAKE_LENGTH);
+    // brand & model
+    EXPECT_EQ(*(std::uint16_t *)(bp + offset), BRAND_LENGTH);
     offset += sizeof(std::uint16_t);
-    EXPECT_EQ(std::string(bp + offset, MAKE_LENGTH), MAKE);
-    offset += MAKE_LENGTH;
+    EXPECT_EQ(std::string(bp + offset, BRAND_LENGTH), BRAND);
+    offset += BRAND_LENGTH;
     EXPECT_EQ(*(std::uint16_t *)(bp + offset), MODEL_LENGTH);
     offset += sizeof(std::uint16_t);
     EXPECT_EQ(std::string(bp + offset, MODEL_LENGTH), MODEL);
@@ -549,8 +549,8 @@ TEST_F(CodeGenTest, shouldbeAbleToEncodeAndDecodeHeaderPlusCarCorrectly)
     EXPECT_EQ(acceleration.mph(), perf2cMph);
     EXPECT_EQ(acceleration.seconds(), perf2cSeconds);
 
-    EXPECT_EQ(m_carDecoder.makeLength(), MAKE_LENGTH);
-    EXPECT_EQ(std::string(m_carDecoder.make(), MAKE_LENGTH), MAKE);
+    EXPECT_EQ(m_carDecoder.brandLength(), BRAND_LENGTH);
+    EXPECT_EQ(std::string(m_carDecoder.brand(), BRAND_LENGTH), BRAND);
 
     EXPECT_EQ(m_carDecoder.modelLength(), MODEL_LENGTH);
     EXPECT_EQ(std::string(m_carDecoder.model(), MODEL_LENGTH), MODEL);
@@ -651,13 +651,13 @@ TEST_F(CodeGenTest, shouldbeAbleUseOnStackCodecsAndGroupForEach)
 
     char tmp[256];
 
-    EXPECT_EQ(carDecoder.getMake(tmp, sizeof(tmp)), MAKE_LENGTH);
-    EXPECT_EQ(std::string(tmp, MAKE_LENGTH), MAKE);
+    EXPECT_EQ(carDecoder.getBrand(tmp, sizeof(tmp)), BRAND_LENGTH);
+    EXPECT_EQ(std::string(tmp, BRAND_LENGTH), BRAND);
 
     EXPECT_EQ(carDecoder.getModel(tmp, sizeof(tmp)), MODEL_LENGTH);
     EXPECT_EQ(std::string(tmp, MODEL_LENGTH), MODEL);
 
-    EXPECT_EQ(carDecoder.getMake(tmp, sizeof(tmp)), ACTIVATION_CODE_LENGTH);
+    EXPECT_EQ(carDecoder.getBrand(tmp, sizeof(tmp)), ACTIVATION_CODE_LENGTH);
     EXPECT_EQ(std::string(tmp, ACTIVATION_CODE_LENGTH), ACTIVATION_CODE);
 
     EXPECT_EQ(carDecoder.encodedLength(), expectedCarSize);
@@ -670,8 +670,8 @@ static const std::size_t offsetUsageDesc2Length = 76;
 static const std::size_t offsetUsageDesc2Data = offsetUsageDesc2Length + sizeof(std::uint16_t);
 static const std::size_t offsetUsageDesc3Length = 98;
 static const std::size_t offsetUsageDesc3Data = offsetUsageDesc3Length + sizeof(std::uint16_t);
-static const std::size_t offsetMakeLength = 163;
-static const std::size_t offsetMakeData = offsetMakeLength + sizeof(std::uint16_t);
+static const std::size_t offsetBrandLength = 163;
+static const std::size_t offsetBrandData = offsetBrandLength + sizeof(std::uint16_t);
 static const std::size_t offsetModelLength = 170;
 static const std::size_t offsetModelData = offsetModelLength + sizeof(std::uint16_t);
 static const std::size_t offsetActivationCodeLength = 181;
@@ -683,7 +683,7 @@ TEST_F(CodeGenTest, shouldBeAbleToUseStdStringMethodsForEncode)
     std::string usageDesc1(FUEL_FIGURES_1_USAGE_DESCRIPTION, FUEL_FIGURES_1_USAGE_DESCRIPTION_LENGTH);
     std::string usageDesc2(FUEL_FIGURES_2_USAGE_DESCRIPTION, FUEL_FIGURES_2_USAGE_DESCRIPTION_LENGTH);
     std::string usageDesc3(FUEL_FIGURES_3_USAGE_DESCRIPTION, FUEL_FIGURES_3_USAGE_DESCRIPTION_LENGTH);
-    std::string make(MAKE, MAKE_LENGTH);
+    std::string brand(BRAND, BRAND_LENGTH);
     std::string model(MODEL, MODEL_LENGTH);
     std::string activationCode(ACTIVATION_CODE, ACTIVATION_CODE_LENGTH);
 
@@ -707,7 +707,7 @@ TEST_F(CodeGenTest, shouldBeAbleToUseStdStringMethodsForEncode)
     perfFigs.next()
         .accelerationCount(ACCELERATION_COUNT).next().next().next();
 
-    car.putMake(make)
+    car.putBrand(brand)
         .putModel(model)
         .putActivationCode(activationCode);
 
@@ -724,8 +724,8 @@ TEST_F(CodeGenTest, shouldBeAbleToUseStdStringMethodsForEncode)
     EXPECT_EQ(*(std::uint16_t *)(buffer + baseOffset + offsetUsageDesc3Length), FUEL_FIGURES_3_USAGE_DESCRIPTION_LENGTH);
     EXPECT_EQ(std::string(buffer + baseOffset + offsetUsageDesc3Data, FUEL_FIGURES_3_USAGE_DESCRIPTION_LENGTH), usageDesc3);
 
-    EXPECT_EQ(*(std::uint16_t *)(buffer + baseOffset + offsetMakeLength), MAKE_LENGTH);
-    EXPECT_EQ(std::string(buffer + baseOffset + offsetMakeData, MAKE_LENGTH), make);
+    EXPECT_EQ(*(std::uint16_t *)(buffer + baseOffset + offsetBrandLength), BRAND_LENGTH);
+    EXPECT_EQ(std::string(buffer + baseOffset + offsetBrandData, BRAND_LENGTH), brand);
 
     EXPECT_EQ(*(std::uint16_t *)(buffer + baseOffset + offsetModelLength), MODEL_LENGTH);
     EXPECT_EQ(std::string(buffer + baseOffset + offsetModelData, MODEL_LENGTH), model);
@@ -749,7 +749,7 @@ TEST_F(CodeGenTest, shouldBeAbleToUseStdStringMethodsForDecode)
     std::string usageDesc1(FUEL_FIGURES_1_USAGE_DESCRIPTION, FUEL_FIGURES_1_USAGE_DESCRIPTION_LENGTH);
     std::string usageDesc2(FUEL_FIGURES_2_USAGE_DESCRIPTION, FUEL_FIGURES_2_USAGE_DESCRIPTION_LENGTH);
     std::string usageDesc3(FUEL_FIGURES_3_USAGE_DESCRIPTION, FUEL_FIGURES_3_USAGE_DESCRIPTION_LENGTH);
-    std::string make(MAKE, MAKE_LENGTH);
+    std::string brand(BRAND, BRAND_LENGTH);
     std::string model(MODEL, MODEL_LENGTH);
     std::string activationCode(ACTIVATION_CODE, ACTIVATION_CODE_LENGTH);
 
@@ -777,7 +777,7 @@ TEST_F(CodeGenTest, shouldBeAbleToUseStdStringMethodsForDecode)
     acceleration = perfFigures.acceleration();
     acceleration.next().next().next();
 
-    EXPECT_EQ(carDecoder.getMakeAsString(), make);
+    EXPECT_EQ(carDecoder.getBrandAsString(), brand);
     EXPECT_EQ(carDecoder.getModelAsString(), model);
     EXPECT_EQ(carDecoder.getActivationCodeAsString(), activationCode);
 

--- a/sbe-tool/src/test/cpp/CodeGenTest.cpp
+++ b/sbe-tool/src/test/cpp/CodeGenTest.cpp
@@ -39,7 +39,7 @@ static char MANUFACTURER_CODE[] = { '1', '2', '3' };
 static const char *FUEL_FIGURES_1_USAGE_DESCRIPTION = "Urban Cycle";
 static const char *FUEL_FIGURES_2_USAGE_DESCRIPTION = "Combined Cycle";
 static const char *FUEL_FIGURES_3_USAGE_DESCRIPTION = "Highway Cycle";
-static const char *BRAND = "Honda";
+static const char *MANUFACTURER = "Honda";
 static const char *MODEL = "Civic VTi";
 static const char *ACTIVATION_CODE = "deadbeef";
 
@@ -48,7 +48,7 @@ static const std::uint64_t MANUFACTURER_CODE_LENGTH = sizeof(MANUFACTURER_CODE);
 static const std::uint64_t FUEL_FIGURES_1_USAGE_DESCRIPTION_LENGTH = 11;
 static const std::uint64_t FUEL_FIGURES_2_USAGE_DESCRIPTION_LENGTH = 14;
 static const std::uint64_t FUEL_FIGURES_3_USAGE_DESCRIPTION_LENGTH = 13;
-static const std::uint64_t BRAND_LENGTH = 5;
+static const std::uint64_t MANUFACTURER_LENGTH = 5;
 static const std::uint64_t MODEL_LENGTH = 9;
 static const std::uint64_t ACTIVATION_CODE_LENGTH = 8;
 static const std::uint8_t PERFORMANCE_FIGURES_COUNT = 2;
@@ -155,7 +155,7 @@ public:
                 .next().mph(perf2bMph).seconds(perf2bSeconds)
                 .next().mph(perf2cMph).seconds(perf2cSeconds);
 
-        car.putBrand(BRAND, static_cast<int>(strlen(BRAND)))
+        car.putManufacturer(MANUFACTURER, static_cast<int>(strlen(MANUFACTURER)))
             .putModel(MODEL, static_cast<int>(strlen(MODEL)))
             .putActivationCode(ACTIVATION_CODE, static_cast<int>(strlen(ACTIVATION_CODE)));
 
@@ -243,7 +243,7 @@ static const uint8_t fieldIdPerfOctaneRating = 14;
 static const uint8_t fieldIdPerfAcceleration = 15;
 static const uint8_t fieldIdPerfAccMph = 16;
 static const uint8_t fieldIdPerfAccSeconds = 17;
-static const uint8_t fieldIdBrand = 18;
+static const uint8_t fieldIdManufacturer = 18;
 static const uint8_t fieldIdModel = 19;
 static const uint8_t fieldIdActivationCode = 20;
 
@@ -268,10 +268,10 @@ TEST_F(CodeGenTest, shouldReturnCorrectValuesForCarFieldIdsAndCharacterEncoding)
     EXPECT_EQ(Car::PerformanceFigures::accelerationId(), fieldIdPerfAcceleration);
     EXPECT_EQ(Car::PerformanceFigures::Acceleration::mphId(), fieldIdPerfAccMph);
     EXPECT_EQ(Car::PerformanceFigures::Acceleration::secondsId(), fieldIdPerfAccSeconds);
-    EXPECT_EQ(Car::brandId(), fieldIdBrand);
+    EXPECT_EQ(Car::manufacturerId(), fieldIdManufacturer);
     EXPECT_EQ(Car::modelId(), fieldIdModel);
     EXPECT_EQ(Car::activationCodeId(), fieldIdActivationCode);
-    EXPECT_EQ(std::string(Car::brandCharacterEncoding()), std::string("UTF-8"));
+    EXPECT_EQ(std::string(Car::manufacturerCharacterEncoding()), std::string("UTF-8"));
     EXPECT_EQ(std::string(Car::modelCharacterEncoding()), std::string("UTF-8"));
     EXPECT_EQ(std::string(Car::activationCodeCharacterEncoding()), std::string("UTF-8"));
 }
@@ -396,11 +396,11 @@ TEST_F(CodeGenTest, shouldBeAbleToEncodeCarCorrectly)
     EXPECT_EQ(*(float *)(bp + offset), perf2cSeconds);
     offset += sizeof(float);
 
-    // brand & model
-    EXPECT_EQ(*(std::uint16_t *)(bp + offset), BRAND_LENGTH);
+    // manufacturer & model
+    EXPECT_EQ(*(std::uint16_t *)(bp + offset), MANUFACTURER_LENGTH);
     offset += sizeof(std::uint16_t);
-    EXPECT_EQ(std::string(bp + offset, BRAND_LENGTH), BRAND);
-    offset += BRAND_LENGTH;
+    EXPECT_EQ(std::string(bp + offset, MANUFACTURER_LENGTH), MANUFACTURER);
+    offset += MANUFACTURER_LENGTH;
     EXPECT_EQ(*(std::uint16_t *)(bp + offset), MODEL_LENGTH);
     offset += sizeof(std::uint16_t);
     EXPECT_EQ(std::string(bp + offset, MODEL_LENGTH), MODEL);
@@ -549,8 +549,8 @@ TEST_F(CodeGenTest, shouldbeAbleToEncodeAndDecodeHeaderPlusCarCorrectly)
     EXPECT_EQ(acceleration.mph(), perf2cMph);
     EXPECT_EQ(acceleration.seconds(), perf2cSeconds);
 
-    EXPECT_EQ(m_carDecoder.brandLength(), BRAND_LENGTH);
-    EXPECT_EQ(std::string(m_carDecoder.brand(), BRAND_LENGTH), BRAND);
+    EXPECT_EQ(m_carDecoder.manufacturerLength(), MANUFACTURER_LENGTH);
+    EXPECT_EQ(std::string(m_carDecoder.manufacturer(), MANUFACTURER_LENGTH), MANUFACTURER);
 
     EXPECT_EQ(m_carDecoder.modelLength(), MODEL_LENGTH);
     EXPECT_EQ(std::string(m_carDecoder.model(), MODEL_LENGTH), MODEL);
@@ -651,13 +651,13 @@ TEST_F(CodeGenTest, shouldbeAbleUseOnStackCodecsAndGroupForEach)
 
     char tmp[256];
 
-    EXPECT_EQ(carDecoder.getBrand(tmp, sizeof(tmp)), BRAND_LENGTH);
-    EXPECT_EQ(std::string(tmp, BRAND_LENGTH), BRAND);
+    EXPECT_EQ(carDecoder.getManufacturer(tmp, sizeof(tmp)), MANUFACTURER_LENGTH);
+    EXPECT_EQ(std::string(tmp, MANUFACTURER_LENGTH), MANUFACTURER);
 
     EXPECT_EQ(carDecoder.getModel(tmp, sizeof(tmp)), MODEL_LENGTH);
     EXPECT_EQ(std::string(tmp, MODEL_LENGTH), MODEL);
 
-    EXPECT_EQ(carDecoder.getBrand(tmp, sizeof(tmp)), ACTIVATION_CODE_LENGTH);
+    EXPECT_EQ(carDecoder.getManufacturer(tmp, sizeof(tmp)), ACTIVATION_CODE_LENGTH);
     EXPECT_EQ(std::string(tmp, ACTIVATION_CODE_LENGTH), ACTIVATION_CODE);
 
     EXPECT_EQ(carDecoder.encodedLength(), expectedCarSize);
@@ -670,8 +670,8 @@ static const std::size_t offsetUsageDesc2Length = 76;
 static const std::size_t offsetUsageDesc2Data = offsetUsageDesc2Length + sizeof(std::uint16_t);
 static const std::size_t offsetUsageDesc3Length = 98;
 static const std::size_t offsetUsageDesc3Data = offsetUsageDesc3Length + sizeof(std::uint16_t);
-static const std::size_t offsetBrandLength = 163;
-static const std::size_t offsetBrandData = offsetBrandLength + sizeof(std::uint16_t);
+static const std::size_t offsetManufacturerLength = 163;
+static const std::size_t offsetManufacturerData = offsetManufacturerLength + sizeof(std::uint16_t);
 static const std::size_t offsetModelLength = 170;
 static const std::size_t offsetModelData = offsetModelLength + sizeof(std::uint16_t);
 static const std::size_t offsetActivationCodeLength = 181;
@@ -683,7 +683,7 @@ TEST_F(CodeGenTest, shouldBeAbleToUseStdStringMethodsForEncode)
     std::string usageDesc1(FUEL_FIGURES_1_USAGE_DESCRIPTION, FUEL_FIGURES_1_USAGE_DESCRIPTION_LENGTH);
     std::string usageDesc2(FUEL_FIGURES_2_USAGE_DESCRIPTION, FUEL_FIGURES_2_USAGE_DESCRIPTION_LENGTH);
     std::string usageDesc3(FUEL_FIGURES_3_USAGE_DESCRIPTION, FUEL_FIGURES_3_USAGE_DESCRIPTION_LENGTH);
-    std::string brand(BRAND, BRAND_LENGTH);
+    std::string manufacturer(MANUFACTURER, MANUFACTURER_LENGTH);
     std::string model(MODEL, MODEL_LENGTH);
     std::string activationCode(ACTIVATION_CODE, ACTIVATION_CODE_LENGTH);
 
@@ -707,7 +707,7 @@ TEST_F(CodeGenTest, shouldBeAbleToUseStdStringMethodsForEncode)
     perfFigs.next()
         .accelerationCount(ACCELERATION_COUNT).next().next().next();
 
-    car.putBrand(brand)
+    car.putManufacturer(manufacturer)
         .putModel(model)
         .putActivationCode(activationCode);
 
@@ -724,8 +724,8 @@ TEST_F(CodeGenTest, shouldBeAbleToUseStdStringMethodsForEncode)
     EXPECT_EQ(*(std::uint16_t *)(buffer + baseOffset + offsetUsageDesc3Length), FUEL_FIGURES_3_USAGE_DESCRIPTION_LENGTH);
     EXPECT_EQ(std::string(buffer + baseOffset + offsetUsageDesc3Data, FUEL_FIGURES_3_USAGE_DESCRIPTION_LENGTH), usageDesc3);
 
-    EXPECT_EQ(*(std::uint16_t *)(buffer + baseOffset + offsetBrandLength), BRAND_LENGTH);
-    EXPECT_EQ(std::string(buffer + baseOffset + offsetBrandData, BRAND_LENGTH), brand);
+    EXPECT_EQ(*(std::uint16_t *)(buffer + baseOffset + offsetManufacturerLength), MANUFACTURER_LENGTH);
+    EXPECT_EQ(std::string(buffer + baseOffset + offsetManufacturerData, MANUFACTURER_LENGTH), manufacturer);
 
     EXPECT_EQ(*(std::uint16_t *)(buffer + baseOffset + offsetModelLength), MODEL_LENGTH);
     EXPECT_EQ(std::string(buffer + baseOffset + offsetModelData, MODEL_LENGTH), model);
@@ -749,7 +749,7 @@ TEST_F(CodeGenTest, shouldBeAbleToUseStdStringMethodsForDecode)
     std::string usageDesc1(FUEL_FIGURES_1_USAGE_DESCRIPTION, FUEL_FIGURES_1_USAGE_DESCRIPTION_LENGTH);
     std::string usageDesc2(FUEL_FIGURES_2_USAGE_DESCRIPTION, FUEL_FIGURES_2_USAGE_DESCRIPTION_LENGTH);
     std::string usageDesc3(FUEL_FIGURES_3_USAGE_DESCRIPTION, FUEL_FIGURES_3_USAGE_DESCRIPTION_LENGTH);
-    std::string brand(BRAND, BRAND_LENGTH);
+    std::string manufacturer(MANUFACTURER, MANUFACTURER_LENGTH);
     std::string model(MODEL, MODEL_LENGTH);
     std::string activationCode(ACTIVATION_CODE, ACTIVATION_CODE_LENGTH);
 
@@ -777,7 +777,7 @@ TEST_F(CodeGenTest, shouldBeAbleToUseStdStringMethodsForDecode)
     acceleration = perfFigures.acceleration();
     acceleration.next().next().next();
 
-    EXPECT_EQ(carDecoder.getBrandAsString(), brand);
+    EXPECT_EQ(carDecoder.getManufacturerAsString(), manufacturer);
     EXPECT_EQ(carDecoder.getModelAsString(), model);
     EXPECT_EQ(carDecoder.getActivationCodeAsString(), activationCode);
 

--- a/sbe-tool/src/test/cpp/Rc3OtfFullIrTest.cpp
+++ b/sbe-tool/src/test/cpp/Rc3OtfFullIrTest.cpp
@@ -46,7 +46,7 @@ static const uint8_t fieldIdPerfOctaneRating = 14;
 static const uint8_t fieldIdPerfAcceleration = 15;
 static const uint8_t fieldIdPerfAccMph = 16;
 static const uint8_t fieldIdPerfAccSeconds = 17;
-static const uint8_t fieldIdMake = 18;
+static const uint8_t fieldIdBrand = 18;
 static const uint8_t fieldIdModel = 19;
 static const uint8_t fieldIdActivationCode = 20;
 
@@ -63,13 +63,13 @@ static char MANUFACTURER_CODE[] = { '1', '2', '3' };
 static const char *FUEL_FIGURES_1_USAGE_DESCRIPTION = "Urban Cycle";
 static const char *FUEL_FIGURES_2_USAGE_DESCRIPTION = "Combined Cycle";
 static const char *FUEL_FIGURES_3_USAGE_DESCRIPTION = "Highway Cycle";
-static const char *MAKE = "Honda";
+static const char *BRAND = "Honda";
 static const char *MODEL = "Civic VTi";
 static const char *ACTIVATION_CODE = "deadbeef";
 
 static const int VEHICLE_CODE_LENGTH = sizeof(VEHICLE_CODE);
 static const int MANUFACTURER_CODE_LENGTH = sizeof(MANUFACTURER_CODE);
-static const size_t MAKE_LENGTH = 5;
+static const size_t BRAND_LENGTH = 5;
 static const size_t MODEL_LENGTH = 9;
 static const size_t ACTIVATION_CODE_LENGTH = 8;
 static const size_t PERFORMANCE_FIGURES_COUNT = 2;
@@ -178,7 +178,7 @@ enum EventNumber
     EN_performanceFigures2_acceleration3_seconds,
     EN_performanceFigures2_endAcceleration3,
     EN_endPerformanceFigures2,
-    EN_make,
+    EN_brand,
     EN_model,
     EN_activationCode,
     EN_endMessage
@@ -274,7 +274,7 @@ public:
             .next().mph(perf2bMph).seconds(perf2bSeconds)
             .next().mph(perf2cMph).seconds(perf2cSeconds);
 
-        car.putMake(MAKE, static_cast<int>(strlen(MAKE)));
+        car.putBrand(BRAND, static_cast<int>(strlen(BRAND)));
         car.putModel(MODEL, static_cast<int>(strlen(MODEL)));
         car.putActivationCode(ACTIVATION_CODE, static_cast<int>(strlen(ACTIVATION_CODE)));
 
@@ -1027,11 +1027,11 @@ public:
                 EXPECT_EQ(std::string(buffer, length), FUEL_FIGURES_3_USAGE_DESCRIPTION);
                 break;
             }
-            case EN_make:
+            case EN_brand:
             {
-                EXPECT_EQ(fieldToken.fieldId(), fieldIdMake);
-                EXPECT_EQ(length, MAKE_LENGTH);
-                EXPECT_EQ(std::string(buffer, MAKE_LENGTH), MAKE);
+                EXPECT_EQ(fieldToken.fieldId(), fieldIdBrand);
+                EXPECT_EQ(length, BRAND_LENGTH);
+                EXPECT_EQ(std::string(buffer, BRAND_LENGTH), BRAND);
                 break;
             }
             case EN_model:

--- a/sbe-tool/src/test/cpp/Rc3OtfFullIrTest.cpp
+++ b/sbe-tool/src/test/cpp/Rc3OtfFullIrTest.cpp
@@ -46,7 +46,7 @@ static const uint8_t fieldIdPerfOctaneRating = 14;
 static const uint8_t fieldIdPerfAcceleration = 15;
 static const uint8_t fieldIdPerfAccMph = 16;
 static const uint8_t fieldIdPerfAccSeconds = 17;
-static const uint8_t fieldIdBrand = 18;
+static const uint8_t fieldIdManufacturer = 18;
 static const uint8_t fieldIdModel = 19;
 static const uint8_t fieldIdActivationCode = 20;
 
@@ -63,13 +63,13 @@ static char MANUFACTURER_CODE[] = { '1', '2', '3' };
 static const char *FUEL_FIGURES_1_USAGE_DESCRIPTION = "Urban Cycle";
 static const char *FUEL_FIGURES_2_USAGE_DESCRIPTION = "Combined Cycle";
 static const char *FUEL_FIGURES_3_USAGE_DESCRIPTION = "Highway Cycle";
-static const char *BRAND = "Honda";
+static const char *MANUFACTURER = "Honda";
 static const char *MODEL = "Civic VTi";
 static const char *ACTIVATION_CODE = "deadbeef";
 
 static const int VEHICLE_CODE_LENGTH = sizeof(VEHICLE_CODE);
 static const int MANUFACTURER_CODE_LENGTH = sizeof(MANUFACTURER_CODE);
-static const size_t BRAND_LENGTH = 5;
+static const size_t MANUFACTURER_LENGTH = 5;
 static const size_t MODEL_LENGTH = 9;
 static const size_t ACTIVATION_CODE_LENGTH = 8;
 static const size_t PERFORMANCE_FIGURES_COUNT = 2;
@@ -178,7 +178,7 @@ enum EventNumber
     EN_performanceFigures2_acceleration3_seconds,
     EN_performanceFigures2_endAcceleration3,
     EN_endPerformanceFigures2,
-    EN_brand,
+    EN_manufacturer,
     EN_model,
     EN_activationCode,
     EN_endMessage
@@ -274,7 +274,7 @@ public:
             .next().mph(perf2bMph).seconds(perf2bSeconds)
             .next().mph(perf2cMph).seconds(perf2cSeconds);
 
-        car.putBrand(BRAND, static_cast<int>(strlen(BRAND)));
+        car.putManufacturer(MANUFACTURER, static_cast<int>(strlen(MANUFACTURER)));
         car.putModel(MODEL, static_cast<int>(strlen(MODEL)));
         car.putActivationCode(ACTIVATION_CODE, static_cast<int>(strlen(ACTIVATION_CODE)));
 
@@ -1027,11 +1027,11 @@ public:
                 EXPECT_EQ(std::string(buffer, length), FUEL_FIGURES_3_USAGE_DESCRIPTION);
                 break;
             }
-            case EN_brand:
+            case EN_manufacturer:
             {
-                EXPECT_EQ(fieldToken.fieldId(), fieldIdBrand);
-                EXPECT_EQ(length, BRAND_LENGTH);
-                EXPECT_EQ(std::string(buffer, BRAND_LENGTH), BRAND);
+                EXPECT_EQ(fieldToken.fieldId(), fieldIdManufacturer);
+                EXPECT_EQ(length, MANUFACTURER_LENGTH);
+                EXPECT_EQ(std::string(buffer, MANUFACTURER_LENGTH), MANUFACTURER);
                 break;
             }
             case EN_model:

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/EncodedCarTestBase.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/EncodedCarTestBase.java
@@ -29,7 +29,7 @@ public class EncodedCarTestBase
 
     private static byte[] vehicleCode;
     private static byte[] manufacturerCode;
-    private static byte[] brand;
+    private static byte[] manufacturer;
     private static byte[] model;
 
     @BeforeClass
@@ -39,7 +39,7 @@ public class EncodedCarTestBase
         {
             vehicleCode = "abcdef".getBytes(CarEncoder.vehicleCodeCharacterEncoding());
             manufacturerCode = "123".getBytes(EngineEncoder.manufacturerCodeCharacterEncoding());
-            brand = "Honda".getBytes(CarEncoder.brandCharacterEncoding());
+            manufacturer = "Honda".getBytes(CarEncoder.manufacturerCharacterEncoding());
             model = "Civic VTi".getBytes(CarEncoder.modelCharacterEncoding());
         }
         catch (final UnsupportedEncodingException ex)
@@ -106,7 +106,7 @@ public class EncodedCarTestBase
             .next().mph(60).seconds(7.1f)
             .next().mph(100).seconds(11.8f);
 
-        CAR.brand(new String(brand));
+        CAR.manufacturer(new String(manufacturer));
         CAR.putModel(model, srcOffset, model.length);
 
         bufferOffset += CAR.encodedLength();

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/EncodedCarTestBase.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/EncodedCarTestBase.java
@@ -29,7 +29,7 @@ public class EncodedCarTestBase
 
     private static byte[] vehicleCode;
     private static byte[] manufacturerCode;
-    private static byte[] make;
+    private static byte[] brand;
     private static byte[] model;
 
     @BeforeClass
@@ -39,7 +39,7 @@ public class EncodedCarTestBase
         {
             vehicleCode = "abcdef".getBytes(CarEncoder.vehicleCodeCharacterEncoding());
             manufacturerCode = "123".getBytes(EngineEncoder.manufacturerCodeCharacterEncoding());
-            make = "Honda".getBytes(CarEncoder.makeCharacterEncoding());
+            brand = "Honda".getBytes(CarEncoder.brandCharacterEncoding());
             model = "Civic VTi".getBytes(CarEncoder.modelCharacterEncoding());
         }
         catch (final UnsupportedEncodingException ex)
@@ -106,7 +106,7 @@ public class EncodedCarTestBase
             .next().mph(60).seconds(7.1f)
             .next().mph(100).seconds(11.8f);
 
-        CAR.make(new String(make));
+        CAR.brand(new String(brand));
         CAR.putModel(model, srcOffset, model.length);
 
         bufferOffset += CAR.encodedLength();

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
@@ -283,7 +283,7 @@ public class JavaGeneratorTest
     @Test
     public void shouldGenerateVarDataCodecs() throws Exception
     {
-        final String expectedBrand = "Ford";
+        final String expectedManufacturer = "Ford";
         final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);
 
         generator().generate();
@@ -291,11 +291,11 @@ public class JavaGeneratorTest
         final Object encoder = wrap(buffer, compileCarEncoder().newInstance());
         final Object decoder = getCarDecoder(buffer, encoder);
 
-        setBrand(encoder, expectedBrand);
+        setManufacturer(encoder, expectedManufacturer);
 
-        final String brand = getBrand(decoder);
+        final String manufacturer = getManufacturer(decoder);
 
-        assertEquals(expectedBrand, brand);
+        assertEquals(expectedManufacturer, manufacturer);
     }
 
     @Test

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
@@ -283,7 +283,7 @@ public class JavaGeneratorTest
     @Test
     public void shouldGenerateVarDataCodecs() throws Exception
     {
-        final String expectedMake = "Ford";
+        final String expectedBrand = "Ford";
         final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);
 
         generator().generate();
@@ -291,11 +291,11 @@ public class JavaGeneratorTest
         final Object encoder = wrap(buffer, compileCarEncoder().newInstance());
         final Object decoder = getCarDecoder(buffer, encoder);
 
-        setMake(encoder, expectedMake);
+        setBrand(encoder, expectedBrand);
 
-        final String make = getMake(decoder);
+        final String brand = getBrand(decoder);
 
-        assertEquals(expectedMake, make);
+        assertEquals(expectedBrand, brand);
     }
 
     @Test

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ReflectionUtil.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ReflectionUtil.java
@@ -37,15 +37,15 @@ public final class ReflectionUtil
         return object.getClass().getMethod(fieldName).invoke(object);
     }
 
-    static String getMake(final Object decoder) throws Exception
+    static String getBrand(final Object decoder) throws Exception
     {
-        return (String)get(decoder, "make");
+        return (String)get(decoder, "brand");
     }
 
-    static void setMake(final Object encoder,
+    static void setBrand(final Object encoder,
         final String value) throws Exception
     {
-        encoder.getClass().getMethod("make", String.class).invoke(encoder, value);
+        encoder.getClass().getMethod("brand", String.class).invoke(encoder, value);
     }
 
     static void putSerialNumber(final Object encoder, final long serial) throws Exception

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ReflectionUtil.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ReflectionUtil.java
@@ -37,15 +37,15 @@ public final class ReflectionUtil
         return object.getClass().getMethod(fieldName).invoke(object);
     }
 
-    static String getBrand(final Object decoder) throws Exception
+    static String getManufacturer(final Object decoder) throws Exception
     {
-        return (String)get(decoder, "brand");
+        return (String)get(decoder, "manufacturer");
     }
 
-    static void setBrand(final Object encoder,
+    static void setManufacturer(final Object encoder,
         final String value) throws Exception
     {
-        encoder.getClass().getMethod("brand", String.class).invoke(encoder, value);
+        encoder.getClass().getMethod("manufacturer", String.class).invoke(encoder, value);
     }
 
     static void putSerialNumber(final Object encoder, final long serial) throws Exception

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ToStringTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ToStringTest.java
@@ -34,7 +34,7 @@ public class ToStringTest extends EncodedCarTestBase
             "performanceFigures=[" +
             "(octaneRating=95|acceleration=[(mph=30|seconds=4.0),(mph=60|seconds=7.5),(mph=100|seconds=12.2)])," +
             "(octaneRating=99|acceleration=[(mph=30|seconds=3.8),(mph=60|seconds=7.1),(mph=100|seconds=11.8)])]|" +
-            "make=Honda|model=Civic VTi|activationCode=",
+            "brand=Honda|model=Civic VTi|activationCode=",
             result);
     }
 
@@ -50,7 +50,7 @@ public class ToStringTest extends EncodedCarTestBase
             "(sbeTemplateId=1|sbeSchemaId=1|sbeSchemaVersion=0|sbeBlockLength=45):" +
             "serialNumber=0|modelYear=0|available=F|code=NULL_VAL|someNumbers=[0,0,0,0,0]|vehicleCode=|extras={}|" +
             "engine=(capacity=0|numCylinders=0|manufacturerCode=|)|" +
-            "fuelFigures=[]|performanceFigures=[]|make=|model=|activationCode=",
+            "fuelFigures=[]|performanceFigures=[]|brand=|model=|activationCode=",
             result);
     }
 }

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ToStringTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ToStringTest.java
@@ -34,7 +34,7 @@ public class ToStringTest extends EncodedCarTestBase
             "performanceFigures=[" +
             "(octaneRating=95|acceleration=[(mph=30|seconds=4.0),(mph=60|seconds=7.5),(mph=100|seconds=12.2)])," +
             "(octaneRating=99|acceleration=[(mph=30|seconds=3.8),(mph=60|seconds=7.1),(mph=100|seconds=11.8)])]|" +
-            "brand=Honda|model=Civic VTi|activationCode=",
+            "manufacturer=Honda|model=Civic VTi|activationCode=",
             result);
     }
 
@@ -50,7 +50,7 @@ public class ToStringTest extends EncodedCarTestBase
             "(sbeTemplateId=1|sbeSchemaId=1|sbeSchemaVersion=0|sbeBlockLength=45):" +
             "serialNumber=0|modelYear=0|available=F|code=NULL_VAL|someNumbers=[0,0,0,0,0]|vehicleCode=|extras={}|" +
             "engine=(capacity=0|numCylinders=0|manufacturerCode=|)|" +
-            "fuelFigures=[]|performanceFigures=[]|brand=|model=|activationCode=",
+            "fuelFigures=[]|performanceFigures=[]|manufacturer=|model=|activationCode=",
             result);
     }
 }

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/json/JsonPrinterTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/json/JsonPrinterTest.java
@@ -108,7 +108,7 @@ public class JsonPrinterTest extends EncodedCarTestBase
             "            \"seconds\": 11.8\n" +
             "        }]\n" +
             "    }],\n" +
-            "    \"brand\": \"Honda\",\n" +
+            "    \"manufacturer\": \"Honda\",\n" +
             "    \"model\": \"Civic VTi\",\n" +
             "    \"activationCode\": \"\"\n" +
             "}",

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/json/JsonPrinterTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/json/JsonPrinterTest.java
@@ -108,7 +108,7 @@ public class JsonPrinterTest extends EncodedCarTestBase
             "            \"seconds\": 11.8\n" +
             "        }]\n" +
             "    }],\n" +
-            "    \"make\": \"Honda\",\n" +
+            "    \"brand\": \"Honda\",\n" +
             "    \"model\": \"Civic VTi\",\n" +
             "    \"activationCode\": \"\"\n" +
             "}",

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/xml/ErrorHandlerTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/xml/ErrorHandlerTest.java
@@ -92,7 +92,7 @@ public class ErrorHandlerTest
         parseTestXmlAddToMap(map, "/types/enum", testXmlString, handler);
         parseTestXmlAddToMap(map, "/types/set", testXmlString, handler);
 
-        assertThat(valueOf(handler.errorCount()), is(valueOf(17)));
+        assertThat(valueOf(handler.errorCount()), is(valueOf(24)));
         assertThat(valueOf(handler.warningCount()), is(valueOf(5)));
     }
 
@@ -173,7 +173,7 @@ public class ErrorHandlerTest
         throws Exception
     {
         exceptionRule.expect(IllegalStateException.class);
-        exceptionRule.expectMessage("had 8 errors");
+        exceptionRule.expectMessage("had 12 errors");
 
         final ParserOptions options = ParserOptions.builder().suppressOutput(true).warningsFatal(true).build();
 

--- a/sbe-tool/src/test/resources/code-generation-schema.xml
+++ b/sbe-tool/src/test/resources/code-generation-schema.xml
@@ -81,7 +81,7 @@
                 <field name="seconds" id="17" type="float"/>
             </group>
         </group>
-        <data name="make" id="18" type="varDataEncoding"/>
+        <data name="brand" id="18" type="varDataEncoding"/>
         <data name="model" id="19" type="varDataEncoding"/>
         <data name="activationCode" id="20" type="varDataEncoding"/>
     </sbe:message>

--- a/sbe-tool/src/test/resources/code-generation-schema.xml
+++ b/sbe-tool/src/test/resources/code-generation-schema.xml
@@ -81,7 +81,7 @@
                 <field name="seconds" id="17" type="float"/>
             </group>
         </group>
-        <data name="brand" id="18" type="varDataEncoding"/>
+        <data name="manufacturer" id="18" type="varDataEncoding"/>
         <data name="model" id="19" type="varDataEncoding"/>
         <data name="activationCode" id="20" type="varDataEncoding"/>
     </sbe:message>

--- a/sbe-tool/src/test/resources/json-printer-test-schema.xml
+++ b/sbe-tool/src/test/resources/json-printer-test-schema.xml
@@ -69,7 +69,7 @@
                 <field name="seconds" id="16" type="float"/>
             </group>
         </group>
-        <data name="brand" id="17" type="varDataEncoding"/>
+        <data name="manufacturer" id="17" type="varDataEncoding"/>
         <data name="model" id="18" type="varDataEncoding"/>
         <data name="activationCode" id="19" type="varDataEncoding"/>
     </sbe:message>

--- a/sbe-tool/src/test/resources/json-printer-test-schema.xml
+++ b/sbe-tool/src/test/resources/json-printer-test-schema.xml
@@ -69,7 +69,7 @@
                 <field name="seconds" id="16" type="float"/>
             </group>
         </group>
-        <data name="make" id="17" type="varDataEncoding"/>
+        <data name="brand" id="17" type="varDataEncoding"/>
         <data name="model" id="18" type="varDataEncoding"/>
         <data name="activationCode" id="19" type="varDataEncoding"/>
     </sbe:message>


### PR DESCRIPTION
[MarketFactory](https://www.marketfactory.com) are currently using sbe-tool for Java and C++ and would like to extend our usage to include golang.  We are happy to maintain a golang backend for sbe-tool and developing one is underway.

I thought that in in the interest of starting a conversation that an initial pull request would help us understand how you like to manage accepting contributions. This pull request has been squashed to two commits.

The first commit results from golang's use of 'make' as a predeclared identifier requiring it to be added to the list of keywords.

The second commit is sufficient to get the car example-schema working but should be regarded as a first snapshot during development.

Further development steps (as currently imagined) are contained in gocode/README.md.

I understand that you will probably have many comments on this snapshot and I'll be very happy to refine things with your input.

