### PR TITLE
enum 'get' method is not noexcept

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -2264,7 +2264,7 @@ public class CppGenerator implements CodeGenerator
         else
         {
             new Formatter(sb).format("\n" +
-                indent + "    SBE_NODISCARD %1$s::Value %2$s() const SBE_NOEXCEPT\n" +
+                indent + "    SBE_NODISCARD %1$s::Value %2$s() const\n" +
                 indent + "    {\n" +
                 "%3$s" +
                 indent + "        %5$s val;\n" +


### PR DESCRIPTION
The C++ code generated for accessing the value of an enumeration was being marked with `SBE_NOEXCEPT` but it invokes the `get()` method for the enumeration, which can throw if the underlying value is not in the supported set of values.

The exception should propagate up to the caller, rather than invoke `std::terminate`