### PR TITLE
Issue #532 `make test` in gocode directory fails

### DIFF
--- a/gocode/Makefile
+++ b/gocode/Makefile
@@ -17,7 +17,7 @@ all: example test # bench
 # use this one output file to check that dependency as it's simple
 DEP=src/simple/SbeMarshalling.go
 $(DEP): $(SBE_JAR)
-	(cd ..; gradlew generateGolangCodecs)
+	(cd ..; ./gradlew generateGolangCodecs)
 	(export GOPATH=$(GOPATH) && \
 	cd src/simple && \
 	go build && \

--- a/gocode/src/issue483/Issue483_test.go
+++ b/gocode/src/issue483/Issue483_test.go
@@ -22,6 +22,13 @@ func TestPresence(t *testing.T) {
 		t.Fail()
 	}
 
+	// Check contant value is set by init func
+	Issue483Init(issue483)
+	if issue483.Constant != 1 {
+		t.Log("Constant's value should be 1")
+		t.Fail()
+	}
+
 	if issue483.OptionalMetaAttribute(4) != "optional" {
 		t.Log("Optional attribute's presence should be 'optional'")
 		t.Fail()

--- a/sbe-tool/src/test/resources/issue483.xml
+++ b/sbe-tool/src/test/resources/issue483.xml
@@ -13,11 +13,14 @@
             <type name="schemaId" primitiveType="uint16"/>
             <type name="version" primitiveType="uint16"/>
         </composite>
+        <enum name="constval" encodingType="uint8">
+            <validValue name="one">1</validValue>
+        </enum>
     </types>
     <sbe:message name="issue483" id="1" description="issue 483 test">
-        <field name="unset" type="uint64" id="2"/>
-        <field name="required" type="uint64" id="3" presence="required"/>
-        <field name="constant" type="uint64" id="4" presence="constant"/>
-        <field name="optional" type="uint64" id="5" presence="optional"/>
+								<field name="unset" type="uint8" id="2"/>
+								<field name="required" type="uint8" id="3" presence="required"/>
+								<field name="constant" type="uint8" id="4" presence="constant" valueRef="constval.one"/>
+								<field name="optional" type="uint8" id="5" presence="optional"/>
     </sbe:message>
 </sbe:messageSchema>


### PR DESCRIPTION
Update the issue483 test case to supply a contant value as it's absence now fails code generation.

Use explicit path to gradlew to not assume '.' is in PATH.

Also reference https://github.com/FIXTradingCommunity/fix-simple-binary-encoding/issues/64 for spec change that might simplify this.