### PR TITLE
[Java] Add new method to decoders to pass in Appendable to write ascii encoded strings to

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -801,6 +801,37 @@ public class JavaGenerator implements CodeGenerator
                 sizeOfLengthField,
                 generateGet(lengthType, "limit", byteOrderStr),
                 characterEncoding));
+
+            if (characterEncoding.contains("ASCII"))
+            {
+                sb.append(String.format("\n" +
+                    indent + "    public void %1$s(final Appendable value)\n" +
+                    indent + "    {\n" +
+                    "%2$s" +
+                    indent + "        final int headerLength = %3$d;\n" +
+                    indent + "        final int limit = parentMessage.limit();\n" +
+                    indent + "        final int dataLength = (int)%4$s;\n" +
+                    indent + "        final int dataOffset = limit + headerLength;\n" +
+                    indent + "        parentMessage.limit(dataOffset + dataLength);\n" +
+                    indent + "        for (int i = 0; i < dataLength; ++i)\n" +
+                    indent + "        {\n" +
+                    indent + "            try\n" +
+                    indent + "            {\n" +
+                    indent + "                final int c = buffer.getByte(dataOffset + i) & 0xFF;\n" +
+                    indent + "                value.append(c > 127 ? '?' : (char)c);\n" +
+                    indent + "            }\n" +
+                    indent + "            catch (final java.io.IOException e)\n" +
+                    indent + "            {\n" +
+                    indent + "                throw new java.io.UncheckedIOException(e);\n" +
+                    indent + "            }\n" +
+                    indent + "        }\n" +
+                    indent + "    }\n",
+                    formatPropertyName(propertyName),
+                    generateStringNotPresentCondition(token.version(), indent),
+                    sizeOfLengthField,
+                    generateGet(lengthType, "limit", byteOrderStr),
+                    byteOrderStr));
+            }
         }
     }
 
@@ -1813,6 +1844,34 @@ public class JavaGenerator implements CodeGenerator
                 fieldLength, offset,
                 fieldLength, fieldLength,
                 charset(encoding.characterEncoding())));
+
+            if (encoding.characterEncoding().contains("ASCII"))
+            {
+                sb.append(String.format("\n" +
+                    indent + "    public void %s(final Appendable value)\n" +
+                    indent + "    {\n" +
+                    "%s" +
+                    indent + "        for (int i = 0; i < %d ; ++i)\n" +
+                    indent + "        {\n" +
+                    indent + "            final int c = buffer.getByte(this.offset + %d + i) & 0xFF;\n" +
+                    indent + "            if (c == 0)\n" +
+                    indent + "            {\n" +
+                    indent + "                break;\n" +
+                    indent + "            }\n" +
+                    indent + "            try\n" +
+                    indent + "            {\n" +
+                    indent + "                value.append(c > 127 ? '?' : (char)c);\n" +
+                    indent + "            }\n" +
+                    indent + "            catch (final java.io.IOException e)\n" +
+                    indent + "            {\n" +
+                    indent + "                throw new java.io.UncheckedIOException(e);\n" +
+                    indent + "            }\n" +
+                    indent + "        }\n" +
+                    indent + "    }\n\n",
+                    formatPropertyName(propertyName),
+                    generateStringNotPresentCondition(propertyToken.version(), indent),
+                    fieldLength, offset));
+            }
         }
 
         return sb;

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -805,7 +805,7 @@ public class JavaGenerator implements CodeGenerator
             if (characterEncoding.contains("ASCII"))
             {
                 sb.append(String.format("\n" +
-                    indent + "    public void %1$s(final Appendable value)\n" +
+                    indent + "    public void get%1$s(final Appendable value)\n" +
                     indent + "    {\n" +
                     "%2$s" +
                     indent + "        final int headerLength = %3$d;\n" +
@@ -826,7 +826,7 @@ public class JavaGenerator implements CodeGenerator
                     indent + "            }\n" +
                     indent + "        }\n" +
                     indent + "    }\n",
-                    formatPropertyName(propertyName),
+                    Generators.toUpperFirstChar(propertyName),
                     generateStringNotPresentCondition(token.version(), indent),
                     sizeOfLengthField,
                     generateGet(lengthType, "limit", byteOrderStr),
@@ -1848,7 +1848,7 @@ public class JavaGenerator implements CodeGenerator
             if (encoding.characterEncoding().contains("ASCII"))
             {
                 sb.append(String.format("\n" +
-                    indent + "    public void %s(final Appendable value)\n" +
+                    indent + "    public void get%s(final Appendable value)\n" +
                     indent + "    {\n" +
                     "%s" +
                     indent + "        for (int i = 0; i < %d ; ++i)\n" +
@@ -1868,7 +1868,7 @@ public class JavaGenerator implements CodeGenerator
                     indent + "            }\n" +
                     indent + "        }\n" +
                     indent + "    }\n\n",
-                    formatPropertyName(propertyName),
+                    Generators.toUpperFirstChar(propertyName),
                     generateStringNotPresentCondition(propertyToken.version(), indent),
                     fieldLength, offset));
             }

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
@@ -376,6 +376,55 @@ public class JavaGeneratorTest
     }
 
     @Test
+    public void shouldGenerateGetFixedLengthStringUsingAppendable() throws Exception
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);
+        final StringBuilder result = new StringBuilder();
+        generator().generate();
+
+        final Object encoder = wrap(buffer, compileCarEncoder().newInstance());
+        final Object decoder = getCarDecoder(buffer, encoder);
+
+        set(encoder, "vehicleCode", String.class, "R11");
+        get(decoder, "vehicleCode", result);
+        assertThat(result.toString(), is("R11"));
+
+        result.setLength(0);
+        set(encoder, "vehicleCode", String.class, "");
+        get(decoder, "vehicleCode", result);
+        assertThat(result.toString(), is(""));
+
+        result.setLength(0);
+        set(encoder, "vehicleCode", String.class, "R11R12");
+        get(decoder, "vehicleCode", result);
+        assertThat(result.toString(), is("R11R12"));
+    }
+
+    @Test
+    public void shouldGenerateGetVariableStringUsingAppendable() throws Exception
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);
+        final StringBuilder result = new StringBuilder();
+        generator().generate();
+
+        final Object encoder = wrap(buffer, compileCarEncoder().newInstance());
+        final Object decoder = getCarDecoder(buffer, encoder);
+        set(encoder, "color", String.class, "Red");
+        get(decoder, "color", result);
+        assertThat(result.toString(), is("Red"));
+
+        result.setLength(0);
+        set(encoder, "color", String.class, "");
+        get(decoder, "color", result);
+        assertThat(result.toString(), is(""));
+
+        result.setLength(0);
+        set(encoder, "color", String.class, "Red and Blue");
+        get(decoder, "color", result);
+        assertThat(result.toString(), is("Red and Blue"));
+    }
+
+    @Test
     public void shouldGeneratePutCharSequence() throws Exception
     {
         final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ReflectionUtil.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ReflectionUtil.java
@@ -37,6 +37,11 @@ public final class ReflectionUtil
         return object.getClass().getMethod(fieldName).invoke(object);
     }
 
