### PR TITLE
Improved internal offset/pointer usage in generated C# code (retry)

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/TargetCodeGeneratorLoader.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/TargetCodeGeneratorLoader.java
@@ -20,6 +20,8 @@ import uk.co.real_logic.sbe.generation.c.CGenerator;
 import uk.co.real_logic.sbe.generation.c.COutputManager;
 import uk.co.real_logic.sbe.generation.cpp.CppGenerator;
 import uk.co.real_logic.sbe.generation.cpp.NamespaceOutputManager;
+import uk.co.real_logic.sbe.generation.csharp.CSharpGenerator;
+import uk.co.real_logic.sbe.generation.csharp.CSharpNamespaceOutputManager;
 import uk.co.real_logic.sbe.generation.golang.GolangGenerator;
 import uk.co.real_logic.sbe.generation.golang.GolangOutputManager;
 import uk.co.real_logic.sbe.generation.java.JavaGenerator;
@@ -70,6 +72,14 @@ public enum TargetCodeGeneratorLoader implements TargetCodeGenerator
         public CodeGenerator newInstance(final Ir ir, final String outputDir)
         {
             return new CppGenerator(ir, new NamespaceOutputManager(outputDir, ir.applicableNamespace()));
+        }
+    },
+
+    CSHARP()
+    {
+        public CodeGenerator newInstance(final Ir ir, final String outputDir)
+        {
+            return new CSharpGenerator(ir, new CSharpNamespaceOutputManager(outputDir, ir.applicableNamespace()));
         }
     },
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -1191,7 +1191,7 @@ public class CSharpGenerator implements CodeGenerator
 
                 generateFieldIdMethod(sb, signalToken, indent + INDENT);
                 generateSinceActingDeprecated(
-                    sb, indent, CSharpUtil.formatPropertyName(signalToken.name()), signalToken);
+                    sb, indent + INDENT, CSharpUtil.formatPropertyName(signalToken.name()), signalToken);
                 generateOffsetMethod(sb, signalToken, indent + INDENT);
                 generateFieldMetaAttributeMethod(sb, signalToken, indent + INDENT);
 


### PR DESCRIPTION
Retry of pull-request regarding issue #692.

* Improved internal pointer usage in generated C# code regarding Groups by making it possible to call WrapForEncode and WrapForDecode more than once. This makes it possible to read a message twice which is especially useful for logging the entire message after errors or when unexpected content is found.
* Enabled CSharp code generator in the sbe-tool.
