### PR TITLE
[C++] Cast memcpy argument to size_t

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -472,7 +472,7 @@ public class CppGenerator implements CodeGenerator
                 indent + "        std::uint64_t bytesToCopy = length < dataLength ? length : dataLength;\n" +
                 indent + "        std::uint64_t pos = sbePosition();\n" +
                 indent + "        sbePosition(pos + dataLength);\n" +
-                indent + "        std::memcpy(dst, m_buffer + pos, bytesToCopy);\n" +
+                indent + "        std::memcpy(dst, m_buffer + pos, static_cast<size_t>(bytesToCopy));\n" +
                 indent + "        return bytesToCopy;\n" +
                 indent + "    }\n",
                 propertyName,
@@ -1441,7 +1441,8 @@ public class CppGenerator implements CodeGenerator
             indent + "        }\n\n" +
 
             "%3$s" +
-            indent + "        std::memcpy(dst, m_buffer + m_offset + %4$d, sizeof(%5$s) * length);\n" +
+            indent + "        std::memcpy(dst, m_buffer + m_offset + %4$d, " +
+            "sizeof(%5$s) * static_cast<size_t>(length));\n" +
             indent + "        return length;\n" +
             indent + "    }\n",
             toUpperFirstChar(propertyName),
@@ -1643,7 +1644,7 @@ public class CppGenerator implements CodeGenerator
             indent + "        std::uint64_t bytesToCopy = " +
             "length < sizeof(%2$sValues) ? length : sizeof(%2$sValues);\n\n" +
 
-            indent + "        std::memcpy(dst, %2$sValues, bytesToCopy);\n" +
+            indent + "        std::memcpy(dst, %2$sValues, static_cast<size_t>(bytesToCopy));\n" +
             indent + "        return bytesToCopy;\n" +
             indent + "    }\n",
             toUpperFirstChar(propertyName),


### PR DESCRIPTION
`memcpy` is expecting a `size_t` argument, 32-bit builds fail with the following message:
```
error: conversion to ‘size_t {aka unsigned int}’ from ‘uint64_t {aka long long unsigned int}’ may alter its value [-Werror=conversion]
```
Adding explicit cast to silence these errors/warnings.

(IMO it would be better to use `size_t` where byte arrays and offsets are referenced. However this would change the public interface, so didn't want to to this as part of this PR.)