### PR TITLE
Rust codec improvements - handle offsets, custom group size encoding

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -533,9 +533,10 @@ task generateRustCarExample(type: JavaExec) {
     classpath = project(':sbe-all').sourceSets.main.runtimeClasspath
     systemProperties(
         'sbe.output.dir': 'rust/car_example/src',
+        'sbe.xinclude.aware': 'true',
         'sbe.target.language': 'uk.co.real_logic.sbe.generation.rust.Rust',
         'sbe.target.namespace': 'car_example_generated_codec')
-    args = ['sbe-tool/src/test/resources/example-schema.xml']
+    args = ['sbe-samples/src/main/resources/example-schema.xml']
 }
 
 task generateCarExampleDataFile(type: JavaExec) {

--- a/rust/car_example/src/main.rs
+++ b/rust/car_example/src/main.rs
@@ -45,11 +45,11 @@ impl std::convert::From<CodecErr> for IoError {
 
 fn decode_car_and_assert_expected_content(buffer: &[u8]) -> CodecResult<()> {
     let (h, dec_fields) = start_decoding_car(&buffer).header()?;
-    assert_eq!(49u16, h.block_length);
+    assert_eq!(45u16, {h.block_length});
     assert_eq!(h.block_length as usize, ::std::mem::size_of::<CarFields>());
-    assert_eq!(1u16, h.template_id);
-    assert_eq!(1u16, h.schema_id);
-    assert_eq!(0u16, h.version);
+    assert_eq!(1u16, {h.template_id});
+    assert_eq!(1u16, {h.schema_id});
+    assert_eq!(0u16, {h.version});
     println!("Header read");
 
     assert_eq!(Model::C, CarFields::discounted_model());
@@ -59,16 +59,16 @@ fn decode_car_and_assert_expected_content(buffer: &[u8]) -> CodecResult<()> {
     let mut found_fuel_figures = Vec::<FuelFigure>::with_capacity(EXPECTED_FUEL_FIGURES.len());
 
     let (fields, dec_fuel_figures_header) = dec_fields.car_fields()?;
-    assert_eq!(1234, fields.serial_number);
-    assert_eq!(2013, fields.model_year);
-    assert_eq!(BooleanType::T, fields.available);
-    assert_eq!([97_i8, 98, 99, 100, 101, 102], fields.vehicle_code); // abcdef
-    assert_eq!([0_u32, 1, 2, 3, 4], fields.some_numbers);
+    assert_eq!(1234, {fields.serial_number});
+    assert_eq!(2013, {fields.model_year});
+    assert_eq!(BooleanType::T, {fields.available});
+    assert_eq!([97_i8, 98, 99, 100, 101, 102], {fields.vehicle_code}); // abcdef
+    assert_eq!([1, 2, 3, 4], {fields.some_numbers});
     assert_eq!(6, fields.extras.0);
     assert!(fields.extras.get_cruise_control());
     assert!(fields.extras.get_sports_pack());
     assert!(!fields.extras.get_sun_roof());
-    assert_eq!(2000, fields.engine.capacity);
+    assert_eq!(2000, {fields.engine.capacity});
     assert_eq!(4, fields.engine.num_cylinders);
     assert_eq!(BoostType::NITROUS, fields.engine.booster.boost_type);
     assert_eq!(200, fields.engine.booster.horse_power);
@@ -82,12 +82,12 @@ fn decode_car_and_assert_expected_content(buffer: &[u8]) -> CodecResult<()> {
                 let (usage_description, next_step) = dec_usage_description.usage_description()?;
                 let usage_str = std::str::from_utf8(usage_description).unwrap();
                 println!("Fuel Figure: Speed: {0}, MPG: {1}, Usage: {2}",
-                         ff_fields.speed,
-                         ff_fields.mpg,
+                         {ff_fields.speed},
+                         {ff_fields.mpg},
                          usage_str);
                 found_fuel_figures.push(FuelFigure {
-                                            speed: ff_fields.speed,
-                                            mpg: ff_fields.mpg,
+                                            speed: {ff_fields.speed},
+                                            mpg: {ff_fields.mpg},
                                             usage_description: usage_str,
                                         });
                 match next_step {
@@ -117,8 +117,8 @@ fn decode_car_and_assert_expected_content(buffer: &[u8]) -> CodecResult<()> {
                 let (accel_slice, next_step) = dec_acceleration_header.acceleration_as_slice()?;
                 for accel_fields in accel_slice {
                     println!("Acceleration: MPH: {0}, Seconds: {1}",
-                             accel_fields.mph,
-                             accel_fields.seconds);
+                             {accel_fields.mph},
+                             {accel_fields.seconds});
                 }
                 match next_step {
                     Either::Left(more_members) => dec_pf_members = more_members,
@@ -165,7 +165,7 @@ fn encode_car_from_scratch() -> CodecResult<Vec<u8>> {
         fields.available = BooleanType::T;
         fields.code = Model::A;
         fields.vehicle_code = [97_i8, 98, 99, 100, 101, 102]; // abcdef
-        fields.some_numbers = [0_u32, 1, 2, 3, 4];
+        fields.some_numbers = [1, 2, 3, 4];
         fields.extras = OptionalExtras::new();
         fields.extras.set_cruise_control(true)
             .set_sports_pack(true)

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustCodecType.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustCodecType.java
@@ -54,7 +54,7 @@ enum RustCodecType
             if (trailingBytes > 0)
             {
                 indent(appendable, 2, "self.%s.skip_bytes(%s)?;\n",
-                        RustCodecType.Decoder.scratchProperty(), trailingBytes);
+                    RustCodecType.Decoder.scratchProperty(), trailingBytes);
             }
             indent(appendable, 2, "Ok((v, %s::wrap(self.%s)))\n",
                 nextCoderType, RustCodecType.Decoder.scratchProperty());
@@ -112,7 +112,7 @@ enum RustCodecType
             {
                 indent(appendable, 2, "// fixed message length > sum of field lengths\n");
                 indent(appendable, 2, "self.%s.skip_bytes(%s)?;\n",
-                        RustCodecType.Decoder.scratchProperty(), trailingBytes);
+                    RustCodecType.Decoder.scratchProperty(), trailingBytes);
             }
             indent(appendable, 2).append(format("Ok(%s::wrap(self.%s))\n",
                 nextCoderType, RustCodecType.Encoder.scratchProperty()));

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustCodecType.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustCodecType.java
@@ -44,12 +44,18 @@ enum RustCodecType
             final String methodName,
             final String representationType,
             final String nextCoderType,
-            final int numBytes) throws IOException
+            final int numBytes,
+            final int trailingBytes) throws IOException
         {
             indent(appendable, 1, "pub fn %s(mut self) -> CodecResult<(&%s %s, %s)> {\n",
                 methodName, DATA_LIFETIME, representationType, RustGenerator.withLifetime(nextCoderType));
             indent(appendable, 2, "let v = self.%s.read_type::<%s>(%s)?;\n",
                 RustCodecType.Decoder.scratchProperty(), representationType, numBytes);
+            if (trailingBytes > 0)
+            {
+                indent(appendable, 2, "self.%s.skip_bytes(%s)?;\n",
+                        RustCodecType.Decoder.scratchProperty(), trailingBytes);
+            }
             indent(appendable, 2, "Ok((v, %s::wrap(self.%s)))\n",
                 nextCoderType, RustCodecType.Decoder.scratchProperty());
             indent(appendable).append("}\n");
@@ -78,15 +84,20 @@ enum RustCodecType
             final String methodName,
             final String representationType,
             final String nextCoderType,
-            final int numBytes) throws IOException
+            final int numBytes,
+            final int trailingBytes) throws IOException
         {
             indent(appendable, 1, "\n/// Create a mutable struct reference overlaid atop the data buffer\n");
             indent(appendable, 1, "/// such that changes to the struct directly edit the buffer. \n");
             indent(appendable, 1, "/// Note that the initial content of the struct's fields may be garbage.\n");
             indent(appendable, 1, "pub fn %s(mut self) -> CodecResult<(&%s mut %s, %s)> {\n",
                 methodName, DATA_LIFETIME, representationType, RustGenerator.withLifetime(nextCoderType));
-            indent(appendable, 2, "let v = self.%s.writable_overlay::<%s>(%s)?;\n",
-                RustCodecType.Encoder.scratchProperty(), representationType, numBytes);
+            if (trailingBytes > 0)
+            {
+                indent(appendable, 2, "// add trailing bytes to extend the end position of the scratch buffer\n");
+            }
+            indent(appendable, 2, "let v = self.%s.writable_overlay::<%s>(%s+%s)?;\n",
+                RustCodecType.Encoder.scratchProperty(), representationType, numBytes, trailingBytes);
             indent(appendable, 2, "Ok((v, %s::wrap(self.%s)))\n",
                 nextCoderType, RustCodecType.Encoder.scratchProperty());
             indent(appendable).append("}\n\n");
@@ -97,6 +108,12 @@ enum RustCodecType
             indent(appendable, 2)
                 .append(format("self.%s.write_type::<%s>(t, %s)?;\n",
                 RustCodecType.Encoder.scratchProperty(), representationType, numBytes));
+            if (trailingBytes > 0)
+            {
+                indent(appendable, 2, "// fixed message length > sum of field lengths\n");
+                indent(appendable, 2, "self.%s.skip_bytes(%s)?;\n",
+                        RustCodecType.Decoder.scratchProperty(), trailingBytes);
+            }
             indent(appendable, 2).append(format("Ok(%s::wrap(self.%s))\n",
                 nextCoderType, RustCodecType.Encoder.scratchProperty()));
             indent(appendable).append("}\n");
@@ -125,7 +142,8 @@ enum RustCodecType
         String methodName,
         String representationType,
         String nextCoderType,
-        int numBytes) throws IOException;
+        int numBytes,
+        int trailingBytes) throws IOException;
 
     abstract String gerund();
 
@@ -175,7 +193,7 @@ enum RustCodecType
             appendScratchWrappingStruct(writer, headerCoderType);
             RustGenerator.appendImplWithLifetimeHeader(writer, headerCoderType);
             appendWrapMethod(writer, headerCoderType);
-            appendDirectCodeMethods(writer, "header", messageHeaderRepresentation, topType, headerSize);
+            appendDirectCodeMethods(writer, "header", messageHeaderRepresentation, topType, headerSize, 0);
             writer.append("}\n");
         }
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -196,6 +196,34 @@ public class RustGenerator implements CodeGenerator
 
             writer.append("}\n");
         }
