### PR TITLE
Move the static generateLiteral(...) method from JavaGenerator to JavaUtil and make it public

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -2493,49 +2493,6 @@ public class JavaGenerator implements CodeGenerator
         return sb;
     }
 
-    private String generateLiteral(final PrimitiveType type, final String value)
-    {
-        String literal = "";
-
-        final String castType = javaTypeName(type);
-        switch (type)
-        {
-            case CHAR:
-            case UINT8:
-            case INT8:
-            case INT16:
-                literal = "(" + castType + ")" + value;
-                break;
-
-            case UINT16:
-            case INT32:
-                literal = value;
-                break;
-
-            case UINT32:
-                literal = value + "L";
-                break;
-
-            case FLOAT:
-                literal = value.endsWith("NaN") ? "Float.NaN" : value + "f";
-                break;
-
-            case INT64:
-                literal = value + "L";
-                break;
-
-            case UINT64:
-                literal = "0x" + Long.toHexString(Long.parseLong(value)) + "L";
-                break;
-
-            case DOUBLE:
-                literal = value.endsWith("NaN") ? "Double.NaN" : value + "d";
-                break;
-        }
-
-        return literal;
-    }
-
     private String generateGet(final PrimitiveType type, final String index, final String byteOrder)
     {
         switch (type)

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaUtil.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaUtil.java
@@ -220,4 +220,48 @@ public class JavaUtil
             return "java.nio.charset.Charset.forName(\"" + encoding + "\")";
         }
     }
+
+    public static String generateLiteral(final PrimitiveType type, final String value)
+    {
+        String literal = "";
+
+        final String castType = javaTypeName(type);
+        switch (type)
+        {
+            case CHAR:
+            case UINT8:
+            case INT8:
+            case INT16:
+                literal = "(" + castType + ")" + value;
+                break;
+
+            case UINT16:
+            case INT32:
+                literal = value;
+                break;
+
+            case UINT32:
+                literal = value + "L";
+                break;
+
+            case FLOAT:
+                literal = value.endsWith("NaN") ? "Float.NaN" : value + "f";
+                break;
+
+            case INT64:
+                literal = value + "L";
+                break;
+
+            case UINT64:
+                literal = "0x" + Long.toHexString(Long.parseLong(value)) + "L";
+                break;
+
+            case DOUBLE:
+                literal = value.endsWith("NaN") ? "Double.NaN" : value + "d";
+                break;
+        }
+
+        return literal;
+    }
+
 }


### PR DESCRIPTION
The `JavaUtil` class contains a lot of useful methods for creating the customer-specific SBE-based tools . The `generateLiteral(final PrimitiveType type, final String value)` method is a nice addition to this toolbox.

NOTE: any objection to moving the `JavaGenerator.eachField(final List<Token> tokens, final BiConsumer<Token, Token> consumer)` method to the `JavaUtil` too? It is turned public in the current SNAPSHOT so somebody uses it already but it does not feel right to use `JavaGenerator` for utility methods.