### PR TITLE
Make the byte order available in the IR

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/Ir.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/Ir.java
@@ -19,6 +19,7 @@ import org.agrona.Verify;
 
 import uk.co.real_logic.sbe.SbeTool;
 
+import java.nio.ByteOrder;
 import java.util.*;
 import java.util.regex.Pattern;
 
@@ -33,6 +34,7 @@ public class Ir
     private final int id;
     private final int version;
     private final String semanticVersion;
+    private final ByteOrder byteOrder;
 
     private final HeaderStructure headerStructure;
     private final Map<Long, List<Token>> messagesByIdMap = new HashMap<>();
@@ -56,6 +58,7 @@ public class Ir
         final int id,
         final int version,
         final String semanticVersion,
+        final ByteOrder byteOrder,
         final List<Token> headerTokens)
     {
         Verify.notNull(packageName, "packageName");
@@ -66,6 +69,7 @@ public class Ir
         this.id = id;
         this.version = version;
         this.semanticVersion = semanticVersion;
+        this.byteOrder = byteOrder;
         this.headerStructure = new HeaderStructure(new ArrayList<>(headerTokens));
 
         if (Boolean.getBoolean(SbeTool.CPP_NAMESPACES_COLLAPSE))
@@ -205,6 +209,16 @@ public class Ir
     public String semanticVersion()
     {
         return semanticVersion;
+    }
+
+    /**
+     * Get the endianness of the schema.
+     *
+     * @return the ByteOrder of the schema
+     */
+    public ByteOrder byteOrder()
+    {
+        return byteOrder;
     }
 
     /**

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/IrDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/IrDecoder.java
@@ -25,6 +25,7 @@ import uk.co.real_logic.sbe.ir.generated.TokenCodecDecoder;
 import java.io.IOException;
 import java.io.RandomAccessFile;
 import java.nio.ByteBuffer;
+import java.nio.ByteOrder;
 import java.nio.MappedByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
@@ -45,6 +46,7 @@ public class IrDecoder implements AutoCloseable
     private String irPackageName = null;
     private String irNamespaceName = null;
     private String semanticVersion = null;
+    private ByteOrder byteOrder = ByteOrder.LITTLE_ENDIAN;
     private List<Token> irHeader = null;
     private int irId;
     private int irVersion = 0;
@@ -97,7 +99,7 @@ public class IrDecoder implements AutoCloseable
             i = captureHeader(tokens, 0);
         }
 
-        final Ir ir = new Ir(irPackageName, irNamespaceName, irId, irVersion, semanticVersion, irHeader);
+        final Ir ir = new Ir(irPackageName, irNamespaceName, irId, irVersion, semanticVersion, byteOrder, irHeader);
 
         for (int size = tokens.size(); i < size; i++)
         {

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/IrGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/IrGenerator.java
@@ -45,7 +45,8 @@ public class IrGenerator
     {
         final List<Token> headerTokens = generateForHeader(schema);
         final Ir ir = new Ir(
-            schema.packageName(), namespace, schema.id(), schema.version(), schema.semanticVersion(), headerTokens);
+            schema.packageName(), namespace, schema.id(), schema.version(), schema.semanticVersion(),
+            schema.byteOrder(), headerTokens);
 
         for (final Message message : schema.messages())
         {


### PR DESCRIPTION
This doesn't push the byteOrder down into each Message as I think it belongs with the message schema beside package, id, version, and semanticVersion.