+
+        try (Writer writer = outputManager.createOutput(setType + " bit set debug"))
+        {
+            indent(writer, 0, "impl core::fmt::Debug for %s {\n", setType);
+            indent(writer, 1, "fn fmt(&self, fmt: &mut core::fmt::Formatter) -> core::fmt::Result {\n");
+            indent(writer, 2, "write!(fmt, \"%s[", setType);
+
+            final StringBuilder string = new StringBuilder();
+            final StringBuilder arguments = new StringBuilder();
+            for (final Token token : tokens)
+            {
+                if (Signal.CHOICE != token.signal())
+                {
+                    continue;
+                }
+
+                final String choiceName = formatMethodName(token.name());
+                final String choiceBitIndex = token.encoding().constValue().toString();
+
+                string.append(choiceName + "(" + choiceBitIndex + ")={},");
+                arguments.append("self.get_" + choiceName + "(),");
+            }
+
+            writer.append(string.toString() + "]\",\n");
+            indent(writer, 3, arguments.toString() + ")\n");
+            indent(writer, 1, "}\n");
+            writer.append("}\n");
+        }
     }
 
     private static void generateMessageEncoder(

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustGeneratorTest.java
@@ -291,6 +291,22 @@ public class RustGeneratorTest
     }
 
     @Test
