### PR TITLE
[Java] Generate put CharSequence methods for ASCII encoded fields

### DIFF
--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
@@ -372,6 +372,25 @@ public class JavaGeneratorTest
         assertThat(get(decoder, "vehicleCode"), is("R11R12"));
     }
 
+    @Test
+    public void shouldGeneratePutCharSequence() throws Exception
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);
+        generator().generate();
+
+        final Object encoder = wrap(buffer, compileCarEncoder().newInstance());
+        final Object decoder = getCarDecoder(buffer, encoder);
+
+        set(encoder, "vehicleCode", CharSequence.class, "R11");
+        assertThat(get(decoder, "vehicleCode"), is("R11"));
+
+        set(encoder, "vehicleCode", CharSequence.class, "");
+        assertThat(get(decoder, "vehicleCode"), is(""));
+
+        set(encoder, "vehicleCode", CharSequence.class, "R11R12");
+        assertThat(get(decoder, "vehicleCode"), is("R11R12"));
+    }
+
     private Class<?> getModelClass(final Object encoder) throws ClassNotFoundException
     {
         final String className = "Model";


### PR DESCRIPTION
This PR allows to set ASCII encoded char array fields with any class implementing CharSequence, not only with Strings. It helps writing GC-free code without handling byte arrays. One for example can pass StringBuilder as an argument which can be shared between invocations.