### PR TITLE
remove deprecated allowMissingJavadoc from JavadocMethod

### DIFF
--- a/config/checkstyle/checkstyle.xml
+++ b/config/checkstyle/checkstyle.xml
@@ -172,7 +172,6 @@
         </module>
 
         <module name="JavadocMethod">
-            <property name="allowMissingJavadoc" value="true"/>
             <property name="allowUndeclaredRTE" value="true"/>
         </module>
     </module>


### PR DESCRIPTION
Identified at https://github.com/checkstyle/checkstyle/pull/7088 , `allowMissingJavadoc` is deprecated and doesn't do anything anymore as the check was split into 2 and the functionality of the property was moved to `MissingJavadocMethod`.