### PR TITLE
Golang beta1, feature complete

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Simple Binary Encoding (SBE)
 
 [SBE](https://github.com/FIXTradingCommunity/fix-simple-binary-encoding) is an OSI layer 6 presentation for 
 encoding and decoding binary application messages for low-latency financial applications. This repository contains 
-the reference implementations in Java and C++.
+the reference implementations in Java, C++, and Golang.
 
 Further details on the background and usage of SBE can be found on the
 [Wiki](https://github.com/real-logic/simple-binary-encoding/wiki).
@@ -107,3 +107,24 @@ If you are comfortable with using CMake, then a full clean, build, and test look
     $ cmake ../..
     $ cmake --build . --clean-first
     $ ctest
+
+Golang Build
+------------
+
+First build using Gradle to generate the SBE jar and then use it to
+generate the golang code for testing
+
+    $ ./gradlew
+    $ ./gradlew generateGolangCodecs
+
+For convenience on Linux, a gnu Makefile is provided that runs some
+tests and containes some examples
+
+    $ cd gocode
+    # make # test, examples, bench
+
+Users of golang generated code should see the [user
+documentation](https://github.com/real-logic/simple-binary-encoding/wiki/Golang-User-Guide). Developers
+wishing to enhance golang generator should see the [developer
+documentation](https://github.com/real-logic/simple-binary-encoding/blob/master/gocode/README.md)
+

--- a/build.gradle
+++ b/build.gradle
@@ -450,6 +450,60 @@ project(':sbe-benchmarks') {
     }
 }
 
+/*
+ * Golang codec targets used for testing, benchmarking etc. We have
+ * multiple targets as:
+ *  *) some of the test files generate warnings from the xsd so we don't
+ *     validate those.
+ *  *) Some of the test files need an additional output directory setting
+ *     as they generate into the same directory and golang won't allow that.
+ */
+task(generateGolangCodecTestComposite, type:JavaExec) {
+    main = 'uk.co.real_logic.sbe.SbeTool'
+    classpath = project(':sbe-all').sourceSets.main.runtimeClasspath
+    systemProperties(
+        'sbe.output.dir': 'gocode/src',
+        'sbe.target.language': 'golang')
+    args = [ 'sbe-tool/src/test/resources/composite-elements-schema-rc4.xml' ]
+}
+task(generateGolangCodecTestBasic, type:JavaExec) {
+    main = 'uk.co.real_logic.sbe.SbeTool'
+    classpath = project(':sbe-all').sourceSets.main.runtimeClasspath
+    systemProperties(
+        'sbe.output.dir': 'gocode/src/basic',
+        'sbe.target.language': 'golang')
+    args = [ 'sbe-tool/src/test/resources/basic-types-schema.xml' ]
+}
+task(generateGolangCodecTestGroup, type:JavaExec) {
+    main = 'uk.co.real_logic.sbe.SbeTool'
+    classpath = project(':sbe-all').sourceSets.main.runtimeClasspath
+    systemProperties(
+        'sbe.output.dir': 'gocode/src/group',
+        'sbe.target.language': 'golang')
+    args = [ 'sbe-tool/src/test/resources/basic-group-schema.xml' ]
+}
+task(generateGolangCodecTestVarData, type:JavaExec) {
+    main = 'uk.co.real_logic.sbe.SbeTool'
+    classpath = project(':sbe-all').sourceSets.main.runtimeClasspath
+    systemProperties(
+        'sbe.output.dir': 'gocode/src/vardata',
+        'sbe.target.language': 'golang')
+    args = [ 'sbe-tool/src/test/resources/basic-variable-length-schema.xml' ]
+}
+task(generateGolangCodecsWithXSD, type:JavaExec) {
+    main = 'uk.co.real_logic.sbe.SbeTool'
+    classpath = project(':sbe-all').sourceSets.main.runtimeClasspath
+    systemProperties(
+        'sbe.output.dir': 'gocode/src',
+        'sbe.target.language': 'golang',
+        'sbe.validation.xsd': validationXsdPath)
+    args = [ 'sbe-tool/src/test/resources/group-with-data-schema.xml', 'sbe-tool/src/test/resources/FixBinary.xml', 'gocode/resources/example-bigendian.xml', 'gocode/resources/example-composite.xml', 'gocode/resources/example-extension-2-schema.xml', 'gocode/resources/group-with-data-extension-schema.xml', 'gocode/resources/simple.xml', 'sbe-samples/src/main/resources/example-schema.xml', 'sbe-samples/src/main/resources/example-extension-schema.xml' ]
+}
+task generateGolangCodecs {
+    description = 'Generate golang test codecs'
+    dependsOn 'generateGolangCodecTestVarData', 'generateGolangCodecTestGroup', 'generateGolangCodecTestBasic', 'generateGolangCodecTestComposite', 'generateGolangCodecsWithXSD'
+}
+
 task(generateJavaIrCodecs, type: JavaExec) {
     main = 'uk.co.real_logic.sbe.SbeTool'
     classpath = project(':sbe-all').sourceSets.main.runtimeClasspath

--- a/gocode/Makefile
+++ b/gocode/Makefile
@@ -1,264 +1,83 @@
 ROOT=..
 SBE_TOOL_VERSION=$(shell cat $(ROOT)/version.txt)
 SBE_JAR=$(ROOT)/sbe-all/build/libs/sbe-all-${SBE_TOOL_VERSION}.jar
-
-#JAVA=/usr/lib/jvm/java-8-openjdk-amd64/bin/java
-JAVA=java
-
-TESTDIR=$(ROOT)/sbe-tool/src/test/golang
-
-JAVA_FILES="-jar ${SBE_JAR}"
-
 # FIXME: Go doesn't like relative paths so us a gnumake extension for now
 GOPATH=$(realpath $(ROOT)/gocode)
-OUTPUTDIR=$(GOPATH)/src
-XMLLOCAL=$(GOPATH)/resources
 
-# Local examples to get started
-SIMPLE=$(XMLLOCAL)/simple.xml
-COMPOSITE=$(XMLLOCAL)/example-composite.xml
-
-# Existing test cases
-XMLTESTDIR=$(ROOT)/sbe-tool/src/test/resources
-BASIC_TYPES=$(XMLTESTDIR)/basic-types-schema.xml
-BASIC_GROUP=$(XMLTESTDIR)/basic-group-schema.xml
-BASIC_VARDATA=$(XMLTESTDIR)/basic-variable-length-schema.xml
-COMPOSITE4=$(XMLTESTDIR)/composite-elements-schema-rc4.xml
-NESTED_GROUP=$(XMLTESTDIR)/group-with-data-schema.xml
-FIX_BINARY=$(XMLTESTDIR)/FixBinary.xml
-
-SCHEMA_DIR=$(ROOT)/sbe-samples/src/main/resources
-EXAMPLES_SCHEMA=$(SCHEMA_DIR)/example-schema.xml
-EXTENSION_SCHEMA=$(SCHEMA_DIR)/example-extension-schema.xml
-EXTENSION2_SCHEMA=$(XMLLOCAL)/example-extension-2-schema.xml
-BIGENDIAN_SCHEMA=$(XMLLOCAL)/example-bigendian.xml
-GROUP_EXTENSION=$(XMLLOCAL)/group-with-data-extension-schema.xml
 
 # Convenience during development
 #SAVE_FORMAT=mkdir -p fmt && cp *.go fmt &&
 SAVE_FORMAT=
 
-$(OUTPUTDIR)/example-schema/example-schema: $(SBE_JAR) $(OUTPUTDIR)/baseline/SbeMarshalling.go $(OUTPUTDIR)/baseline-bigendian/SbeMarshalling.go $(OUTPUTDIR)/extension/SbeMarshalling.go $(OUTPUTDIR)/extension2/SbeMarshalling.go $(OUTPUTDIR)/example-schema/CarExample.go $(OUTPUTDIR)/example-schema/CarExample_test.go
+all: example test # bench
+
+
+# This target is used to build golang files using parent gradle
+# script's invocation of sbe-tool in case it needs to be run again. We
+# use this one output file to check that dependency as it's simple
+DEP=src/simple/SbeMarshalling.go
+$(DEP): $(SBE_JAR)
+	(cd ..; gradlew generateGolangCodecs)
 	(export GOPATH=$(GOPATH) && \
-	cd $(OUTPUTDIR)/example-schema && \
+	cd src/simple && \
+	go build && \
+	$(SAVE_FORMAT) \
+	go fmt && \
+	go test)
+
+# Wil regenerate codecs by removing dependencies
+clean:
+	rm -f src/*/SbeMarshalling.go src/*/*/SbeMarshalling.go
+
+# Example code and benchmarking 
+example: src/example-schema/example-schema
+src/example-schema/example-schema: $(DEP)
+	(export GOPATH=$(GOPATH) && \
+	cd src/example-schema && \
 	go build && \
 	go fmt && \
 	./example-schema)
 
-clean:
-	rm -f $(OUTPUTDIR)/*/SbeMarshalling.go $(OUTPUTDIR)/*/*/SbeMarshalling.go
-
-$(OUTPUTDIR)/baseline/SbeMarshalling.go: $(SBE_JAR)
-	$(JAVA) \
-	-Dsbe.output.dir=$(OUTPUTDIR) \
-	-Dsbe.generate.ir="false" \
-	-Dsbe.target.language="golang" \
-	-jar ${SBE_JAR} \
-	$(EXAMPLES_SCHEMA)
+bench: $(DEP) src/example-schema/example-schema.test
 	(export GOPATH=$(GOPATH) && \
-        cd $(OUTPUTDIR)/baseline && \
-	go build && \
-	go fmt && \
-	go test && \
-	go install)
-
-$(OUTPUTDIR)/baseline-bigendian/SbeMarshalling.go: $(SBE_JAR)
-	$(JAVA) \
-	-Dsbe.output.dir=$(OUTPUTDIR) \
-	-Dsbe.generate.ir="false" \
-	-Dsbe.target.language="golang" \
-	-jar ${SBE_JAR} \
-	$(BIGENDIAN_SCHEMA)
-	(export GOPATH=$(GOPATH) && \
-        cd $(OUTPUTDIR)/baseline-bigendian && \
-	go build && \
-	go fmt && \
-	go test && \
-	go install)
-
-$(OUTPUTDIR)/extension/SbeMarshalling.go: $(SBE_JAR)
-	$(JAVA) \
-	-Dsbe.output.dir=$(OUTPUTDIR) \
-	-Dsbe.generate.ir="false" \
-	-Dsbe.target.language="golang" \
-	-jar ${SBE_JAR} \
-	$(EXTENSION_SCHEMA) && \
-	(export GOPATH=$(GOPATH) && \
-        cd $(OUTPUTDIR)/extension && \
-	go build && \
-	go install)
-
-$(OUTPUTDIR)/extension2/SbeMarshalling.go: $(SBE_JAR)
-	$(JAVA) \
-	-Dsbe.output.dir=$(OUTPUTDIR) \
-	-Dsbe.generate.ir="false" \
-	-Dsbe.target.language="golang" \
-	-jar ${SBE_JAR} \
-	$(EXTENSION2_SCHEMA) && \
-	(export GOPATH=$(GOPATH) && \
-        cd $(OUTPUTDIR)/extension2 && \
-	go build && \
-	go install)
-
-bench: $(SBE_JAR) $(OUTPUTDIR)/example-schema/example-schema
-	(export GOPATH=$(GOPATH) && \
-        cd $(OUTPUTDIR)/example-schema && \
+        cd src/example-schema && \
 	go test --bench . -cpuprofile=cpu.out && \
 	go tool pprof -text example-schema.test cpu.out)
 
-test: fix-binary nested-group nested-group-extension basic-vardata basic-group basic-types simple composite composite-elements
-
-fix-binary:
-	$(JAVA) \
-	-Dsbe.output.dir=$(OUTPUTDIR) \
-	-Dsbe.target.language=golang \
-	-Dfile.encoding=US-ASCII \
-	-Duser.country=US \
-	-Duser.langimuage=en \
-	-Duser.variant \
-	-jar ${SBE_JAR} \
-	$(FIX_BINARY)
+src/baseline/SbeMarshalling.go: $(DEP)
+	$(GOPATH)/sbe-tool -d src -s $(EXAMPLES_SCHEMA)
 	(export GOPATH=$(GOPATH) && \
-	cd $(OUTPUTDIR)/mktdata && \
+        cd src/baseline && \
 	go build && \
-	$(SAVE_FORMAT) \
-	go fmt && echo && \
-	go test)
+	go fmt && \
+	go test && \
+	go install)
 
-# Note this one installs so it can be used in the extension below
-nested-group:
-	$(JAVA) \
-	-Dsbe.output.dir=$(OUTPUTDIR) \
-	-Dsbe.target.language=golang \
-	-Dfile.encoding=US-ASCII \
-	-Duser.country=US \
-	-Duser.langimuage=en \
-	-Duser.variant \
-	-jar ${SBE_JAR} \
-	$(NESTED_GROUP)
+# The first set does a make install as there is a test that uses
+# multiple packages and needs them in GOPATH The second set work in
+# src/foo, and the third need a GOPATH addition as for Java and C++
+# they geenrate into the same directory but golang doesn't allow that
+test: $(DEP)
 	(export GOPATH=$(GOPATH) && \
-	cd $(OUTPUTDIR)/group_with_data && \
-	go build && \
-	$(SAVE_FORMAT) \
-	go fmt && echo && \
-	go install && \
-	go test)
-
-nested-group-extension:
-	$(JAVA) \
-	-Dsbe.output.dir=$(OUTPUTDIR) \
-	-Dsbe.target.language=golang \
-	-Dfile.encoding=US-ASCII \
-	-Duser.country=US \
-	-Duser.langimuage=en \
-	-Duser.variant \
-	-jar ${SBE_JAR} \
-	$(GROUP_EXTENSION)
+		(for t in baseline extension extension2; do \
+		export GOPATH=$(GOPATH) && \
+	        cd $(GOPATH)/src/$$t && \
+		go build && \
+		go fmt && \
+		go test && \
+		go install \
+		;done))
 	(export GOPATH=$(GOPATH) && \
-	cd $(OUTPUTDIR)/group_with_data_extension && \
-	go build && \
-	$(SAVE_FORMAT) \
-	go fmt && echo && \
-	go test)
-
-composite-elements:
-	$(JAVA) \
-	-Dsbe.output.dir=$(OUTPUTDIR) \
-	-Dsbe.target.language=golang \
-	-Dfile.encoding=US-ASCII \
-	-Duser.country=US \
-	-Duser.langimuage=en \
-	-Duser.variant \
-	-jar ${SBE_JAR} \
-	$(COMPOSITE4)
-	(export GOPATH=$(GOPATH) && \
-	cd $(OUTPUTDIR)/composite_elements && \
-	go build && \
-	$(SAVE_FORMAT) \
-	go fmt && echo && \
-	go test)
-
-basic-vardata:
-	$(JAVA) \
-	-Dsbe.output.dir=$(OUTPUTDIR)/vardata \
-	-Dsbe.target.language=golang \
-	-Dfile.encoding=US-ASCII \
-	-Duser.country=US \
-	-Duser.langimuage=en \
-	-Duser.variant \
-	-jar ${SBE_JAR} \
-	$(BASIC_VARDATA)
-	(export GOPATH=$(GOPATH)/vardata && \
-	cd $(OUTPUTDIR)/vardata/'SBE tests' && \
-	go build && \
-	$(SAVE_FORMAT) \
-	go fmt && echo && \
-	go test)
-
-basic-group:
-	$(JAVA) \
-	-Dsbe.output.dir=$(OUTPUTDIR)/group \
-	-Dsbe.target.language=golang \
-	-Dfile.encoding=US-ASCII \
-	-Duser.country=US \
-	-Duser.language=en \
-	-Duser.variant \
-	-jar ${SBE_JAR} \
-	$(BASIC_GROUP)
-	(export GOPATH=$(GOPATH)/group && \
-	cd $(OUTPUTDIR)/group/'SBE tests' && \
-	go build && \
-	$(SAVE_FORMAT) \
-	go fmt && echo && \
-	go test)
-
-basic-types:
-	$(JAVA) \
-	-Dsbe.output.dir=$(OUTPUTDIR)/basic \
-	-Dsbe.target.language=golang \
-	-Dfile.encoding=US-ASCII \
-	-Duser.country=US \
-	-Duser.language=en \
-	-Duser.variant \
-	-jar ${SBE_JAR} \
-	$(BASIC_TYPES)
-	(export GOPATH=$(GOPATH)/basic && \
-	cd $(OUTPUTDIR)/basic/'SBE tests' && \
-	go build && \
-	$(SAVE_FORMAT) \
-	go fmt && echo && \
-	go test)
-
-
-composite:
-	$(JAVA) \
-	-Dsbe.output.dir=$(OUTPUTDIR) \
-	-Dsbe.target.language=golang \
-	-Dfile.encoding=US-ASCII \
-	-Duser.country=US \
-	-Duser.language=en \
-	-Duser.variant \
-	-jar ${SBE_JAR} \
-	$(COMPOSITE)
-	(export GOPATH=$(GOPATH) && \
-	cd $(OUTPUTDIR)/composite && \
-	$(SAVE_FORMAT) \
-	go fmt && echo && \
-	go test)
-
-simple:
-	$(JAVA) \
-	-Dsbe.output.dir=$(OUTPUTDIR) \
-	-Dsbe.target.language=golang \
-	-Dfile.encoding=US-ASCII \
-	-Duser.country=US \
-	-Duser.language=en \
-	-Duser.variant \
-	-jar ${SBE_JAR} \
-	$(SIMPLE)
-	(export GOPATH=$(GOPATH) && \
-	cd $(OUTPUTDIR)/simple && \
-	go build && \
-	$(SAVE_FORMAT) \
-	go fmt && echo && \
-	go test)
+		(for t in mktdata group_with_data group_with_data_extension composite_element composite simple; do \
+		cd $(GOPATH)/src/$$t && \
+		go build && \
+		go fmt && \
+		go test \
+		;done))
+	(for t in vardata group basic; do \
+		export GOPATH=$(GOPATH)/$$t && \
+		cd $(GOPATH)/src/$$t/'SBE tests' && \
+		go build && \
+		go fmt && \
+		go test \
+		;done)

--- a/gocode/README.md
+++ b/gocode/README.md
@@ -1,45 +1,24 @@
 Overview
 ========
 
-The generated golang code attempts to match golang idioms where such
-choices are both possible and reasonable.
-
-The golang SBE backend represents FIX messages as golang types and
-provides Encode and Decode methods for these types and their embedded
-elements. This differs from the Java and C++ implementations that provide a
-flyweight idiom and has some important ramifications.
-
-Firstly, any semantic checking of values is not performed by a
-Getter/Setter method but is instead performed in the Encode and Decode
-methods. In general the Encode methods attempt to be strictly
-enforcing to ensure only valid SBE is emitted. Where it remains within
-the standard the Decode methods attempt to be forgiving in their
-interpretation.
-
-To maintain consistency of datastreams, `Encode()` will fail without
-writing to the stream, and `Decode()` will fail but will have read (and
-where possible decoded) an entire message from the stream.
-
-Secondly, constant values are not set when an object is created. As
-golang does not provide constructors, we instead have each support
-type `Foo` provide a `FooInit()` function which will fill out constant
-values. Decoding automatically fills out constant values.
-
-Some design decisions are based around the structure of sbe-tool
-itself. sbe-tool parses the XML into an internal representation (IR)
-and then passes this to the language specific generator. As a result
-some information on the xml structure has been lost.
-
-An examples of this include the use of the `<ref>` tag which if used to
-the same underlying type in a composite will create two differently
-named definitions of the type in the IR.
-
-A second example occurs where a field references an aliased primitive
-type definition in which case we lose the aliased type name in the IR
-as it is unreferenced.
+There is now a [user
+guide]https://github.com/real-logic/simple-binary-encoding/wiki/Golang-User-Guide
+and this document is for development of the SBE golang generator.
 
 Code Layout
 -----------
+The Java code that performs the generation of golang code is
+[here]https://github.com/real-logic/simple-binary-encoding/tree/master/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang.
+
+Golang code used for testing resides in the top-level [gocode
+directory]https://github.com/real-logic/simple-binary-encoding/tree/master/gocode
+
+Building and testing
+--------------------
+At some point teh golang build will be better integrated into
+gradle. For the time being some instructions/procedures are encoded
+into a gnu Makefile in the top level gocode directory
+
 To match golang's requirement on directory structure and file layout,
 the build environment, example and test code are structured into a top
 level gocode directory hierarchy.
@@ -56,75 +35,37 @@ supplied Makefile which does this for you. For the tests you will need
 to not have `GOPATH` set or use the supplied Makefile which does this
 for you.
 
-Alpha Code Warning
-------------------
-The golang generator is still under development and the provided APIs
-are still subject to change. Some design decisions remain
-open. Currently the Car example (and extension) works but this is not
-an exhaustive set of features.
+
+Available make targets are:
+
+```example``` will generate golang for the example schema (and
+extensions) and run some test code that goes with it.
+
+```test``` will generate golang for some test schemas and run some
+test code for them.
+
+```bench``` will run some benchmarking code based on the Car example.
 
 
-Design Notes
-============
-
-Primitive Types
----------------
-Most Primitive types map well to golang basic types. Character arrays
-are represented as either fixed or variable sized byte arrays.
-
-Unicode
--------
-The SBE spec allows character arrays and vardata elements to specify a
-character encoding such as "ASCII" or "UTF-8". For vardata this is
-additionally allowed on integral types such as uint8. The spec does
-not mandate a set of supported encodings but golang currently supports:
- * ASCII
- * UTF-8
-
-Enumerations and Choices
-------------------------
-golang does not have an enumeration type and so enums are represented
-as a type and a variable with the known constant values is
-provided. To preserve name uniqueness within a message the const
-values contain the enum type name.
-
-Range Checking of enumeration values is only performed when the
-schemaVersion is equal to or greater than the actingVersion so that
-new enumeration values are allowed to propogate to older decoders.
-
-Messages and Composites
------------------------
-Messages and composites are both represented as golang structures with
-`Encode()` and `Decode()` methods amongst others.
-
-Groups and VarData
-------------------
-Groups and VarData are represented as arrays with their NumInGroup
-being implicit in `len()`
-
-Semantic Types
+Design choices
 --------------
-The golang generator provides no special support for semantic
-types (as for Java and C++).
+Most of the design choice rationale is contained in the user guide
+however, Some design decisions are based around the structure of
+sbe-tool itself. sbe-tool parses the XML into an internal
+representation (IR) and then passes this to the language specific
+generator. As a result some information on the xml structure has been
+lost.
 
-The `Boolean` semantic type is not represented as a golang `bool` as the
-spec requires that discrepancies between SinceVersion and
-ActingVersion can be resolved using the NullValue.
+The first example of this include the use of the `<ref>` tag which if
+used to the same underlying type in a composite will create two
+differently named definitions of the type in the IR.
 
-The `String` semantic type is simply represented as a byte array as
-golang Strings are immutable and are not useful in structures.
-
-The `UTCTimestamp`, `UTCTimeOnly`, `UTCDateOnly` and `MktTime` semantic types
-are not represented as a golang `Time` type as none of these semantic
-types contain a location. Mapping to a golang `Time` type will be
-relatively easy for the application developer who will know the
-location and can set it accordingly (null is UTC). They can also
-decide what to with golang `Time`'s nanosecond timer when converting
-(probably treating it as zero).
+A second example occurs where a field references an aliased primitive
+type definition in which case we lose the aliased type name in the IR
+as it is unreferenced.
 
 Roadmap
 =======
- * Further examples and doumentation
  * Windows developer support (currently tested on Linux/MacOS)
  * Unnecessary code removal (e.g., GroupSizeEncoding)
  * Further Unicode support

--- a/gocode/resources/simple.xml
+++ b/gocode/resources/simple.xml
@@ -8,7 +8,7 @@
                    byteOrder="littleEndian">
     <types>
         <composite name="messageHeader" description="Message identifiers and length of message root">
-            <type name="blockLength" primitiveType="uint16"/>
+            <type name="blockLength" primitiveType="uint8"/>
             <type name="templateId" primitiveType="uint16"/>
             <type name="schemaId" primitiveType="uint16"/>
             <type name="version" primitiveType="uint16"/>
@@ -27,7 +27,10 @@
     </types>
     <sbe:message name="Simple0" id="11" semanticType="womble" description="A very simple first example" blockLength="76">
         <field name="U64nv"   id="10"  type="uint64nv" sinceVersion="1"/>
-        <field name="U64"     id="20"  type="uint64" deprecated="2" sinceVersion="1" presence="optional" nullValue="18446744073709551615"/>
+        <!-- open spec issue on whether this can be allowed 
+             <field name="U64"     id="20"  type="uint64" deprecated="2" sinceVersion="1" presence="optional" nullValue="18446744073709551615"/>
+        -->
+        <field name="U64"     id="20"  type="uint64" deprecated="2" sinceVersion="1"/>
         <field name="U32"     id="30"  type="uint32"/>
         <field name="U16"     id="40"  type="uint16"/>
         <field name="U8"      id="50"  type="uint8"/>

--- a/gocode/sbe-tool
+++ b/gocode/sbe-tool
@@ -1,0 +1,42 @@
+#! /usr/bin/env bash
+
+ROOTDIR=`dirname $0`/..
+SBE_TOOL_VERSION=`cat $ROOTDIR/version.txt`
+SBE_JAR=$ROOTDIR/sbe-all/build/libs/sbe-all-$SBE_TOOL_VERSION.jar
+
+[ -f $SBE_JAR ] || (echo "Missing $SBE_JAR. Run gradle first"; exit 1)
+
+function usage {
+    echo usage: `basename $0` [-d output_dir] -s schema
+}
+
+# defaults
+OUTPUTDIR=.
+
+while getopts "d:s:" OPT "$@"; do
+    case $OPT in
+    d)
+        OUTPUTDIR=$OPTARG
+        ;;
+    s)
+        SCHEMA=$OPTARG
+        ;;
+    *)
+        echo $OPT
+        usage
+        exit 1
+        ;;
+    esac
+done
+shift $(($OPTIND - 1))
+
+# Check args
+[ -z $SCHEMA ] && (usage; exit 1)
+[ -f $SCHEMA ] || (echo invalid schema $SCHEMA; exit 1)
+
+java \
+-Dsbe.output.dir=$OUTPUTDIR \
+-Dsbe.generate.ir="false" \
+-Dsbe.target.language="golang" \
+-jar $SBE_JAR \
+$SCHEMA

