### PR TITLE
Explain the produced Jars to avoid missuses

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,9 +83,18 @@ Run the Java examples
 
 Distribution
 ------------
-Jars for the executable, source, and javadoc for the various modules can be found in
+Jars for the executable, source, and javadoc for the various modules can be found in the following directories:
 
-    <module>/build/libs
+    sbe-benchmarks/build/libs
+    sbe-samples/build/libs
+    sbe-tool/build/libs
+    sbe-all/build/libs
+
+An example to execute a Jar from command line:
+
+    java -Dsbe.generate.ir=true -Dsbe.target.language=Cpp -Dsbe.target.namespace=sbe -Dsbe.output.dir=include/gen -Dsbe.errorLog=yes -jar sbe-tool/build/libs/sbe-tool-1.7.0-all.jar my_sbe_input.xml
+
+Note: The Jars in directory `build/libs` do not contain `META-INF/MANIFEST.MF` and the error *"no main manifest attribute"* will occur when trying to execute it.
 
 C++ Build using CMake
 ---------------------


### PR DESCRIPTION
I spent some hours to understand that I was trying to execute the wrong Jar:  
I was wondering for hours what was wrong in the building process about produced `build/libs/sbe-all-1.7.0.jar` without `META-INF/MANIFEST.MF`... 😞 

I think I am not alone because it was also the issue #324

Instead of creating a new issue to request someone to document that point, I propose in this pull reuest to provide some documentation in the README.md about produced Jars, and also a warning to prevent using the wrong Jars.

It is important to keep the error message *"no main manifest attribute"* within the README.md in case someone is searching this error on the GitHub project or in the web (e.g. googling *"error SBE no main manifest attribute"*). With some luck this person will helpfully find this information within the README.md.