### PR TITLE
Add support of constexpr, noexcept and move semantic for Visual Studio 2015+

### DIFF
--- a/sbe-tool/src/main/cpp/sbe/sbe.h
+++ b/sbe-tool/src/main/cpp/sbe/sbe.h
@@ -74,6 +74,26 @@ namespace sbe
 #define SBE_NULLVALUE_UINT32 (std::numeric_limits<std::uint32_t>::max)()
 #define SBE_NULLVALUE_UINT64 (std::numeric_limits<std::uint64_t>::max)()
 
+#if defined(_MSC_VER)
+#  if _MSC_VER >= 1911
+#    define SBE_CPLUSPLUS _MSVC_LANG
+#  elif _MSC_VER >= 1900
+#    define SBE_CPLUSPLUS 201103L
+#  else
+#    define SBE_CPLUSPLUS __cplusplus
+#  endif _MSC_VER >= 1900
+#else
+#  define SBE_CPLUSPLUS __cplusplus
+#endif //defined(_MSC_VER)
+
+#if SBE_CPLUSPLUS >= 201103L
+#  define SBE_CONSTEXPR constexpr
+#  define SBE_NOEXCEPT noexcept
+#else
+#  define SBE_CONSTEXPR
+#  define SBE_NOEXCEPT
+#endif
+
 typedef union sbe_float_as_uint_u
 {
     float fp_value;

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -853,6 +853,17 @@ public class CppGenerator implements CodeGenerator
         sb.append(String.format(
             "#ifndef _%1$s_%2$s_H_\n" +
             "#define _%1$s_%2$s_H_\n\n" +
+            "#if defined(_MSC_VER)\n" +
+            "#  if _MSC_VER >= 1911\n" +
+            "#    define SBE_CPLUSPLUS _MSVC_LANG\n" +
+            "#  elif _MSC_VER >= 1900\n" +
+            "#    define SBE_CPLUSPLUS 201103L\n" +
+            "#  else\n" +
+            "#    define SBE_CPLUSPLUS __cplusplus\n" +
+            "#  endif _MSC_VER >= 1900\n" +
+            "#else\n" +
+            "#  define SBE_CPLUSPLUS __cplusplus\n" +
+            "#endif //defined(_MSC_VER)\n" +
             "#if defined(SBE_HAVE_CMATH)\n" +
             "/* cmath needed for std::numeric_limits<double>::quiet_NaN() */\n" +
             "#  include <cmath>\n" +
@@ -864,12 +875,12 @@ public class CppGenerator implements CodeGenerator
             "#  define SBE_FLOAT_NAN NAN\n" +
             "#  define SBE_DOUBLE_NAN NAN\n" +
             "#endif\n\n" +
-            "#if __cplusplus >= 201103L\n" +
+            "#if SBE_CPLUSPLUS >= 201103L\n" +
             "#  include <cstdint>\n" +
             "#  include <string>\n" +
             "#  include <cstring>\n" +
             "#endif\n\n" +
-            "#if __cplusplus >= 201103L\n" +
+            "#if SBE_CPLUSPLUS >= 201103L\n" +
             "#  define SBE_CONSTEXPR constexpr\n" +
             "#  define SBE_NOEXCEPT noexcept\n" +
             "#else\n" +
@@ -1376,7 +1387,7 @@ public class CppGenerator implements CodeGenerator
             "        m_bufferLength(codec.m_bufferLength),\n" +
             "        m_offset(codec.m_offset),\n" +
             "        m_actingVersion(codec.m_actingVersion){}\n\n" +
-            "#if __cplusplus >= 201103L\n" +
+            "#if SBE_CPLUSPLUS >= 201103L\n" +
             "    %1$s(%1$s&& codec) :\n" +
             "        m_buffer(codec.m_buffer),\n" +
             "        m_bufferLength(codec.m_bufferLength),\n" +
@@ -1442,7 +1453,7 @@ public class CppGenerator implements CodeGenerator
             "    {\n" +
             "        reset(codec);\n" +
             "    }\n\n" +
-            "#if __cplusplus >= 201103L\n" +
+            "#if SBE_CPLUSPLUS >= 201103L\n" +
             "    %1$s(%1$s&& codec)\n" +
             "    {\n" +
             "        reset(codec);\n" +

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -293,7 +293,7 @@ public class CppGenerator implements CodeGenerator
             indent + "    }\n\n",
             dimensionHeaderLength, blockLength, formatClassName(groupName)));
 
-        sb.append(indent).append("#if __cplusplus < 201103L\n")
+        sb.append(indent).append("#if SBE_CPLUSPLUS < 201103L\n")
             .append(indent).append("    template<class Func> inline void forEach(Func& func)\n")
             .append(indent).append("    {\n")
             .append(indent).append("        while (hasNext())\n")
@@ -853,17 +853,6 @@ public class CppGenerator implements CodeGenerator
         sb.append(String.format(
             "#ifndef _%1$s_%2$s_H_\n" +
             "#define _%1$s_%2$s_H_\n\n" +
-            "#if defined(_MSC_VER)\n" +
-            "#  if _MSC_VER >= 1911\n" +
-            "#    define SBE_CPLUSPLUS _MSVC_LANG\n" +
-            "#  elif _MSC_VER >= 1900\n" +
-            "#    define SBE_CPLUSPLUS 201103L\n" +
-            "#  else\n" +
-            "#    define SBE_CPLUSPLUS __cplusplus\n" +
-            "#  endif _MSC_VER >= 1900\n" +
-            "#else\n" +
-            "#  define SBE_CPLUSPLUS __cplusplus\n" +
-            "#endif //defined(_MSC_VER)\n" +
             "#if defined(SBE_HAVE_CMATH)\n" +
             "/* cmath needed for std::numeric_limits<double>::quiet_NaN() */\n" +
             "#  include <cmath>\n" +
@@ -879,13 +868,6 @@ public class CppGenerator implements CodeGenerator
             "#  include <cstdint>\n" +
             "#  include <string>\n" +
             "#  include <cstring>\n" +
-            "#endif\n\n" +
-            "#if SBE_CPLUSPLUS >= 201103L\n" +
-            "#  define SBE_CONSTEXPR constexpr\n" +
-            "#  define SBE_NOEXCEPT noexcept\n" +
-            "#else\n" +
-            "#  define SBE_CONSTEXPR\n" +
-            "#  define SBE_NOEXCEPT\n" +
             "#endif\n\n" +
             "#include <sbe/sbe.h>\n\n",
             String.join("_", namespaces).toUpperCase(),


### PR DESCRIPTION
Since Visual Studio 2015 constexpr and noexcept keywords are supported. Given commit enables those features.