### PR TITLE
[C++] Removed property access in ostream printer

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -2509,9 +2509,6 @@ public class CppGenerator implements CodeGenerator
                 sb.append(
                     indent + "builder << '\"' <<\n" +
                     indent + INDENT + getLengthFunction + " << \" bytes of raw data\\\"\";\n");
-
-                sb.append(
-                    indent + "writer." + propertyName + "();\n\n");
             }
             else
             {


### PR DESCRIPTION
* Removed generated access of a property when character encoding
is not set
* This fixes unused return value warning