### PR TITLE
[C#] support for `uint32` representation of group size

### DIFF
--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/csharp/Issue567GroupSizeTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/csharp/Issue567GroupSizeTest.java
@@ -13,8 +13,7 @@ import uk.co.real_logic.sbe.xml.ParserOptions;
 
 public class Issue567GroupSizeTest
 {
-
-    @Test(expected = Exception.class)
+    @Test(expected = IllegalArgumentException.class)
     public void shouldThrowWhenUsingATypeThatIsNotConstrainedToFitInAnIntAsTheGroupSize() throws Exception
     {
         // Arrange
@@ -27,8 +26,24 @@ public class Issue567GroupSizeTest
         outputManager.setPackageName(ir.applicableNamespace());
         final CSharpGenerator generator = new CSharpGenerator(ir, outputManager);
 
-        // Act + Assert
+        // Act + Assert (exception thrown)
         generator.generate();
     }
 
+    @Test
+    public void shouldGenerateWhenUsingATypeThatIsConstrainedToFitInAnIntAsTheGroupSize() throws Exception
+    {
+        // Arrange
+        final ParserOptions options = ParserOptions.builder().stopOnError(true).build();
+        final MessageSchema schema = parse(TestUtil.getLocalResource("issue567-valid.xml"), options);
+        final IrGenerator irg = new IrGenerator();
+        final Ir ir = irg.generate(schema);
+
+        final StringWriterOutputManager outputManager = new StringWriterOutputManager();
+        outputManager.setPackageName(ir.applicableNamespace());
+        final CSharpGenerator generator = new CSharpGenerator(ir, outputManager);
+
+        // Act + Assert (no exception)
+        generator.generate();
+    }
 }

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/csharp/Issue567GroupSizeTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/csharp/Issue567GroupSizeTest.java
@@ -1,0 +1,34 @@
+package uk.co.real_logic.sbe.generation.csharp;
+
+import static uk.co.real_logic.sbe.xml.XmlSchemaParser.parse;
+
+import org.agrona.generation.StringWriterOutputManager;
+import org.junit.Test;
+
+import uk.co.real_logic.sbe.TestUtil;
+import uk.co.real_logic.sbe.ir.Ir;
+import uk.co.real_logic.sbe.xml.IrGenerator;
+import uk.co.real_logic.sbe.xml.MessageSchema;
+import uk.co.real_logic.sbe.xml.ParserOptions;
+
+public class Issue567GroupSizeTest
+{
+
+    @Test(expected = Exception.class)
+    public void shouldThrowWhenUsingATypeThatIsNotConstrainedToFitInAnIntAsTheGroupSize() throws Exception
+    {
+        // Arrange
+        final ParserOptions options = ParserOptions.builder().stopOnError(true).build();
+        final MessageSchema schema = parse(TestUtil.getLocalResource("issue567-invalid.xml"), options);
+        final IrGenerator irg = new IrGenerator();
+        final Ir ir = irg.generate(schema);
+
+        final StringWriterOutputManager outputManager = new StringWriterOutputManager();
+        outputManager.setPackageName(ir.applicableNamespace());
+        final CSharpGenerator generator = new CSharpGenerator(ir, outputManager);
+
+        // Act + Assert
+        generator.generate();
+    }
+
+}

--- a/sbe-tool/src/test/resources/issue567-invalid.xml
+++ b/sbe-tool/src/test/resources/issue567-invalid.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   package="issue567"
+                   id="567"
+                   version="0"
+                   semanticVersion="5.2"
+                   description="issue 567 example where group size doesn't fit in an int32"
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader" description="Message identifiers and length of message root">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+        <composite name="groupSizeEncoding" description="Repeating group dimensions">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="numInGroup" primitiveType="uint32"/>
+        </composite>
+        <composite name="varStringEncoding">
+            <type name="length" primitiveType="uint32" maxValue="1073741824"/>
+            <type name="varData" primitiveType="uint8" length="0" characterEncoding="UTF-8"/>
+        </composite>
+        <composite name="varDataEncoding">
+            <type name="length" primitiveType="uint32" maxValue="1073741824"/>
+            <type name="varData" primitiveType="uint8" length="0"/>
+        </composite>
+    </types>
+    <types>
+        <composite name="issue567Element" description="element for group exposing issue 567">
+            <type name="id" primitiveType="int32" />
+        </composite>
+    </types>
+    <sbe:message name="issue567" id="1" description="issue 560 test">
+        <field name="groupField" id="1" type="issue567Element" />
+    </sbe:message>
+</sbe:messageSchema>

--- a/sbe-tool/src/test/resources/issue567-valid.xml
+++ b/sbe-tool/src/test/resources/issue567-valid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
-                   package="issue567Invalid"
+                   package="issue567Valid"
                    id="567"
                    version="0"
                    semanticVersion="5.2"
@@ -15,7 +15,7 @@
         </composite>
         <composite name="groupSizeEncoding" description="Repeating group dimensions">
             <type name="blockLength" primitiveType="uint16"/>
-            <type name="numInGroup" primitiveType="uint32"/>
+            <type name="numInGroup" primitiveType="uint32" maxValue="2147483647" />
         </composite>
         <composite name="varStringEncoding">
             <type name="length" primitiveType="uint32" maxValue="1073741824"/>


### PR DESCRIPTION
# Changes

- Unsafely casts `numInGroup` to be an `int` when setting `count` field so that "larger" types than `uint16` may be supported without breaking the existing API
- Checks that the encoding of `numInGroup` does not exceed the range of an `int` at generation time in order to make the above cast safe
- Adds tests around this check