### PR TITLE
[C++] Cleaning up unit tests' global namespaces

### DIFF
--- a/sbe-tool/src/test/cpp/BoundsCheckTest.cpp
+++ b/sbe-tool/src/test/cpp/BoundsCheckTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 Real Logic Ltd.
+ * Copyright 2013-2018 Real Logic Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,6 @@
 #include "code_generation_test/MessageHeader.h"
 #include "code_generation_test/Car.h"
 
-using namespace std;
 using namespace code::generation::test;
 
 #define SERIAL_NUMBER 1234u

--- a/sbe-tool/src/test/cpp/CodeGenTest.cpp
+++ b/sbe-tool/src/test/cpp/CodeGenTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 Real Logic Ltd.
+ * Copyright 2013-2018 Real Logic Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 #include "code_generation_test/MessageHeader.h"
 #include "code_generation_test/Car.h"
 
-using namespace std;
 using namespace code::generation::test;
 
 static const std::size_t BUFFER_LEN = 2048;

--- a/sbe-tool/src/test/cpp/CompositeElementsTest.cpp
+++ b/sbe-tool/src/test/cpp/CompositeElementsTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 Real Logic Ltd.
+ * Copyright 2013-2018 Real Logic Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,7 @@
 #include "otf/OtfHeaderDecoder.h"
 #include "otf/OtfMessageDecoder.h"
 
-using namespace std;
 using namespace composite::elements;
