### PR TITLE
Made lengthOfType inline

### DIFF
--- a/sbe-tool/src/main/cpp/otf/Encoding.h
+++ b/sbe-tool/src/main/cpp/otf/Encoding.h
@@ -97,7 +97,7 @@ enum class Presence : int
         SBE_CONSTANT = 2
 };
 
-std::size_t lengthOfType(PrimitiveType type)
+inline std::size_t lengthOfType(PrimitiveType type)
 {
     switch (type)
     {


### PR DESCRIPTION
Prevents linker errors with multiple defined symbols when including Encoding.h in multiple source files