### PR TITLE
Handle IR changes to const enums for Rust; re-enable regression tests

### DIFF
--- a/rust/car_example/src/main.rs
+++ b/rust/car_example/src/main.rs
@@ -46,6 +46,7 @@ impl std::convert::From<CodecErr> for IoError {
 fn decode_car_and_assert_expected_content(buffer: &[u8]) -> CodecResult<()> {
     let (h, dec_fields) = start_decoding_car(&buffer).header()?;
     assert_eq!(49u16, h.block_length);
+    assert_eq!(h.block_length as usize, ::std::mem::size_of::<CarFields>());
     assert_eq!(1u16, h.template_id);
     assert_eq!(1u16, h.schema_id);
     assert_eq!(0u16, h.version);
@@ -67,6 +68,11 @@ fn decode_car_and_assert_expected_content(buffer: &[u8]) -> CodecResult<()> {
     assert!(fields.extras.get_cruise_control());
     assert!(fields.extras.get_sports_pack());
     assert!(!fields.extras.get_sun_roof());
+    assert_eq!(2000, fields.engine.capacity);
+    assert_eq!(4, fields.engine.num_cylinders);
+    assert_eq!(BoostType::NITROUS, fields.engine.booster.boost_type);
+    assert_eq!(200, fields.engine.booster.horse_power);
+    println!("Static-length fields all match the expected values");
 
     let dec_perf_figures_header = match dec_fuel_figures_header.fuel_figures_individually()? {
         Either::Left(mut dec_ff_members) => {

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/NamedToken.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/NamedToken.java
@@ -43,10 +43,16 @@ public class NamedToken
         return typeToken;
     }
 
-    public static List<NamedToken> gatherNamedFieldTokens(final List<Token> fields)
+    public static List<NamedToken> gatherNamedNonConstantFieldTokens(final List<Token> fields)
     {
         final List<NamedToken> namedTokens = new ArrayList<>();
-        forEachField(fields, (f, t) -> namedTokens.add(new NamedToken(f.name(), t)));
+        forEachField(fields, (f, t) ->
+        {
+            if (!f.isConstantEncoding())
+            {
+                namedTokens.add(new NamedToken(f.name(), t));
+            }
+        });
 
         return namedTokens;
     }

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustGeneratorTest.java
@@ -133,6 +133,11 @@ public class RustGeneratorTest
     {
         final String generatedRust = fullGenerateForResource(outputManager, "example-schema");
         assertContainsSharedImports(generatedRust);
+        assertContains(generatedRust,
+            "pub fn car_fields(mut self) -> CodecResult<(&'d CarFields, CarFuelFiguresHeaderDecoder<'d>)> {\n" +
+            "    let v = self.scratch.read_type::<CarFields>(49)?;\n" +
+            "    Ok((v, CarFuelFiguresHeaderDecoder::wrap(self.scratch)))\n" +
+            "  }");
         final String expectedBooleanTypeDeclaration =
             "#[derive(Clone,Copy,Debug,PartialEq,Eq,PartialOrd,Ord,Hash)]\n" +
             "#[repr(u8)]\n" +
@@ -236,7 +241,6 @@ public class RustGeneratorTest
         assertRustBuildable(rust, Optional.of(localResourceSchema));
     }
 
-    @Ignore
     @Test
     public void checkValidRustFromAllExampleSchema() throws IOException, InterruptedException
     {
@@ -267,7 +271,36 @@ public class RustGeneratorTest
         }
     }
 
-    @Ignore
+    @Test
+    public void constantEnumFields() throws IOException, InterruptedException
+    {
+        final String rust = fullGenerateForResource(outputManager, "constant-enum-fields");
+        assertContainsSharedImports(rust);
+        final String expectedCharTypeDeclaration =
+            "#[derive(Clone,Copy,Debug,PartialEq,Eq,PartialOrd,Ord,Hash)]\n" +
+            "#[repr(i8)]\n" +
+            "pub enum Model {\n" +
+            "  A = 65i8,\n" +
+            "  B = 66i8,\n" +
+            "  C = 67i8,\n" +
+            "}\n";
+        assertContains(rust, expectedCharTypeDeclaration);
+        assertContains(rust, "pub struct ConstantEnumsFields {\n}");
+        assertContains(rust, "impl ConstantEnumsFields {");
+        assertContains(rust, "  pub fn c() -> Model {\n" +
+            "    Model::C\n  }");
+        assertContains(rust, "impl ConstantEnumsFMember {");
+        assertContains(rust, "  pub fn k() -> Model {\n" +
+            "    Model::C\n  }");
+        assertContains(rust,
+            "pub fn constant_enums_fields(mut self) -> " +
+            "CodecResult<(&'d ConstantEnumsFields, ConstantEnumsFHeaderDecoder<'d>)> {\n" +
+            "    let v = self.scratch.read_type::<ConstantEnumsFields>(0)?;\n" +
+            "    Ok((v, ConstantEnumsFHeaderDecoder::wrap(self.scratch)))\n" +
+            "  }");
+        assertRustBuildable(rust, Optional.of("constant-enum-fields"));
+    }
+
     @Test
     public void constantFieldsCase() throws IOException, InterruptedException
     {

--- a/sbe-tool/src/test/resources/constant-enum-fields.xml
+++ b/sbe-tool/src/test/resources/constant-enum-fields.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   package="baseline"
+                   id="1"
+                   version="0"
+                   semanticVersion="5.2"
+                   description="Enum Constants as top-level and group field"
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader" description="Message identifiers and length of message root">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+        <composite name="groupSizeEncoding" description="Repeating group dimensions">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="numInGroup" primitiveType="uint16"/>
+        </composite>
+    </types>
+    <types>
+        <enum name="Model" encodingType="char">
+            <validValue name="A">A</validValue>
+            <validValue name="B">B</validValue>
+            <validValue name="C">C</validValue>
+        </enum>
+    </types>
+    <sbe:message name="ConstantEnums" id="1" description="">
+        <field name="c" id="4" type="Model" presence="constant" valueRef="Model.C"/>
+        <group name="f" id="7" dimensionType="groupSizeEncoding">
+            <field name="k" id="12" type="Model" presence="constant" valueRef="Model.C"/>
+        </group>
+    </sbe:message>
+</sbe:messageSchema>


### PR DESCRIPTION
As requested in https://github.com/real-logic/simple-binary-encoding/issues/560