-using namespace sbe::otf;
 
 enum EventNumber
 {

--- a/sbe-tool/src/test/cpp/CompositeOffsetsCodeGenTest.cpp
+++ b/sbe-tool/src/test/cpp/CompositeOffsetsCodeGenTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 Real Logic Ltd.
+ * Copyright 2013-2018 Real Logic Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -19,7 +19,6 @@
 #include "composite_offsets_test/MessageHeader.h"
 #include "composite_offsets_test/TestMessage1.h"
 
-using namespace std;
 using namespace composite::offsets::test;
 
 class CompositeOffsetsCodeGenTest : public testing::Test

--- a/sbe-tool/src/test/cpp/CompositeOffsetsIrTest.cpp
+++ b/sbe-tool/src/test/cpp/CompositeOffsetsIrTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 Real Logic Ltd.
+ * Copyright 2013-2018 Real Logic Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,7 @@
 #include "otf/OtfMessageDecoder.h"
 #include "otf/IrDecoder.h"
 
-using namespace std;
 using namespace composite::offsets::test;
-using namespace sbe::otf;
 
 static const char *SCHEMA_FILENAME = "composite-offsets-schema.sbeir";
 

--- a/sbe-tool/src/test/cpp/GroupWithDataTest.cpp
+++ b/sbe-tool/src/test/cpp/GroupWithDataTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 Real Logic Ltd.
+ * Copyright 2013-2018 Real Logic Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -21,7 +21,7 @@
 #include "group_with_data/TestMessage3.h"
 #include "group_with_data/TestMessage4.h"
 
-using namespace std;
+// using namespace std;
 using namespace group::with::data;
 
 static const std::uint32_t TAG_1 = 32;

--- a/sbe-tool/src/test/cpp/MessageBlockLengthTest.cpp
+++ b/sbe-tool/src/test/cpp/MessageBlockLengthTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 Real Logic Ltd.
+ * Copyright 2013-2018 Real Logic Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -22,9 +22,7 @@
 #include "otf/OtfHeaderDecoder.h"
 #include "otf/OtfMessageDecoder.h"
 
-using namespace std;
 using namespace message::block::length::test;
-using namespace sbe::otf;
 
 class MessageBlockLengthIrTest : public testing::Test, public OtfMessageDecoder::BasicTokenListener
 {

--- a/sbe-tool/src/test/cpp/Rc3OtfFullIrTest.cpp
+++ b/sbe-tool/src/test/cpp/Rc3OtfFullIrTest.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright 2013-2017 Real Logic Ltd.
+ * Copyright 2013-2018 Real Logic Ltd.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -23,7 +23,6 @@
 #include "otf/OtfHeaderDecoder.h"
 #include "otf/OtfMessageDecoder.h"
 
-using namespace std;
 using namespace code::generation::test;
 
 static const char *SCHEMA_FILENAME = "code-generation-schema.sbeir";
@@ -283,7 +282,7 @@ public:
 
     void onBeginMessage(Token& token)
     {
-        cout << m_eventNumber << ": Begin Message " << token.name() << " id " << token.fieldId() << "\n";
+        std::cout << m_eventNumber << ": Begin Message " << token.name() << " id " << token.fieldId() << "\n";
 
         EXPECT_EQ(EventNumber(m_eventNumber), EN_beginMessage);
         EXPECT_EQ(token.fieldId(), Car::sbeTemplateId());
@@ -292,7 +291,7 @@ public:
 
     void onEndMessage(Token& token)
     {
-        cout << m_eventNumber << ": End Message " << token.name() << "\n";
+        std::cout << m_eventNumber << ": End Message " << token.name() << "\n";
 
         EXPECT_EQ(EventNumber(m_eventNumber), EN_endMessage);
         EXPECT_EQ(token.fieldId(), Car::sbeTemplateId());
@@ -306,7 +305,7 @@ public:
         std::uint64_t actingVersion)
     {
         std::string name = (m_compositeLevel > 1) ? typeToken.name() : fieldToken.name();
-        cout << m_eventNumber << ": Encoding " <<  name << " offset " << typeToken.offset() << "\n";
+        std::cout << m_eventNumber << ": Encoding " <<  name << " offset " << typeToken.offset() << "\n";
 
         const Encoding& encoding = typeToken.encoding();
 
@@ -543,7 +542,7 @@ public:
         std::size_t toIndex,
         std::uint64_t actingVersion)
     {
-        cout << m_eventNumber << ": Enum " << determineName(fieldToken, tokens, fromIndex) << "\n";
+        std::cout << m_eventNumber << ": Enum " << determineName(fieldToken, tokens, fromIndex) << "\n";
 
         const Token& typeToken = tokens.at(fromIndex + 1);
         const Encoding& encoding = typeToken.encoding();
@@ -564,7 +563,7 @@ public:
                     const Token& token = tokens.at(i);
                     const std::uint64_t constValue = token.encoding().constValue().getAsUInt();
 
-                    cout << "    " << token.name() << " = " << constValue << "\n";
+                    std::cout << "    " << token.name() << " = " << constValue << "\n";
 
                     if (constValue == value)
                     {
@@ -589,7 +588,7 @@ public:
                     const Token& token = tokens.at(i);
                     const std::int64_t constValue = token.encoding().constValue().getAsUInt();
 
-                    cout << "    " << token.name() << " = " << constValue << "\n";
+                    std::cout << "    " << token.name() << " = " << constValue << "\n";
 
                     if (constValue == value)
                     {
@@ -617,7 +616,7 @@ public:
                     const Token& token = tokens.at(i);
                     const std::int64_t constValue = token.encoding().constValue().getAsInt();
 
-                    cout << "    " << token.name() << " = " << constValue << "\n";
+                    std::cout << "    " << token.name() << " = " << constValue << "\n";
 
                     if (constValue == value.getAsInt())
                     {
@@ -641,7 +640,7 @@ public:
                     const Token& token = tokens.at(i);
                     const std::int64_t constValue = token.encoding().constValue().getAsUInt();
 
-                    cout << "    " << token.name() << " = " << constValue << "\n";
+                    std::cout << "    " << token.name() << " = " << constValue << "\n";
 
                     if (constValue == value)
                     {
@@ -667,7 +666,7 @@ public:
         std::size_t toIndex,
         std::uint64_t actingVersion)
     {
-        cout << m_eventNumber << ": Bit Set " << fieldToken.name() << "\n";
+        std::cout << m_eventNumber << ": Bit Set " << fieldToken.name() << "\n";
 
         const Token& typeToken = tokens.at(fromIndex + 1);
         const Encoding& encoding = typeToken.encoding();
@@ -690,15 +689,15 @@ public:
 
                     if (constValue && value)
                     {
-                        cout << "    * ";
+                        std::cout << "    * ";
                         bitsSet++;
                     }
                     else
                     {
-                        cout << "      ";
+                        std::cout << "      ";
                     }
 
-                    cout << token.name() << " = " << constValue << "\n";
+                    std::cout << token.name() << " = " << constValue << "\n";
                 }
                 EXPECT_EQ(bitsSet, 2);
                 break;
@@ -719,7 +718,7 @@ public:
         m_compositeLevel++;
         std::string name = determineName(fieldToken, tokens, fromIndex);
 
-        cout << m_eventNumber << ": Begin Composite " << name << "\n";
+        std::cout << m_eventNumber << ": Begin Composite " << name << "\n";
 
         switch (EventNumber(m_eventNumber))
         {
@@ -749,7 +748,7 @@ public:
         std::string name = determineName(fieldToken, tokens, fromIndex);
         m_compositeLevel--;
 
-        cout << m_eventNumber << ": End Composite " << name << "\n";
+        std::cout << m_eventNumber << ": End Composite " << name << "\n";
 
         switch (EventNumber(m_eventNumber))
         {
@@ -774,7 +773,7 @@ public:
         Token& token,
         std::uint64_t numInGroup)
     {
-        cout << m_eventNumber << ": Group Header " << token.name() << " num " << numInGroup << "\n";
+        std::cout << m_eventNumber << ": Group Header " << token.name() << " num " << numInGroup << "\n";
 
         switch (EventNumber(m_eventNumber))
         {
@@ -815,7 +814,7 @@ public:
         std::uint64_t groupIndex,
         std::uint64_t numInGroup)
     {
-        cout << m_eventNumber << ": Begin Group " << token.name() << " " << groupIndex + 1 << "/" << numInGroup << "\n";
+        std::cout << m_eventNumber << ": Begin Group " << token.name() << " " << groupIndex + 1 << "/" << numInGroup << "\n";
 
         switch (EventNumber(m_eventNumber))
         {
@@ -908,7 +907,7 @@ public:
         std::uint64_t groupIndex,
         std::uint64_t numInGroup)
     {
-        cout << m_eventNumber << ": End Group " << token.name() << " " << groupIndex + 1 << "/" << numInGroup << "\n";
+        std::cout << m_eventNumber << ": End Group " << token.name() << " " << groupIndex + 1 << "/" << numInGroup << "\n";
 
         switch (EventNumber(m_eventNumber))
         {
@@ -1002,7 +1001,7 @@ public:
         std::uint64_t length,
         Token& typeToken)
     {
-        cout << m_eventNumber << ": Data " << fieldToken.name() << "\n";
+        std::cout << m_eventNumber << ": Data " << fieldToken.name() << "\n";
 
         switch (EventNumber(m_eventNumber))
         {


### PR DESCRIPTION
Cleaning up namespaces in C++ unit tests.
Also bumping copyright year while I'm already here.