### PR TITLE
[Java] Avoid memory allocation at varDataDisplay

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -3274,7 +3274,9 @@ public class JavaGenerator implements CodeGenerator
                     append(sb, indent, "builder.append('\\'');");
                     append(sb, indent, formatGetterName(varDataToken.name()) + "(builder);");
                     append(sb, indent, "builder.append('\\'');");
-                } else {
+                }
+                else
+                {
                     append(sb, indent, "builder.append('\\'').append(" + varDataName + "()).append('\\'');");
                 }
             }

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -904,7 +904,7 @@ public class JavaGenerator implements CodeGenerator
                     generateGet(lengthType, "limit", byteOrderStr),
                     byteOrderStr);
             }
-            if (characterEncoding.contains("UTF8"))
+            if (characterEncoding.contains("UTF"))
             {
                 new Formatter(sb).format("\n" +
                     indent + "    public int get%1$s(final Appendable appendable)\n" +

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -904,28 +904,6 @@ public class JavaGenerator implements CodeGenerator
                     generateGet(lengthType, "limit", byteOrderStr),
                     byteOrderStr);
             }
-            if (characterEncoding.contains("UTF"))
-            {
-                new Formatter(sb).format("\n" +
-                    indent + "    public int get%1$s(final Appendable appendable)\n" +
-                    indent + "    {\n" +
-                    "%2$s" +
-                    indent + "        final int headerLength = %3$d;\n" +
-                    indent + "        final int limit = parentMessage.limit();\n" +
-                    indent + "        final int dataLength = (int)%4$s;\n" +
-                    indent + "        final int dataOffset = limit + headerLength;\n\n" +
-                    indent + "        parentMessage.limit(dataOffset + dataLength);\n" +
-                    indent + "        appendable.append(buffer.getStringWithoutLengthUtf8(dataOffset, dataLength));\n\n" +
-                    //TODO: wait for signature below, similar to getStringWithoutLengthAscii(offset,length,appendable)
-                    indent + "        //buffer.getStringWithoutLengthUtf8(dataOffset, dataLength, appendable);\n\n" +
-                    indent + "        return dataLength;\n" +
-                    indent + "    }\n",
-                    Generators.toUpperFirstChar(propertyName),
-                    generateStringNotPresentConditionForAppendable(token.version(), indent),
-                    sizeOfLengthField,
-                    generateGet(lengthType, "limit", byteOrderStr),
-                    byteOrderStr);
-            }
         }
     }
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -3269,7 +3269,8 @@ public class JavaGenerator implements CodeGenerator
             }
             else
             {
-                append(sb, indent, "builder.append('\\'' + " + varDataName + "() + '\\'');");
+              //append(sb, indent, "builder.append('\\'' + " + varDataName + "() + '\\'');");
+                append(sb, indent, formatGetterName(varDataToken.name()) + "(builder);");
             }
 
             lengthBeforeLastGeneratedSeparator = sb.length();

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -904,6 +904,28 @@ public class JavaGenerator implements CodeGenerator
                     generateGet(lengthType, "limit", byteOrderStr),
                     byteOrderStr);
             }
+            if (characterEncoding.contains("UTF8"))
+            {
+                new Formatter(sb).format("\n" +
+                    indent + "    public int get%1$s(final Appendable appendable)\n" +
+                    indent + "    {\n" +
+                    "%2$s" +
+                    indent + "        final int headerLength = %3$d;\n" +
+                    indent + "        final int limit = parentMessage.limit();\n" +
+                    indent + "        final int dataLength = (int)%4$s;\n" +
+                    indent + "        final int dataOffset = limit + headerLength;\n\n" +
+                    indent + "        parentMessage.limit(dataOffset + dataLength);\n" +
+                    indent + "        appendable.append(buffer.getStringWithoutLengthUtf8(dataOffset, dataLength));\n\n" +
+                    //TODO: wait for signature below, similar to getStringWithoutLengthAscii(offset,length,appendable)
+                    indent + "        //buffer.getStringWithoutLengthUtf8(dataOffset, dataLength, appendable);\n\n" +
+                    indent + "        return dataLength;\n" +
+                    indent + "    }\n",
+                    Generators.toUpperFirstChar(propertyName),
+                    generateStringNotPresentConditionForAppendable(token.version(), indent),
+                    sizeOfLengthField,
+                    generateGet(lengthType, "limit", byteOrderStr),
+                    byteOrderStr);
+            }
         }
     }
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -3291,8 +3291,14 @@ public class JavaGenerator implements CodeGenerator
             }
             else
             {
-              //append(sb, indent, "builder.append('\\'' + " + varDataName + "() + '\\'');");
-                append(sb, indent, formatGetterName(varDataToken.name()) + "(builder);");
+                if (characterEncoding.contains("ASCII"))
+                {
+                    append(sb, indent, "builder.append('\\'');");
+                    append(sb, indent, formatGetterName(varDataToken.name()) + "(builder);");
+                    append(sb, indent, "builder.append('\\'');");
+                } else {
+                    append(sb, indent, "builder.append('\\'').append(" + varDataName + "()).append('\\'');");
+                }
             }
 
             lengthBeforeLastGeneratedSeparator = sb.length();

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaUtil.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaUtil.java
@@ -159,6 +159,18 @@ public class JavaUtil
     }
 
     /**
+     * Format a Getter name for generated code.
+     * <p>
+     *
+     * @param value to be formatted.
+     * @return the string formatted as a getter name.
+     */
+    public static String formatGetterName(final String value)
+    {
+        return "get" + Generators.toUpperFirstChar(value);
+    }
+
+    /**
      * Format a class name for the generated code.
      *
      * @param value to be formatted.


### PR DESCRIPTION
varDataDisplay - use method `getVarFieldName(Appendable)` - no memory allocation. unlike calling method `varFieldName` where it allocates memory (new byte[] and new String).
