### PR TITLE
Upgrade csharp benchmark, samples and tests console app projects to u…

### DIFF
--- a/csharp/sbe-benchmarks/sbe-benchmarks.csproj
+++ b/csharp/sbe-benchmarks/sbe-benchmarks.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Org.SbeTool.Sbe.Benchmarks</RootNamespace>
     <AssemblyName>Org.SbeTool.Sbe.Benchmarks</AssemblyName>
     <OutputTypeEx>exe</OutputTypeEx>

--- a/csharp/sbe-samples-car/sbe-samples-car.csproj
+++ b/csharp/sbe-samples-car/sbe-samples-car.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
     <OutputTypeEx>exe</OutputTypeEx>
     <RootNamespace>Org.SbeTool.Sbe.Example.Car</RootNamespace>
     <AssemblyName>Org.SbeTool.Sbe.Example.Car</AssemblyName>

--- a/csharp/sbe-tests/sbe-tests.csproj
+++ b/csharp/sbe-tests/sbe-tests.csproj
@@ -1,6 +1,6 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp2.2</TargetFrameworks>
+    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
     <RootNamespace>Org.SbeTool.Sbe.Tests</RootNamespace>
     <AssemblyName>Org.SbeTool.Sbe.UnitTests</AssemblyName>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>


### PR DESCRIPTION
…se dotnet core 3.1 (LTS) as opposed to the end of life dotnet core 2.2 (which less people will have installed)