### PR TITLE
[Java] fix: remove extra empty lines

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangGenerator.java
@@ -568,7 +568,6 @@ public class GolangGenerator implements CodeGenerator
         init.append("\treturn\n}\n");
     }
 
-
     // Newer messages and groups can add extra properties before the variable
     // length elements (groups and varData). We read past the difference
     // between the message's blockLength and our (older) schema's blockLength

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/Encoding.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/Encoding.java
@@ -213,7 +213,6 @@ public class Encoding
         return primitiveType.minValue();
     }
 
-
     /**
      * The most applicable max value for the encoded type.
      *


### PR DESCRIPTION
This PR is created because of violations found during regression testing after implementing [checkstyle](https://github.com/checkstyle/checkstyle/) ability to check multiple lines with comments and javadocs.
Issue: https://github.com/checkstyle/checkstyle/issues/5981
PR: https://github.com/checkstyle/checkstyle/pull/6388
Checkstyle use simple-binary-encoding source code in regression testing.
Testing of checkstyle PR shows places with multiple lines used to separate methods.

You can merge this PR or create your own when checkstyle PR will be merged.