+    static void get(final Object object, final String fieldName, final Appendable arg) throws Exception
+    {
+        object.getClass().getMethod(fieldName, Appendable.class).invoke(object, arg);
+    }
+
     static String getManufacturer(final Object decoder) throws Exception
     {
         return (String)get(decoder, "manufacturer");

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ReflectionUtil.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ReflectionUtil.java
@@ -15,6 +15,8 @@
  */
 package uk.co.real_logic.sbe.generation.java;
 
+import uk.co.real_logic.sbe.generation.Generators;
+
 public final class ReflectionUtil
 {
     static int getSbeSchemaVersion(final Object encoder) throws Exception
@@ -39,7 +41,8 @@ public final class ReflectionUtil
 
     static void get(final Object object, final String fieldName, final Appendable arg) throws Exception
     {
-        object.getClass().getMethod(fieldName, Appendable.class).invoke(object, arg);
+        final String methodName = "get" + Generators.toUpperFirstChar(fieldName);
+        object.getClass().getMethod(methodName, Appendable.class).invoke(object, arg);
     }
 
     static String getManufacturer(final Object decoder) throws Exception

--- a/sbe-tool/src/test/resources/code-generation-schema.xml
+++ b/sbe-tool/src/test/resources/code-generation-schema.xml
@@ -30,6 +30,10 @@
             <type name="length" primitiveType="uint16"/>
             <type name="varData" primitiveType="uint8" length="0" characterEncoding="UTF-8"/>
         </composite>
+        <composite name="varAsciiStringEncoding">
+            <type name="length" primitiveType="uint32" maxValue="1073741824"/>
+            <type name="varData" primitiveType="uint8" length="0" characterEncoding="ASCII"/>
+        </composite>
     </types>
     <types>
         <type name="ModelYear" primitiveType="uint16"/>
@@ -84,5 +88,6 @@
         <data name="manufacturer" id="18" type="varStringEncoding"/>
         <data name="model" id="19" type="varStringEncoding"/>
         <data name="activationCode" id="20" type="varStringEncoding"/>
+        <data name="color" id="21" type="varAsciiStringEncoding"/>
     </sbe:message>
 </sbe:messageSchema>


### PR DESCRIPTION
This PR allows to read ASCII encoded fixed and variable length strings from generated decoders. This allows for users to pass in a StringBuilder to avoid allocating a string.