### PR TITLE
[Rust] Generate NullVal enum values

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -1356,6 +1356,16 @@ public class RustGenerator implements CodeGenerator
                     .append(",\n");
             }
 
+            // null value
+            final Token token = messageBody.get(0);
+            final Encoding encoding = token.encoding();
+            final CharSequence nullVal = generateRustLiteral(
+                encoding.primitiveType(), encoding.applicableNullValue().toString());
+            indent(writer, 1).append("NullVal")
+                .append(" = ")
+                .append(nullVal)
+                .append(",\n");
+
             writer.append("}\n");
         }
     }

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustGeneratorTest.java
@@ -124,6 +124,7 @@ public class RustGeneratorTest
             "pub enum ENUM {\n" +
             "  Value1 = 1u8,\n" +
             "  Value10 = 10u8,\n" +
+            "  NullVal = 255u8,\n" +
             "}\n";
         assertTrue(generatedRust.contains(expectedDeclaration));
     }
@@ -144,6 +145,7 @@ public class RustGeneratorTest
             "pub enum BooleanType {\n" +
             "  F = 0u8,\n" +
             "  T = 1u8,\n" +
+            "  NullVal = 255u8,\n" +
             "}\n";
         assertTrue(generatedRust.contains(expectedBooleanTypeDeclaration));
         final String expectedCharTypeDeclaration =
@@ -153,6 +155,7 @@ public class RustGeneratorTest
             "  A = 65i8,\n" +
             "  B = 66i8,\n" +
             "  C = 67i8,\n" +
+            "  NullVal = 0i8,\n" +
             "}\n";
         assertTrue(generatedRust.contains(expectedCharTypeDeclaration));
         assertRustBuildable(generatedRust, Optional.of("example-schema"));
@@ -283,6 +286,7 @@ public class RustGeneratorTest
             "  A = 65i8,\n" +
             "  B = 66i8,\n" +
             "  C = 67i8,\n" +
+            "  NullVal = 0i8,\n" +
             "}\n";
         assertContains(rust, expectedCharTypeDeclaration);
         assertContains(rust, "pub struct ConstantEnumsFields {\n}");
@@ -313,6 +317,7 @@ public class RustGeneratorTest
             "  A = 65i8,\n" +
             "  B = 66i8,\n" +
             "  C = 67i8,\n" +
+            "  NullVal = 0i8,\n" +
             "}\n";
         assertContains(rust, expectedCharTypeDeclaration);
         final String expectedComposite =


### PR DESCRIPTION
Mimic the Java generator in generating null enum values. The `NullVal`
values are generated even if the enum type is not optional.