### PR TITLE
[C++] Unit test improvements

### DIFF
--- a/sbe-tool/src/test/cpp/BoundsCheckTest.cpp
+++ b/sbe-tool/src/test/cpp/BoundsCheckTest.cpp
@@ -44,7 +44,7 @@ class BoundsCheckTest : public testing::Test
 {
 public:
 
-    virtual std::uint64_t encodeHdr(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
+    std::uint64_t encodeHdr(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
     {
         m_hdr.wrap(buffer, offset, 0, bufferLength)
             .blockLength(Car::sbeBlockLength())
@@ -55,7 +55,7 @@ public:
         return m_hdr.encodedLength();
     }
 
-    virtual std::uint64_t decodeHdr(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
+    std::uint64_t decodeHdr(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
     {
         m_hdrDecoder.wrap(buffer, offset, 0, bufferLength);
 
@@ -67,7 +67,7 @@ public:
         return m_hdrDecoder.encodedLength();
     }
 
-    virtual std::uint64_t encodeCarRoot(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
+    std::uint64_t encodeCarRoot(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
     {
         m_car.wrapForEncode(buffer, offset, bufferLength)
             .serialNumber(SERIAL_NUMBER)
@@ -95,7 +95,7 @@ public:
         return m_car.encodedLength();
     }
 
-    virtual std::uint64_t encodeCarFuelFigures()
+    std::uint64_t encodeCarFuelFigures()
     {
         Car::FuelFigures& fuelFigures = m_car.fuelFiguresCount(3);
 
@@ -114,7 +114,7 @@ public:
         return m_car.encodedLength();
     }
 
-    virtual std::uint64_t encodeCarPerformanceFigures()
+    std::uint64_t encodeCarPerformanceFigures()
     {
         Car::PerformanceFigures &perfFigs = m_car.performanceFiguresCount(2);
 
@@ -135,7 +135,7 @@ public:
         return m_car.encodedLength();
     }
 
-    virtual std::uint64_t encodeCarManufacturerModelAndActivationCode()
+    std::uint64_t encodeCarManufacturerModelAndActivationCode()
     {
         m_car.putManufacturer(MANUFACTURER, static_cast<int>(strlen(MANUFACTURER)));
         m_car.putModel(MODEL, static_cast<int>(strlen(MODEL)));
@@ -144,7 +144,7 @@ public:
         return m_car.encodedLength();
     }
 
-    virtual std::uint64_t decodeCarRoot(char *buffer, const std::uint64_t offset, const std::uint64_t bufferLength)
+    std::uint64_t decodeCarRoot(char *buffer, const std::uint64_t offset, const std::uint64_t bufferLength)
     {
         m_carDecoder.wrapForDecode(buffer, offset, Car::sbeBlockLength(), Car::sbeSchemaVersion(), bufferLength);
         EXPECT_EQ(m_carDecoder.serialNumber(), SERIAL_NUMBER);
@@ -178,7 +178,7 @@ public:
         return m_carDecoder.encodedLength();
     }
 
-    virtual std::uint64_t decodeCarFuelFigures()
+    std::uint64_t decodeCarFuelFigures()
     {
         char tmp[256];
         Car::FuelFigures &fuelFigures = m_carDecoder.fuelFigures();
@@ -208,7 +208,7 @@ public:
         return m_carDecoder.encodedLength();
     }
 
-    virtual std::uint64_t decodeCarPerformanceFigures()
+    std::uint64_t decodeCarPerformanceFigures()
     {
         Car::PerformanceFigures &performanceFigures = m_carDecoder.performanceFigures();
         EXPECT_EQ(performanceFigures.count(), 2u);
@@ -258,7 +258,7 @@ public:
         return m_carDecoder.encodedLength();
     }
 
-    virtual std::uint64_t decodeCarManufacturerModelAndActivationCode()
+    std::uint64_t decodeCarManufacturerModelAndActivationCode()
     {
         char tmp[256];
 

--- a/sbe-tool/src/test/cpp/CodeGenTest.cpp
+++ b/sbe-tool/src/test/cpp/CodeGenTest.cpp
@@ -161,13 +161,13 @@ public:
         return car.encodedLength();
     }
 
-    virtual std::uint64_t encodeHdr(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
+    std::uint64_t encodeHdr(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
     {
         m_hdr.wrap(buffer, offset, 0, bufferLength);
         return encodeHdr(m_hdr);
     }
 
-    virtual std::uint64_t encodeCar(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
+    std::uint64_t encodeCar(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
     {
         m_car.wrapForEncode(buffer, offset, bufferLength);
         return encodeCar(m_car);

--- a/sbe-tool/src/test/cpp/CompositeElementsTest.cpp
+++ b/sbe-tool/src/test/cpp/CompositeElementsTest.cpp
@@ -49,7 +49,7 @@ public:
         m_eventNumber = 0;
     }
 
-    virtual std::uint64_t encodeHdrAndMsg()
+    std::uint64_t encodeHdrAndMsg()
     {
         MessageHeader hdr;
         Msg msg;
@@ -75,7 +75,7 @@ public:
         return hdr.encodedLength() + msg.encodedLength();
     }
 
-    virtual void onBeginComposite(
+    void onBeginComposite(
         Token &fieldToken,
         std::vector<Token> &tokens,
         std::size_t fromIndex,
@@ -94,7 +94,7 @@ public:
         }
     }
 
-    virtual void onEndComposite(
+    void onEndComposite(
         Token &fieldToken,
         std::vector<Token> &tokens,
         std::size_t fromIndex,
@@ -113,7 +113,7 @@ public:
         }
     }
 
-    virtual void onEncoding(
+    void onEncoding(
         Token& fieldToken,
         const char *buffer,
         Token& typeToken,
@@ -145,7 +145,7 @@ public:
 
     }
 
-    virtual void onBitSet(
+    void onBitSet(
         Token& fieldToken,
         const char *buffer,
         std::vector<Token>& tokens,
@@ -174,7 +174,7 @@ public:
         }
     }
 
-    virtual void onEnum(
+    void onEnum(
         Token &fieldToken,
         const char *buffer,
         std::vector<Token> &tokens,

--- a/sbe-tool/src/test/cpp/CompositeOffsetsCodeGenTest.cpp
+++ b/sbe-tool/src/test/cpp/CompositeOffsetsCodeGenTest.cpp
@@ -25,7 +25,7 @@ class CompositeOffsetsCodeGenTest : public testing::Test
 {
 public:
 
-    virtual std::uint64_t encodeHdr(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
+    std::uint64_t encodeHdr(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
     {
         m_hdr.wrap(buffer, offset, 0, bufferLength)
             .blockLength(TestMessage1::sbeBlockLength())
@@ -36,7 +36,7 @@ public:
         return m_hdr.encodedLength();
     }
 
-    virtual std::uint64_t encodeMsg(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
+    std::uint64_t encodeMsg(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
     {
         m_msg.wrapForEncode(buffer, offset, bufferLength);
 

--- a/sbe-tool/src/test/cpp/CompositeOffsetsIrTest.cpp
+++ b/sbe-tool/src/test/cpp/CompositeOffsetsIrTest.cpp
@@ -38,7 +38,7 @@ public:
         m_eventNumber = 0;
     }
 
-    virtual std::uint64_t encodeHdrAndMsg()
+    std::uint64_t encodeHdrAndMsg()
     {
         MessageHeader hdr;
         TestMessage1 msg;
@@ -64,7 +64,7 @@ public:
         return hdr.encodedLength() + msg.encodedLength();
     }
 
-    virtual void onEncoding(
+    void onEncoding(
         Token& fieldToken,
         const char *buffer,
         Token& typeToken,
@@ -102,7 +102,7 @@ public:
 
     }
 
-    virtual void onGroupHeader(
+    void onGroupHeader(
         Token& token,
         std::uint64_t numInGroup)
     {

--- a/sbe-tool/src/test/cpp/GroupWithDataTest.cpp
+++ b/sbe-tool/src/test/cpp/GroupWithDataTest.cpp
@@ -80,7 +80,7 @@ class GroupWithDataTest : public testing::Test
 {
 public:
 
-    virtual std::uint64_t encodeTestMessage1(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
+    std::uint64_t encodeTestMessage1(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
     {
         m_msg1.wrapForEncode(buffer, offset, bufferLength);
 
@@ -103,7 +103,7 @@ public:
         return m_msg1.encodedLength();
     }
 
-    virtual std::uint64_t encodeTestMessage2(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
+    std::uint64_t encodeTestMessage2(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
     {
         m_msg2.wrapForEncode(buffer, offset, bufferLength);
 
@@ -128,7 +128,7 @@ public:
         return m_msg2.encodedLength();
     }
 
-    virtual std::uint64_t encodeTestMessage3(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
+    std::uint64_t encodeTestMessage3(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
     {
         m_msg3.wrapForEncode(buffer, offset, bufferLength);
 
@@ -183,7 +183,7 @@ public:
         return m_msg3.encodedLength();
     }
 
-    virtual std::uint64_t encodeTestMessage4(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
+    std::uint64_t encodeTestMessage4(char *buffer, std::uint64_t offset, std::uint64_t bufferLength)
     {
         m_msg4.wrapForEncode(buffer, offset, bufferLength);
 

--- a/sbe-tool/src/test/cpp/MessageBlockLengthTest.cpp
+++ b/sbe-tool/src/test/cpp/MessageBlockLengthTest.cpp
@@ -36,7 +36,7 @@ public:
         m_eventNumber = 0;
     }
 
-    virtual std::uint64_t encodeHdrAndMsg()
+    std::uint64_t encodeHdrAndMsg()
     {
         MessageHeader hdr;
         MsgName msg;
@@ -66,7 +66,7 @@ public:
         return hdr.encodedLength() + msg.encodedLength();
     }
 
-    virtual void onEncoding(
+    void onEncoding(
         Token& fieldToken,
         const char *buffer,
         Token& typeToken,
@@ -110,7 +110,7 @@ public:
 
     }
 
-    virtual void onBitSet(
+    void onBitSet(
         Token& fieldToken,
         const char *buffer,
         std::vector<Token>& tokens,
@@ -134,7 +134,7 @@ public:
         }
     }
 
-    virtual void onGroupHeader(
+    void onGroupHeader(
         Token& token,
         std::uint64_t numInGroup)
     {

--- a/sbe-tool/src/test/cpp/Rc3OtfFullIrTest.cpp
+++ b/sbe-tool/src/test/cpp/Rc3OtfFullIrTest.cpp
@@ -197,7 +197,7 @@ public:
         m_compositeLevel = 0;
     }
 
-    virtual std::string determineName(
+    std::string determineName(
         Token& fieldToken,
         std::vector<Token>& tokens,
         std::size_t fromIndex)
@@ -205,7 +205,7 @@ public:
         return (m_compositeLevel > 1) ? tokens.at(fromIndex).name() : fieldToken.name();
     }
 
-    virtual std::uint64_t encodeHdrAndCar()
+    std::uint64_t encodeHdrAndCar()
     {
         MessageHeader hdr;
         Car car;

--- a/sbe-tool/src/test/cpp/Rc3OtfFullIrTest.cpp
+++ b/sbe-tool/src/test/cpp/Rc3OtfFullIrTest.cpp
@@ -25,83 +25,83 @@
 
 using namespace code::generation::test;
 
-static const char *SCHEMA_FILENAME = "code-generation-schema.sbeir";
+constexpr const char *SCHEMA_FILENAME = "code-generation-schema.sbeir";
 
-static const uint8_t fieldIdSerialNumber = 1;
-static const uint8_t fieldIdModelYear = 2;
-static const uint8_t fieldIdAvailable = 3;
-static const uint8_t fieldIdCode = 4;
-static const uint8_t fieldIdSomeNumbers = 5;
-static const uint8_t fieldIdVehicleCode = 6;
-static const uint8_t fieldIdExtras = 7;
-static const uint8_t fieldIdDiscountedModel = 8;
-static const uint8_t fieldIdEngine = 9;
-static const uint8_t fieldIdFuelFigures = 10;
-static const uint8_t fieldIdFuelSpeed = 11;
-static const uint8_t fieldIdFuelMpg = 12;
-static const uint8_t fieldIdFuelUsageDescription = 200;
-static const uint8_t fieldIdPerformanceFigures = 13;
-static const uint8_t fieldIdPerfOctaneRating = 14;
-static const uint8_t fieldIdPerfAcceleration = 15;
-static const uint8_t fieldIdPerfAccMph = 16;
-static const uint8_t fieldIdPerfAccSeconds = 17;
-static const uint8_t fieldIdManufacturer = 18;
-static const uint8_t fieldIdModel = 19;
-static const uint8_t fieldIdActivationCode = 20;
+constexpr std::uint8_t fieldIdSerialNumber = 1;
+constexpr std::uint8_t fieldIdModelYear = 2;
+constexpr std::uint8_t fieldIdAvailable = 3;
+constexpr std::uint8_t fieldIdCode = 4;
+constexpr std::uint8_t fieldIdSomeNumbers = 5;
+constexpr std::uint8_t fieldIdVehicleCode = 6;
+constexpr std::uint8_t fieldIdExtras = 7;
+constexpr std::uint8_t fieldIdDiscountedModel = 8;
+constexpr std::uint8_t fieldIdEngine = 9;
+constexpr std::uint8_t fieldIdFuelFigures = 10;
+constexpr std::uint8_t fieldIdFuelSpeed = 11;
+constexpr std::uint8_t fieldIdFuelMpg = 12;
+constexpr std::uint8_t fieldIdFuelUsageDescription = 200;
+constexpr std::uint8_t fieldIdPerformanceFigures = 13;
+constexpr std::uint8_t fieldIdPerfOctaneRating = 14;
+constexpr std::uint8_t fieldIdPerfAcceleration = 15;
+constexpr std::uint8_t fieldIdPerfAccMph = 16;
+constexpr std::uint8_t fieldIdPerfAccSeconds = 17;
+constexpr std::uint8_t fieldIdManufacturer = 18;
+constexpr std::uint8_t fieldIdModel = 19;
+constexpr std::uint8_t fieldIdActivationCode = 20;
 
-static const std::uint32_t SERIAL_NUMBER = 1234;
-static const std::uint16_t MODEL_YEAR = 2013;
-static const BooleanType::Value AVAILABLE = BooleanType::T;
-static const Model::Value CODE = Model::A;
-static const bool CRUISE_CONTROL = true;
-static const bool SPORTS_PACK = true;
-static const bool SUNROOF = false;
+constexpr std::uint32_t SERIAL_NUMBER = 1234;
+constexpr std::uint16_t MODEL_YEAR = 2013;
+constexpr BooleanType::Value AVAILABLE = BooleanType::T;
+constexpr Model::Value CODE = Model::A;
+constexpr bool CRUISE_CONTROL = true;
+constexpr bool SPORTS_PACK = true;
+constexpr bool SUNROOF = false;
 
 static char VEHICLE_CODE[] = { 'a', 'b', 'c', 'd', 'e', 'f' };
 static char MANUFACTURER_CODE[] = { '1', '2', '3' };
-static const char *FUEL_FIGURES_1_USAGE_DESCRIPTION = "Urban Cycle";
-static const char *FUEL_FIGURES_2_USAGE_DESCRIPTION = "Combined Cycle";
-static const char *FUEL_FIGURES_3_USAGE_DESCRIPTION = "Highway Cycle";
-static const char *MANUFACTURER = "Honda";
-static const char *MODEL = "Civic VTi";
-static const char *ACTIVATION_CODE = "deadbeef";
+constexpr const char *FUEL_FIGURES_1_USAGE_DESCRIPTION = "Urban Cycle";
+constexpr const char *FUEL_FIGURES_2_USAGE_DESCRIPTION = "Combined Cycle";
+constexpr const char *FUEL_FIGURES_3_USAGE_DESCRIPTION = "Highway Cycle";
+constexpr const char *MANUFACTURER = "Honda";
+constexpr const char *MODEL = "Civic VTi";
+constexpr const char *ACTIVATION_CODE = "deadbeef";
 
 static const int VEHICLE_CODE_LENGTH = sizeof(VEHICLE_CODE);
 static const int MANUFACTURER_CODE_LENGTH = sizeof(MANUFACTURER_CODE);
-static const size_t MANUFACTURER_LENGTH = 5;
-static const size_t MODEL_LENGTH = 9;
-static const size_t ACTIVATION_CODE_LENGTH = 8;
-static const size_t PERFORMANCE_FIGURES_COUNT = 2;
-static const size_t FUEL_FIGURES_COUNT = 3;
-static const size_t ACCELERATION_COUNT = 3;
+constexpr std::size_t MANUFACTURER_LENGTH = 5;
+constexpr std::size_t MODEL_LENGTH = 9;
+constexpr std::size_t ACTIVATION_CODE_LENGTH = 8;
+constexpr std::size_t PERFORMANCE_FIGURES_COUNT = 2;
+constexpr std::size_t FUEL_FIGURES_COUNT = 3;
+constexpr std::size_t ACCELERATION_COUNT = 3;
 
-static const std::uint16_t fuel1Speed = 30;
-static const float fuel1Mpg = 35.9f;
-static const std::uint16_t fuel2Speed = 55;
-static const float fuel2Mpg = 49.0f;
-static const std::uint16_t fuel3Speed = 75;
-static const float fuel3Mpg = 40.0f;
+constexpr std::uint16_t fuel1Speed = 30;
+constexpr float fuel1Mpg = 35.9f;
+constexpr std::uint16_t fuel2Speed = 55;
+constexpr float fuel2Mpg = 49.0f;
+constexpr std::uint16_t fuel3Speed = 75;
+constexpr float fuel3Mpg = 40.0f;
 
-static const std::uint8_t perf1Octane = 95;
-static const std::uint16_t perf1aMph = 30;
-static const float perf1aSeconds = 4.0f;
-static const std::uint16_t perf1bMph = 60;
-static const float perf1bSeconds = 7.5f;
-static const std::uint16_t perf1cMph = 100;
-static const float perf1cSeconds = 12.2f;
+constexpr std::uint8_t perf1Octane = 95;
+constexpr std::uint16_t perf1aMph = 30;
+constexpr float perf1aSeconds = 4.0f;
+constexpr std::uint16_t perf1bMph = 60;
+constexpr float perf1bSeconds = 7.5f;
+constexpr std::uint16_t perf1cMph = 100;
+constexpr float perf1cSeconds = 12.2f;
 
-static const std::uint8_t perf2Octane = 99;
-static const std::uint16_t perf2aMph = 30;
-static const float perf2aSeconds = 3.8f;
-static const std::uint16_t perf2bMph = 60;
-static const float perf2bSeconds = 7.1f;
-static const std::uint16_t perf2cMph = 100;
-static const float perf2cSeconds = 11.8f;
+constexpr std::uint8_t perf2Octane = 99;
+constexpr std::uint16_t perf2aMph = 30;
+constexpr float perf2aSeconds = 3.8f;
+constexpr std::uint16_t perf2bMph = 60;
+constexpr float perf2bSeconds = 7.1f;
+constexpr std::uint16_t perf2cMph = 100;
+constexpr float perf2cSeconds = 11.8f;
 
-static const std::uint16_t engineCapacity = 2000;
-static const std::uint8_t engineNumCylinders = 4;
+constexpr std::uint16_t engineCapacity = 2000;
+constexpr std::uint8_t engineNumCylinders = 4;
 
-static const std::uint64_t encodedCarAndHdrLength = 191 + 8;
+constexpr std::uint64_t encodedCarAndHdrLength = 191 + 8;
 
 // This enum represents the expected events that
 // will be received during the decoding process.


### PR DESCRIPTION
The virtual specifier is not needed in unit test functions because the functions do not get overridden in derived classes. Also, I refactored the Rc3OtfFullIrTest to use constexpr where applicable.