### PR TITLE
Fixes an issue associated with issue #543.

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -210,6 +210,7 @@ public class CSharpGenerator implements CodeGenerator
             indent + INDENT + INDENT + "_index = -1;\n" +
             indent + INDENT + INDENT + "_count = count;\n" +
             indent + INDENT + INDENT + "_blockLength = %3$d;\n" +
+            indent + INDENT + INDENT + "_actingVersion = SchemaVersion;\n" +
             indent + INDENT + INDENT + "parentMessage.Limit = parentMessage.Limit + SbeHeaderSize;\n" +
             indent + INDENT + "}\n",
             parentMessageClassName,


### PR DESCRIPTION
Previously `_actingVersion` was not initialized upon a call to `WrapForEncode(...)`.
This meant that access to properties on the group that allow the items to be encoded fails.
Now we initialize it to the current schema version.