### PR TITLE
[C#] Add Offsets and WrapForEncodeAndApplyHeader

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -1097,7 +1097,7 @@ public class CSharpGenerator implements CodeGenerator
                 final Token encodingToken = tokens.get(i + 1);
                 final String propertyName = signalToken.name();
 
-                generateFieldIdMethod(sb, signalToken, indent + INDENT);            
+                generateFieldIdMethod(sb, signalToken, indent + INDENT);
                 generateFieldMetaAttributeMethod(sb, signalToken, indent + INDENT);
 
                 switch (encodingToken.signal())

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -1035,6 +1035,16 @@ public class CSharpGenerator implements CodeGenerator
             indent + INDENT + INDENT + "_actingVersion = SchemaVersion;\n" +
             indent + INDENT + INDENT + "Limit = offset + _actingBlockLength;\n" +
             indent + INDENT + "}\n\n" +
+            indent + INDENT + "public void WrapForEncodeAndApplyHeader(DirectBuffer buffer, int offset, MessageHeader headerEncoder)\n" +
+            indent + INDENT + "{\n" +
+            indent + INDENT + INDENT + "headerEncoder.Wrap(buffer, offset, SchemaVersion);\n" +
+            indent + INDENT + INDENT + "headerEncoder.BlockLength = BlockLength;\n" +
+            indent + INDENT + INDENT + "headerEncoder.TemplateId = TemplateId;\n" +
+            indent + INDENT + INDENT + "headerEncoder.SchemaId = SchemaId;\n" +
+            indent + INDENT + INDENT + "headerEncoder.Version = SchemaVersion;\n" +
+            indent + INDENT + INDENT + "\n" +
+            indent + INDENT + INDENT + "WrapForEncode(buffer, offset + MessageHeader.Size);\n" +
+            indent + INDENT + "}\n\n" +
             indent + INDENT + "public void WrapForDecode(DirectBuffer buffer, int offset, " +
                 "int actingBlockLength, int actingVersion)\n" +
             indent + INDENT + "{\n" +

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -1035,7 +1035,8 @@ public class CSharpGenerator implements CodeGenerator
             indent + INDENT + INDENT + "_actingVersion = SchemaVersion;\n" +
             indent + INDENT + INDENT + "Limit = offset + _actingBlockLength;\n" +
             indent + INDENT + "}\n\n" +
-            indent + INDENT + "public void WrapForEncodeAndApplyHeader(DirectBuffer buffer, int offset, MessageHeader headerEncoder)\n" +
+            indent + INDENT + "public void WrapForEncodeAndApplyHeader(DirectBuffer buffer, int offset, " +
+                " MessageHeader headerEncoder)\n" +
             indent + INDENT + "{\n" +
             indent + INDENT + INDENT + "headerEncoder.Wrap(buffer, offset, SchemaVersion);\n" +
             indent + INDENT + INDENT + "headerEncoder.BlockLength = BlockLength;\n" +

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -1087,7 +1087,7 @@ public class CSharpGenerator implements CodeGenerator
                 final Token encodingToken = tokens.get(i + 1);
                 final String propertyName = signalToken.name();
 
-                generateFieldIdMethod(sb, signalToken, indent + INDENT);
+                generateFieldIdMethod(sb, signalToken, indent + INDENT);            
                 generateFieldMetaAttributeMethod(sb, signalToken, indent + INDENT);
 
                 switch (encodingToken.signal())
@@ -1122,6 +1122,11 @@ public class CSharpGenerator implements CodeGenerator
             token.id()));
 
         generateSinceActingDeprecated(sb, indent, CSharpUtil.formatPropertyName(token.name()), token);
+
+        sb.append(String.format("\n" +
+            indent + "public const int %sOffset = %d;\n",
+            CSharpUtil.formatPropertyName(token.name()),
+            token.offset()));
     }
 
     private void generateFieldMetaAttributeMethod(final StringBuilder sb, final Token token, final String indent)


### PR DESCRIPTION
This adds two new members to the generated C# messages. Both of these are already available in the generated Java classes, but were missing in the C# version.

**`public const int <FieldMember>Offset`**
This is useful if you need to read/write a member with some other method than the generated accessors, e.g. read a fixed-length byte array as a `ReadOnlySpan<byte>`. Currently these offsets need to be hardcoded.

**`public void WrapForEncodeAndApplyHeader(DirectBuffer buffer, int offset, MessageHeader headerEncoder)`**
Generates the repetitive code to fill the header. Same as "wrapAndApplyHeader" in Java.