--- a/gocode/src/baseline-bigendian/Car_test.go
+++ b/gocode/src/baseline-bigendian/Car_test.go
@@ -122,7 +122,7 @@ func TestDecodeJavaBuffer(t *testing.T) {
 	buf := bytes.NewBuffer(data)
 	m := NewSbeGoMarshaller()
 
-	var hdr SbeGoMessageHeader
+	var hdr MessageHeader
 	if err := hdr.Decode(m, buf); err != nil {
 		t.Logf("Failed to decode message header", err)
 		t.Fail()

--- a/gocode/src/baseline/Car_test.go
+++ b/gocode/src/baseline/Car_test.go
@@ -120,7 +120,7 @@ func TestDecodeJavaBuffer(t *testing.T) {
 	buf := bytes.NewBuffer(data)
 	m := NewSbeGoMarshaller()
 
-	var hdr SbeGoMessageHeader
+	var hdr MessageHeader
 	if err := hdr.Decode(m, buf); err != nil {
 		t.Logf("Failed to decode message header", err)
 		t.Fail()

--- a/gocode/src/composite/Composite_test.go
+++ b/gocode/src/composite/Composite_test.go
@@ -23,24 +23,24 @@ func TestEncodeDecode(t *testing.T) {
 	t.Log(in, " -> ", cbuf.Bytes())
 	t.Log("Cap() = ", cbuf.Cap(), "Len() = \n", cbuf.Len())
 
-	hdr := SbeGoMessageHeader{in.SbeBlockLength(), in.SbeTemplateId(), in.SbeSchemaId(), in.SbeSchemaVersion()}
+	hdr := MessageHeader{in.SbeBlockLength(), in.SbeTemplateId(), in.SbeSchemaId(), in.SbeSchemaVersion()}
 	var mbuf = new(bytes.Buffer)
 	if err := hdr.Encode(m, mbuf); err != nil {
-		t.Log("SbeGoMessageHeader Encoding Error", err)
+		t.Log("MessageHeader Encoding Error", err)
 		t.Fail()
 	}
 	t.Log(hdr, " -> ", mbuf.Bytes())
 	t.Log("Cap() = ", mbuf.Cap(), "Len() = \n", mbuf.Len())
 
-	// Create a new empty SbeGoMessageHeader and Composite
-	hdr = *new(SbeGoMessageHeader)
+	// Create a new empty MessageHeader and Composite
+	hdr = *new(MessageHeader)
 	var out Composite = *new(Composite)
 
 	if err := hdr.Decode(m, mbuf); err != nil {
-		t.Log("SbeGoMessageHeader Decoding Error", err)
+		t.Log("MessageHeader Decoding Error", err)
 		t.Fail()
 	}
-	t.Log("SbeGoMessageHeader Decodes as: ", m)
+	t.Log("MessageHeader Decodes as: ", m)
 	t.Log("Cap() = ", mbuf.Cap(), "Len() = \n", mbuf.Len())
 
 	if err := out.Decode(m, cbuf, in.SbeSchemaVersion(), in.SbeBlockLength(), true); err != nil {

--- a/gocode/src/example-schema/CarExample.go
+++ b/gocode/src/example-schema/CarExample.go
@@ -131,7 +131,7 @@ func ExampleDecodeBuffer() bool {
 	buf := bytes.NewBuffer(data)
 	m := baseline.NewSbeGoMarshaller()
 
-	var hdr baseline.SbeGoMessageHeader
+	var hdr baseline.MessageHeader
 	if err := hdr.Decode(m, buf); err != nil {
 		fmt.Println("Failed to decode message header", err)
 		os.Exit(1)
@@ -173,7 +173,7 @@ func ExampleDecodePipe() bool {
 		}
 	}()
 
-	var hdr baseline.SbeGoMessageHeader
+	var hdr baseline.MessageHeader
 	hdr.Decode(m, r)
 
 	var c baseline.Car
@@ -217,7 +217,7 @@ func ExampleDecodeSocket() bool {
 		defer conn.Close()
 
 		// fmt.Println("reading messageheader")
-		var hdr baseline.SbeGoMessageHeader
+		var hdr baseline.MessageHeader
 		hdr.Decode(m, conn)
 
 		// fmt.Println("reading car")

--- a/gocode/src/example-schema/CarExample_test.go
+++ b/gocode/src/example-schema/CarExample_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"baseline"
+	"bufio"
 	"bytes"
 	"io"
 	"testing"
@@ -151,6 +152,26 @@ func BenchmarkDecodeLax(b *testing.B) {
 		}
 	}
 }
+func xBenchmarkDecodeLaxBufio(b *testing.B) {
+	car := makeCar()
+	m := baseline.NewSbeGoMarshaller()
+	var buf = new(bytes.Buffer)
+	for i := 0; i < b.N; i++ {
+		if err := car.Encode(m, buf, false); err != nil {
+			b.Logf("Encoding Error", err)
+			b.Fail()
+		}
+	}
+
+	buf2 := bufio.NewReader(buf)
+	b.ResetTimer()
+	for i := 0; i < b.N; i++ {
+		if err := car.Decode(m, buf2, car.SbeSchemaVersion(), car.SbeBlockLength(), false); err != nil {
+			b.Logf("Decoding Error", err)
+			b.Fail()
+		}
+	}
+}
 
 func BenchmarkPipe(b *testing.B) {
 	var r, w = io.Pipe()
@@ -169,7 +190,7 @@ func BenchmarkPipe(b *testing.B) {
 		}
 	}()
 
-	var hdr baseline.SbeGoMessageHeader
+	var hdr baseline.MessageHeader
 	var c baseline.Car
 	m := baseline.NewSbeGoMarshaller()
 	<-writerReady
@@ -177,6 +198,40 @@ func BenchmarkPipe(b *testing.B) {
 	for i := 0; i < b.N; i++ {
 		hdr.Decode(m, r)
 		if err := c.Decode(m, r, hdr.Version, hdr.BlockLength, false); err != nil {
+			b.Logf("Failed to decode car", err)
+			b.Fail()
+		}
+	}
+	r.Close()
+}
+
+func BenchmarkPipeBufio(b *testing.B) {
+	var r, w = io.Pipe()
+	var data []byte = []byte{47, 0, 1, 0, 1, 0, 0, 0, 210, 4, 0, 0, 0, 0, 0, 0, 221, 7, 1, 65, 0, 0, 0, 0, 1, 0, 0, 0, 2, 0, 0, 0, 3, 0, 0, 0, 4, 0, 0, 0, 97, 98, 99, 100, 101, 102, 6, 208, 7, 4, 49, 50, 51, 78, 200, 6, 0, 3, 0, 30, 0, 154, 153, 15, 66, 11, 0, 0, 0, 85, 114, 98, 97, 110, 32, 67, 121, 99, 108, 101, 55, 0, 0, 0, 68, 66, 14, 0, 0, 0, 67, 111, 109, 98, 105, 110, 101, 100, 32, 67, 121, 99, 108, 101, 75, 0, 0, 0, 32, 66, 13, 0, 0, 0, 72, 105, 103, 104, 119, 97, 121, 32, 67, 121, 99, 108, 101, 1, 0, 2, 0, 95, 6, 0, 3, 0, 30, 0, 0, 0, 128, 64, 60, 0, 0, 0, 240, 64, 100, 0, 51, 51, 67, 65, 99, 6, 0, 3, 0, 30, 0, 51, 51, 115, 64, 60, 0, 51, 51, 227, 64, 100, 0, 205, 204, 60, 65, 5, 0, 0, 0, 72, 111, 110, 100, 97, 9, 0, 0, 0, 67, 105, 118, 105, 99, 32, 86, 84, 105, 6, 0, 0, 0, 97, 98, 99, 100, 101, 102}
+	writerReady := make(chan bool)
+
+	go func() {
+		defer w.Close()
+		writerReady <- true
+		// By way of test, stream the bytes into the pipe a
+		// chunk at a time
+		for looping := true; looping; {
+			if _, err := w.Write(data); err != nil {
+				looping = false
+			}
+		}
+	}()
+
+	var hdr baseline.MessageHeader
+	var c baseline.Car
+	m := baseline.NewSbeGoMarshaller()
+	<-writerReady
+	b.ResetTimer()
+	buf := bufio.NewReader(r)
+
+	for i := 0; i < b.N; i++ {
+		hdr.Decode(m, r)
+		if err := c.Decode(m, buf, hdr.Version, hdr.BlockLength, false); err != nil {
 			b.Logf("Failed to decode car", err)
 			b.Fail()
 		}

--- a/gocode/src/example-socket-clientserver/clientserver.go
+++ b/gocode/src/example-socket-clientserver/clientserver.go
@@ -76,7 +76,7 @@ func mainReader(doDecode bool, iterations int) {
 			}
 		}
 	} else {
-		var h baseline.SbeGoMessageHeader
+		var h baseline.MessageHeader
 		m := baseline.NewSbeGoMarshaller()
 		for i := 0; i < iterations; i++ {
 			if err := h.Decode(m, conn); err != nil {
@@ -124,7 +124,7 @@ func mainWriter(doEncode bool, iterations int) {
 				}
 			}
 		} else {
-			var h = baseline.SbeGoMessageHeader{car.SbeBlockLength(), car.SbeTemplateId(), car.SbeSchemaId(), car.SbeSchemaVersion()}
+			var h = baseline.MessageHeader{car.SbeBlockLength(), car.SbeTemplateId(), car.SbeSchemaId(), car.SbeSchemaVersion()}
 			m := baseline.NewSbeGoMarshaller()
 			for i := 0; i < iterations; i++ {
 				if err := h.Encode(m, conn); err != nil {

--- a/gocode/src/mktdata/fixme_test.go
+++ b/gocode/src/mktdata/fixme_test.go
@@ -6,5 +6,5 @@ import (
 )
 
 func TestFixme(t *testing.T) {
-	fmt.Println("FIXME")
+	fmt.Println("No tests implemented here")
 }

--- a/gocode/src/simple/simple_test.go
+++ b/gocode/src/simple/simple_test.go
@@ -18,24 +18,24 @@ func TestEncodeDecode(t *testing.T) {
 	t.Log(in, " -> ", sbuf.Bytes())
 	t.Log("Cap() = ", sbuf.Cap(), "Len() = ", sbuf.Len())
 
-	hdr := SbeGoMessageHeader{in.SbeBlockLength(), in.SbeTemplateId(), in.SbeSchemaId(), in.SbeSchemaVersion()}
+	hdr := MessageHeader{in.SbeBlockLength(), in.SbeTemplateId(), in.SbeSchemaId(), in.SbeSchemaVersion()}
 	var mbuf = new(bytes.Buffer)
 	if err := hdr.Encode(m, mbuf); err != nil {
-		t.Log("SbeGoMessageHeader Encoding Error", err)
+		t.Log("MessageHeader Encoding Error", err)
 		t.Fail()
 	}
 	t.Log(hdr, " -> ", mbuf.Bytes())
 	t.Log("Cap() = ", mbuf.Cap(), "Len() = ", mbuf.Len())
 
-	// Create a new empty SbeGoMessageHeader and Simple0
-	hdr = *new(SbeGoMessageHeader)
+	// Create a new empty MessageHeader and Simple0
+	hdr = *new(MessageHeader)
 	var out Simple0 = *new(Simple0)
 
 	if err := hdr.Decode(m, mbuf); err != nil {
-		t.Log("SbeGoMessageHeader Decoding Error", err)
+		t.Log("MessageHeader Decoding Error", err)
 		t.Fail()
 	}
-	t.Log("SbeGoMessageHeader Decodes as: ", m)
+	t.Log("MessageHeader Decodes as: ", m)
 	t.Log("Cap() = ", mbuf.Cap(), "Len() = ", mbuf.Len())
 
 	if err := out.Decode(m, sbuf, in.SbeSchemaVersion(), in.SbeBlockLength(), true); err != nil {

--- a/sbe-tool/src/main/resources/golang/templates/SbeMarshallingBigEndian.go
+++ b/sbe-tool/src/main/resources/golang/templates/SbeMarshallingBigEndian.go
@@ -24,39 +24,7 @@ import (
 	"math"
 )
 
-type SbeGoMessageHeader struct {
-	BlockLength uint16
-	TemplateId  uint16
-	SchemaId    uint16
-	Version     uint16
-}
-
-func (m SbeGoMessageHeader) Encode(_m *SbeGoMarshaller, _w io.Writer) error {
-	_m.b8[1] = byte(m.BlockLength)
-	_m.b8[0] = byte(m.BlockLength >> 8)
-	_m.b8[3] = byte(m.TemplateId)
-	_m.b8[2] = byte(m.TemplateId >> 8)
-	_m.b8[5] = byte(m.SchemaId)
-	_m.b8[4] = byte(m.SchemaId >> 8)
-	_m.b8[7] = byte(m.Version)
-	_m.b8[6] = byte(m.Version >> 8)
-	if _, err := _w.Write(_m.b8); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (m *SbeGoMessageHeader) Decode(_m *SbeGoMarshaller, _r io.Reader) error {
-	if _, err := io.ReadFull(_r, _m.b8); err != nil {
-		return err
-	}
-	m.BlockLength = uint16(_m.b8[1]) | uint16(_m.b8[0])<<8
-	m.TemplateId = uint16(_m.b8[3]) | uint16(_m.b8[2])<<8
-	m.SchemaId = uint16(_m.b8[5]) | uint16(_m.b8[4])<<8
-	m.Version = uint16(_m.b8[7]) | uint16(_m.b8[6])<<8
-	return nil
-}
-
+// Allocate via NewSbeGoMarshaller to initialize
 type SbeGoMarshaller struct {
 	b8 []byte // statically allocated tmp space to avoid alloc
 	b1 []byte // previously created slice into b to save time

--- a/sbe-tool/src/main/resources/golang/templates/SbeMarshallingLittleEndian.go
+++ b/sbe-tool/src/main/resources/golang/templates/SbeMarshallingLittleEndian.go
@@ -24,39 +24,7 @@ import (
 	"math"
 )
 
-type SbeGoMessageHeader struct {
-	BlockLength uint16
-	TemplateId  uint16
-	SchemaId    uint16
-	Version     uint16
-}
-
-func (m SbeGoMessageHeader) Encode(_m *SbeGoMarshaller, _w io.Writer) error {
-	_m.b8[0] = byte(m.BlockLength)
-	_m.b8[1] = byte(m.BlockLength >> 8)
-	_m.b8[2] = byte(m.TemplateId)
-	_m.b8[3] = byte(m.TemplateId >> 8)
-	_m.b8[4] = byte(m.SchemaId)
-	_m.b8[5] = byte(m.SchemaId >> 8)
-	_m.b8[6] = byte(m.Version)
-	_m.b8[7] = byte(m.Version >> 8)
-	if _, err := _w.Write(_m.b8); err != nil {
-		return err
-	}
-	return nil
-}
-
-func (m *SbeGoMessageHeader) Decode(_m *SbeGoMarshaller, _r io.Reader) error {
-	if _, err := io.ReadFull(_r, _m.b8); err != nil {
-		return err
-	}
-	m.BlockLength = uint16(_m.b8[0]) | uint16(_m.b8[1])<<8
-	m.TemplateId = uint16(_m.b8[2]) | uint16(_m.b8[3])<<8
-	m.SchemaId = uint16(_m.b8[4]) | uint16(_m.b8[5])<<8
-	m.Version = uint16(_m.b8[6]) | uint16(_m.b8[7])<<8
-	return nil
-}
-
+// Allocate via NewSbeGoMarshaller to initialize
 type SbeGoMarshaller struct {
 	b8 []byte // statically allocated tmp space to avoid alloc
 	b1 []byte // previously created slice into b to save time


### PR DESCRIPTION
Much improved documentation moving much content into wiki.

MessageHeader's are now allowed to be any unsigned integer type,
rather than just uint16. This causes a small API change as MessageHeaders
are now generated

Added gradlew generateGolangCodec target to create golang source
code using sbe-tool. This assists windows developers by providing
a convenience target and examples and simplifies the still
linux-centric gnu Makefile.

Add an example using bufio so that reads and writes get merged
for performance.