### PR TITLE
enhancements to Rust generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,7 +13,7 @@
 # Build tools
 build-local.properties
 deps
-/bin
+*/bin
 build
 .gradle
 target
@@ -23,6 +23,7 @@ GPATH
 prop
 out
 .vs/
+.vscode
 
 # cmake
 

--- a/build.gradle
+++ b/build.gradle
@@ -569,7 +569,8 @@ def cargo_exists() {
     try {
         def result = project.exec {
             executable = 'cargo'
-            args = '-v'
+            args = [ '-V' ]
+            standardOutput = new ByteArrayOutputStream()
         }
         return result.exitValue == 0
     }

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustCodecType.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustCodecType.java
@@ -173,7 +173,7 @@ enum RustCodecType
         throws IOException
     {
         appendable.append("\n").append(INDENT).append(String.format(
-            "fn wrap(%s: %s) -> %s {%n", scratchProperty(), RustGenerator.withLifetime(scratchType()),
+            "pub fn wrap(%s: %s) -> %s {%n", scratchProperty(), RustGenerator.withLifetime(scratchType()),
             RustGenerator.withLifetime(structName)));
         indent(appendable, 2, "%s { %s: %s }\n",
             structName, scratchProperty(), scratchProperty());

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -291,8 +291,8 @@ public class RustGenerator implements CodeGenerator
         final OutputManager outputManager,
         final int headerSize) throws IOException
     {
-        String messageTypeName = "MessageHeader";
-        RustCodecType codecType = RustCodecType.Decoder;
+        final String messageTypeName = "MessageHeader";
+        final RustCodecType codecType = RustCodecType.Decoder;
         try (Writer writer = outputManager.createOutput(messageTypeName + format(" %s entry point", codecType.name())))
         {
             final String gerund = codecType.gerund();
@@ -1821,7 +1821,7 @@ public class RustGenerator implements CodeGenerator
             indent(writer, 1, "pub message_header: MessageHeader\n");
             writer.append("}\n");
 
-            final String blockLength =  Integer.toString(messageToken.encodedLength());
+            final String blockLength = Integer.toString(messageToken.encodedLength());
             final String templateId = Integer.toString(messageToken.id());
             final String schemaId = Integer.toString(ir.id());
             final String version = Integer.toString(ir.version());

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustGeneratorTest.java
@@ -237,7 +237,7 @@ public class RustGeneratorTest
     {
         try
         {
-            final ProcessBuilder builder = new ProcessBuilder("cargo", "-v");
+            final ProcessBuilder builder = new ProcessBuilder("cargo", "-V");
             final Process process = builder.start();
             process.waitFor(5, TimeUnit.SECONDS);
             return process.exitValue() == 0;

--- a/sbe-tool/src/test/resources/message-block-length-test.xml
+++ b/sbe-tool/src/test/resources/message-block-length-test.xml
@@ -15,7 +15,7 @@
             <type name="blockLength" primitiveType="uint16"/>
             <type name="numInGroup" primitiveType="uint8" semanticType="NumInGroup"/>
         </composite>
-        <set name="event" encodingType="uint8">
+        <set name="choice_event" encodingType="uint8">
             <choice name="choice0">0</choice>
             <choice name="choice1">1</choice>
             <choice name="choice2">2</choice>
@@ -28,7 +28,7 @@
     </types>
     <message name="msgName" id="10" blockLength="11" semanticType="M">
         <field name="field1" id="11" type="uint64" offset="0" semanticType="UTCTimestamp"/>
-        <field name="field2" id="12" type="event" offset="8" semanticType="MultipleCharValue"/>
+        <field name="field2" id="12" type="choice_event" offset="8" semanticType="MultipleCharValue"/>
         <group name="grName" id="20" dimensionType="groupSizeEncoding">
             <field name="grField1" id="21" type="uint64" semanticType="int"/>
             <field name="grField2" id="22" type="int64" semanticType="int"/>

--- a/sbe-tool/src/test/resources/message-block-length-test.xml
+++ b/sbe-tool/src/test/resources/message-block-length-test.xml
@@ -15,7 +15,7 @@
             <type name="blockLength" primitiveType="uint16"/>
             <type name="numInGroup" primitiveType="uint8" semanticType="NumInGroup"/>
         </composite>
-        <set name="choice_event" encodingType="uint8">
+        <set name="event" encodingType="uint8">
             <choice name="choice0">0</choice>
             <choice name="choice1">1</choice>
             <choice name="choice2">2</choice>
@@ -28,7 +28,7 @@
     </types>
     <message name="msgName" id="10" blockLength="11" semanticType="M">
         <field name="field1" id="11" type="uint64" offset="0" semanticType="UTCTimestamp"/>
-        <field name="field2" id="12" type="choice_event" offset="8" semanticType="MultipleCharValue"/>
+        <field name="field2" id="12" type="event" offset="8" semanticType="MultipleCharValue"/>
         <group name="grName" id="20" dimensionType="groupSizeEncoding">
             <field name="grField1" id="21" type="uint64" semanticType="int"/>
             <field name="grField2" id="22" type="int64" semanticType="int"/>


### PR DESCRIPTION
while experimenting with the Rust generator I found a few things that didn't work as expected:

* cargo_exits() in build.gradle wasn't finding cargo
    * the 'args' argument should be an array of arguments
    * was using `-v` (verbose) instead of `-V` (version).  `-V` is valid by itself while `-v` is not.
    * the output went to the screen 
* warnings during `gradlew.bat test`
    * caused by a type identifier that was invalid for C#

I cleaned those up and added the ability for rust to decode a header and then pick a template by `template_id`.  This required making some things pub which were private before but I don't think that's an issue.  The code for using this new method looks like this:
```Rust
let (h, buf) = start_decoding_message_header(&buffer)?;
match h.template_id {
    CarMessageHeader::TEMPLATE_ID => {
        let dec_fields = CarFieldsDecoder::wrap(buf);
        //...
    },
    _ => panic!("unknown template_id");
}
```

If keeping the `FieldsDecoder` and `ScratchDecoderData` private is really important then maybe some helper that skips over the bytes of decoded header would be sufficient.  The implementation here was just a 'get it to work for me' attempt and conversation-starter.