+    public void messageWithOffsets()
+    {
+        final String rust = fullGenerateForResource(outputManager, "composite-offsets-schema");
+        final String expectedHeader =
+                "pub struct MessageHeader {\n" +
+                "  pub block_length:u16,\n" +
+                "  template_id_padding:[u8;2],\n" +
+                "  pub template_id:u16,\n" +
+                "  schema_id_padding:[u8;2],\n" +
+                "  pub schema_id:u16,\n" +
+                "  pub version:u16,\n" +
+                "}";
+        assertContains(rust, expectedHeader);
+    }
+
+    @Test
     public void constantEnumFields() throws IOException, InterruptedException
     {
         final String rust = fullGenerateForResource(outputManager, "constant-enum-fields");

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustGeneratorTest.java
@@ -187,12 +187,13 @@ public class RustGeneratorTest
         return folder;
     }
 
-    private static class CargoCheckResult
+    private static final class CargoCheckResult
     {
         final boolean isSuccess;
         final String error;
 
-        private CargoCheckResult(boolean isSuccess, String error) {
+        private CargoCheckResult(final boolean isSuccess, final String error)
+        {
             this.isSuccess = isSuccess;
             this.error = error;
         }
@@ -218,7 +219,9 @@ public class RustGeneratorTest
                     if (line == null)
                     {
                         break;
-                    } else {
+                    }
+                    else
+                    {
                         errorString.append(line);
                         errorString.append('\n');
                     }
@@ -250,7 +253,8 @@ public class RustGeneratorTest
         Assume.assumeTrue(cargoExists());
         final File folder = writeCargoFolderWrapper(name.orElse("test"), generatedRust, folderRule.newFolder());
         final CargoCheckResult result = cargoCheckInDirectory(folder);
-        assertTrue(String.format("Generated Rust (%s) should be buildable with cargo", name) + result.error, result.isSuccess);
+        assertTrue(String.format("Generated Rust (%s) should be buildable with cargo", name) + result.error,
+            result.isSuccess);
     }
 
     private void assertSchemaInterpretableAsRust(final String localResourceSchema)
@@ -295,14 +299,14 @@ public class RustGeneratorTest
     {
         final String rust = fullGenerateForResource(outputManager, "composite-offsets-schema");
         final String expectedHeader =
-                "pub struct MessageHeader {\n" +
-                "  pub block_length:u16,\n" +
-                "  template_id_padding:[u8;2],\n" +
-                "  pub template_id:u16,\n" +
-                "  schema_id_padding:[u8;2],\n" +
-                "  pub schema_id:u16,\n" +
-                "  pub version:u16,\n" +
-                "}";
+            "pub struct MessageHeader {\n" +
+            "  pub block_length:u16,\n" +
+            "  template_id_padding:[u8;2],\n" +
+            "  pub template_id:u16,\n" +
+            "  schema_id_padding:[u8;2],\n" +
+            "  pub schema_id:u16,\n" +
+            "  pub version:u16,\n" +
+            "}";
         assertContains(rust, expectedHeader);
     }
 
@@ -313,7 +317,7 @@ public class RustGeneratorTest
         final String expectedEncoderSegment = "let v = self.scratch.writable_overlay::<MsgNameFields>(9+2)?;";
         assertContains(rust, expectedEncoderSegment);
         final String expectedDecoderSegment = "let v = self.scratch.read_type::<MsgNameFields>(9)?;\n" +
-                "    self.scratch.skip_bytes(2)?;";
+            "    self.scratch.skip_bytes(2)?;";
         assertContains(rust, expectedDecoderSegment);
     }
 

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustGeneratorTest.java
@@ -301,9 +301,9 @@ public class RustGeneratorTest
         final String expectedHeader =
             "pub struct MessageHeader {\n" +
             "  pub block_length:u16,\n" +
