### PR TITLE
Eliminated garbage produced in appendTo for set-based fields

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -3393,8 +3393,11 @@ public class JavaGenerator implements CodeGenerator
                 break;
 
             case BEGIN_ENUM:
-            case BEGIN_SET:
                 append(sb, indent, "builder.append(" + fieldName + "());");
+                break;
+
+            case BEGIN_SET:
+                append(sb, indent, fieldName + "().appendTo(builder);");
                 break;
 
             case BEGIN_COMPOSITE:


### PR DESCRIPTION
Eliminated garbage produced in appendTo for set-based fields to allow full GC-free logging of decoders