### PR TITLE
[Rust] Remove a spurious lifetime from a parameter a slice-encoding method

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -539,8 +539,8 @@ public class RustGenerator implements CodeGenerator
         indent(out, 1).append("}\n");
 
         indent(out).append("#[inline]\n");
-        indent(out, 1, "pub fn %s_from_slice(mut self, s: &%s [%s]) -> CodecResult<%s> {\n",
-            formatMethodName(node.originalName), DATA_LIFETIME, fieldsType,
+        indent(out, 1, "pub fn %s_from_slice(mut self, s: &[%s]) -> CodecResult<%s> {\n",
+            formatMethodName(node.originalName), fieldsType,
             withLifetime(afterGroupCoderType));
         indent(out, 2, "%s.write_type::<%s>(&%s, %s)?; // block length\n",
             scratchChain, rustTypeName(node.blockLengthType),


### PR DESCRIPTION
This improves the usability of the `*_from_slice` method of encoding a group of fixed-size members all in one go by removing an unnecessary link between the input slice that will be copied and the output data buffer. The fact that we're copying bytes behind the curtains obviates the need to do more than be sure the slice lives for the duration of the method call.

Preliminary testing also shows an ~10% performance encoding improvement over the immediate alternatives and reduces client-user temptation to apply `unsafe` methods.

@mjpt777 