### PR TITLE
[Rust] Simplify done unwrapping to prevent dual mutable aliasing

### DIFF
--- a/rust/car_example/src/main.rs
+++ b/rust/car_example/src/main.rs
@@ -139,10 +139,10 @@ fn decode_car_and_assert_expected_content(buffer: &[u8]) -> CodecResult<()> {
     println!("Activation Code: {}", activation_code);
     assert_eq!("abcdef", activation_code);
 
-    let (position, buffer_back) = dec_done.unwrap();
+    let position = dec_done.unwrap();
     println!("Finished decoding. Made it to position {0} out of {1}",
              position,
-             buffer_back.len());
+             buffer.len());
     Ok(())
 }
 
@@ -202,7 +202,7 @@ fn encode_car_from_scratch() -> CodecResult<Vec<u8>> {
         let enc_model = enc_manufacturer.manufacturer("Honda".as_bytes())?;
         let enc_activation_code = enc_model.model("Civic VTi".as_bytes())?;
         let done = enc_activation_code.activation_code("abcdef".as_bytes())?;
-        let (pos, _) = done.unwrap();
+        let pos = done.unwrap();
         pos
     };
     println!("encoded up to position {}", used_pos);

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustCodecType.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustCodecType.java
@@ -118,11 +118,10 @@ enum RustCodecType
         {
             appendScratchWrappingStruct(writer, doneTypeName);
             RustGenerator.appendImplWithLifetimeHeader(writer, doneTypeName);
-            writer.append(INDENT).append(String.format("pub fn unwrap(mut self) -> (usize, &%s%s [u8]) {\n",
-                DATA_LIFETIME, this == Encoder ? " mut" : ""))
-                .append(INDENT).append(INDENT).append(format("(self.%s.pos, self.%s.data)\n",
-                scratchProperty(), scratchProperty()))
-                .append(INDENT).append("}\n");
+            indent(writer, 1, "/// Returns the number of bytes %s\n", this == Encoder ? "encoded" : "decoded");
+            indent(writer, 1, "pub fn unwrap(self) -> usize {\n");
+            indent(writer, 2, "self.%s.pos\n", scratchProperty());
+            indent(writer, 1, "}\n");
 
             appendWrapMethod(writer, doneTypeName);
             writer.append("}\n");


### PR DESCRIPTION
Previously the done-state of generated rust encoders and decoders handed back a reference to the wrapped data buffer and a the final position read/written to. Now only the final position is provided. 

This ensures that it is impossible for the mutable references data struct overlays optionally created during encoding to coexist with a same-lifetime'd mutable byte slice produced at the end.  Since the final position is still returned, and the original input buffers were all slice-references anyhow, users should be able to trivally re-slice the source data equivalently themselves without loss of functionality.

A minor performance gain is also accomplished because returning a `usize` is marginally cheaper than returning a newly-allocated tuple containing a usize and a slice-reference.

@mjpt777 