### PR TITLE
Header validation warning on non-uint16 types instead of error

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/CompositeType.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/CompositeType.java
@@ -323,7 +323,7 @@ public class CompositeType extends Type
         }
         else if (templateIdType.primitiveType() != UINT16)
         {
-            XmlSchemaParser.handleWarning(node, "\"templateId\" must be UINT16");
+            XmlSchemaParser.handleWarning(node, "\"templateId\" should be UINT16");
         }
 
         if (schemaIdType == null)
@@ -332,7 +332,7 @@ public class CompositeType extends Type
         }
         else if (schemaIdType.primitiveType() != UINT16)
         {
-            XmlSchemaParser.handleWarning(node, "\"schemaId\" must be UINT16");
+            XmlSchemaParser.handleWarning(node, "\"schemaId\" should be UINT16");
         }
 
         if (versionType == null)
@@ -341,7 +341,7 @@ public class CompositeType extends Type
         }
         else if (versionType.primitiveType() != UINT16)
         {
-            XmlSchemaParser.handleWarning(node, "\"version\" must be UINT16");
+            XmlSchemaParser.handleWarning(node, "\"version\" should be UINT16");
         }
     }
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/CompositeType.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/CompositeType.java
@@ -323,7 +323,7 @@ public class CompositeType extends Type
         }
         else if (templateIdType.primitiveType() != UINT16)
         {
-            XmlSchemaParser.handleError(node, "\"templateId\" must be UINT16");
+            XmlSchemaParser.handleWarning(node, "\"templateId\" must be UINT16");
         }
 
         if (schemaIdType == null)
@@ -332,7 +332,7 @@ public class CompositeType extends Type
         }
         else if (schemaIdType.primitiveType() != UINT16)
         {
-            XmlSchemaParser.handleError(node, "\"schemaId\" must be UINT16");
+            XmlSchemaParser.handleWarning(node, "\"schemaId\" must be UINT16");
         }
 
         if (versionType == null)
@@ -341,7 +341,7 @@ public class CompositeType extends Type
         }
         else if (versionType.primitiveType() != UINT16)
         {
-            XmlSchemaParser.handleError(node, "\"version\" must be UINT16");
+            XmlSchemaParser.handleWarning(node, "\"version\" must be UINT16");
         }
     }
 


### PR DESCRIPTION
SBE generator currently errors out if schema/template/version fields are not 16 bits.  This PR changes that error to a warning to match the existing validation for blockLength

Similar to #609 and #617 