### PR TITLE
[Rust] Fix warnings in the generated codec

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -648,7 +648,7 @@ public class RustGenerator implements CodeGenerator
             indent(out).append("}\n");
 
             indent(out).append("#[inline]\n");
-            indent(out, 1, "fn after_member(mut self) -> %s {\n", groupLevelNextDecoderType);
+            indent(out, 1, "fn after_member(self) -> %s {\n", groupLevelNextDecoderType);
             indent(out, 2).append("if self.index <= self.max_index {\n");
             indent(out, 3).append("Either::Left(self)\n");
             indent(out, 2).append("} else {\n").append(INDENT).append(INDENT).append(INDENT)

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -197,7 +197,7 @@ public class RustGenerator implements CodeGenerator
         final String setType = formatTypeName(beginToken.applicableTypeName());
         try (Writer writer = outputManager.createOutput(setType + " bit set"))
         {
-            writer.append("#[derive(Debug,Default)]\n");
+            writer.append("#[derive(Default)]\n");
             writer.append("#[repr(C,packed)]\n");
             final String rustPrimitiveType = rustTypeName(beginToken.encoding().primitiveType());
             writer.append(format("pub struct %s(pub %s);\n", setType, rustPrimitiveType));


### PR DESCRIPTION
1. Debug can't be derived on packed structs
2. `mut` qualifier unnecessary in `after_member` function