-            "  template_id_padding:[u8;2],\n" +
+            "  template_id_padding_1:[u8;2],\n" +
             "  pub template_id:u16,\n" +
-            "  schema_id_padding:[u8;2],\n" +
+            "  schema_id_padding_1:[u8;2],\n" +
             "  pub schema_id:u16,\n" +
             "  pub version:u16,\n" +
             "}";

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustGeneratorTest.java
@@ -307,6 +307,17 @@ public class RustGeneratorTest
     }
 
     @Test
+    public void messageBlockLengthExceedingSumOfFieldLengths()
+    {
+        final String rust = fullGenerateForResource(outputManager, "message-block-length-test");
+        final String expectedEncoderSegment = "let v = self.scratch.writable_overlay::<MsgNameFields>(9+2)?;";
+        assertContains(rust, expectedEncoderSegment);
+        final String expectedDecoderSegment = "let v = self.scratch.read_type::<MsgNameFields>(9)?;\n" +
+                "    self.scratch.skip_bytes(2)?;";
+        assertContains(rust, expectedDecoderSegment);
+    }
+
+    @Test
     public void constantEnumFields() throws IOException, InterruptedException
     {
         final String rust = fullGenerateForResource(outputManager, "constant-enum-fields");

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustGeneratorTest.java
@@ -234,7 +234,7 @@ public class RustGeneratorTest
     {
         Assume.assumeTrue(cargoExists());
         final File folder = writeCargoFolderWrapper(name.orElse("test"), generatedRust, folderRule.newFolder());
-        assertTrue("Generated Rust should be buildable with cargo", cargoCheckInDirectory(folder));
+        assertTrue(String.format("Generated Rust (%s) should be buildable with cargo", name), cargoCheckInDirectory(folder));
     }
 
     private void assertSchemaInterpretableAsRust(final String localResourceSchema)


### PR DESCRIPTION
Fixed a few issues with the Rust codec. Decoders can now handle messages with custom offsets, custom default message header and custom group size encodings. Custom group size is not yet implemented for encoders.

There are also no tests for Rust which would exercise the full encode -> decode cycle. Hopefully I'll get to that and improving encoders when I need to do encoding.