### PR TITLE
[C++ Generator]:Incorrect generation of arrays within groups

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -161,7 +161,7 @@ public class CppGenerator implements CodeGenerator
 
             final List<Token> fields = new ArrayList<>();
             i = collectFields(tokens, i, fields);
-            sb.append(generateFields(groupName, fields, indent + INDENT));
+            sb.append(generateFields(formatClassName(groupName), fields, indent + INDENT));
 
             final List<Token> groups = new ArrayList<>();
             i = collectGroups(tokens, i, groups);


### PR DESCRIPTION
I found an issue when using the java SBE tool to generate C++ code. When generating Array fields within groups the code does not compile due to the return class name on the generated Put methods being set to the group name rather than the class name. The non array fields were ok as the string generation methods call formatClassName for the return type but on the array builder it does not. I couldn't see any reason not to convert to the class name when calling generateFields so did so there.