### PR TITLE
Use assumeTrue to confirm filesystem manipulation for output manager testing usable

### DIFF
--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustFlatFileOutputManagerTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustFlatFileOutputManagerTest.java
@@ -1,5 +1,6 @@
 package uk.co.real_logic.sbe.generation.rust;
 
+import org.junit.Assume;
 import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
@@ -67,7 +68,7 @@ public class RustFlatFileOutputManagerTest
     public void shouldThrowExceptionIfTargetDirNotWritable() throws IOException, InterruptedException
     {
         final File tempDir = folderRule.newFolder();
-        assertTrue(tempDir.setReadOnly());
+        Assume.assumeTrue(tempDir.setReadOnly());
         final String tempDirName = tempDir.getAbsolutePath();
 
         try


### PR DESCRIPTION
The filesystem manipulation that enables a certain kind of testing of the output manager is not supported when running tests in windows. Uses `assumeTrue` to conditionally ignore the relevant test when said capabilities are absent.