### PR TITLE
[Java] Generate bulk put/get/wrap methods for fixed-length data (uint8 array)

### DIFF
--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/FixedSizeDataGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/FixedSizeDataGeneratorTest.java
@@ -1,0 +1,200 @@
+/*
+ * Copyright 2013-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.sbe.generation.java;
+
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.concurrent.UnsafeBuffer;
+import org.agrona.generation.CompilerUtil;
+import org.agrona.generation.StringWriterOutputManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.co.real_logic.sbe.Tests;
+import uk.co.real_logic.sbe.ir.Ir;
+import uk.co.real_logic.sbe.xml.IrGenerator;
+import uk.co.real_logic.sbe.xml.MessageSchema;
+import uk.co.real_logic.sbe.xml.ParserOptions;
+
+import java.nio.charset.StandardCharsets;
+import java.util.Map;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.*;
+import static uk.co.real_logic.sbe.generation.java.ReflectionUtil.*;
+import static uk.co.real_logic.sbe.xml.XmlSchemaParser.parse;
+
+public class FixedSizeDataGeneratorTest
+{
+    private static final Class<?> BUFFER_CLASS = MutableDirectBuffer.class;
+    private static final String BUFFER_NAME = BUFFER_CLASS.getName();
+    private static final Class<DirectBuffer> READ_ONLY_BUFFER_CLASS = DirectBuffer.class;
+    private static final String READ_ONLY_BUFFER_NAME = READ_ONLY_BUFFER_CLASS.getName();
+
+    private final StringWriterOutputManager outputManager = new StringWriterOutputManager();
+
+    private Ir ir;
+
+    @BeforeEach
+    public void setUp() throws Exception
+    {
+        final ParserOptions options = ParserOptions.builder().stopOnError(true).build();
+        final MessageSchema schema = parse(Tests.getLocalResource("extension-schema.xml"), options);
+        final IrGenerator irg = new IrGenerator();
+        ir = irg.generate(schema);
+
+        outputManager.clear();
+        outputManager.setPackageName(ir.applicableNamespace());
+
+        generator().generate();
+    }
+
+    @Test
+    public void shouldGeneratePutAndGetByteArrayForFixedLengthBlob() throws Exception
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);
+
+        final Object encoder = getTestMessage2Encoder(buffer);
+        final Object decoder = getTestMessage2Decoder(buffer, encoder);
+
+        final byte[] encodedData = "  **DATA**  ".getBytes(StandardCharsets.US_ASCII);
+        byte[] decodedData;
+        int decodedDataLength;
+
+        // Every byte written, every byte read
+        putByteArray(encoder, "putTag6", encodedData, 2, 8);
+        decodedData = "            ".getBytes(StandardCharsets.US_ASCII);
+        decodedDataLength = getByteArray(decoder, "getTag6", decodedData, 1, 8);
+        assertThat(decodedDataLength, is(8));
+        assertThat(new String(decodedData, StandardCharsets.US_ASCII), is(" **DATA**   "));
+
+        // Every byte written, less bytes read
+        putByteArray(encoder, "putTag6", encodedData, 2, 8);
+        decodedData = "            ".getBytes(StandardCharsets.US_ASCII);
+        decodedDataLength = getByteArray(decoder, "getTag6", decodedData, 1, 6);
+        assertThat(decodedDataLength, is(6));
+        assertThat(new String(decodedData, StandardCharsets.US_ASCII), is(" **DATA     "));
+
+        // Less bytes written (padding), every byte read
+        putByteArray(encoder, "putTag6", encodedData, 2, 6);
+        decodedData = "            ".getBytes(StandardCharsets.US_ASCII);
+        decodedDataLength = getByteArray(decoder, "getTag6", decodedData, 1, 8);
+        assertThat(decodedDataLength, is(8));
+        assertThat(new String(decodedData, StandardCharsets.US_ASCII), is(" **DATA\u0000\u0000   "));
+    }
+
+    @Test
+    public void shouldGeneratePutAndGetDirectBufferForFixedLengthBlob() throws Exception
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);
+
+        final Object encoder = getTestMessage2Encoder(buffer);
+        final Object decoder = getTestMessage2Decoder(buffer, encoder);
+
+        final UnsafeBuffer encodedData = new UnsafeBuffer("  **DATA**  ".getBytes(StandardCharsets.US_ASCII));
+        UnsafeBuffer decodedData;
+        int decodedDataLength;
+
+        // Every byte written, every byte read
+        putDirectBuffer(encoder, "putTag6", encodedData, 2, 8);
+        decodedData = new UnsafeBuffer("            ".getBytes(StandardCharsets.US_ASCII));
+        decodedDataLength = getDirectBuffer(decoder, "getTag6", decodedData, 1, 8);
+        assertThat(decodedDataLength, is(8));
+        assertThat(decodedData.getStringWithoutLengthAscii(0, 12), is(" **DATA**   "));
+
+        // Every byte written, less bytes read
+        putDirectBuffer(encoder, "putTag6", encodedData, 2, 8);
+        decodedData = new UnsafeBuffer("            ".getBytes(StandardCharsets.US_ASCII));
+        decodedDataLength = getDirectBuffer(decoder, "getTag6", decodedData, 1, 6);
+        assertThat(decodedDataLength, is(6));
+        assertThat(decodedData.getStringWithoutLengthAscii(0, 12), is(" **DATA     "));
+
+        // Less bytes written (padding), every byte read
+        putDirectBuffer(encoder, "putTag6", encodedData, 2, 6);
+        decodedData = new UnsafeBuffer("            ".getBytes(StandardCharsets.US_ASCII));
+        decodedDataLength = getDirectBuffer(decoder, "getTag6", decodedData, 1, 8);
+        assertThat(decodedDataLength, is(8));
+        assertThat(decodedData.getStringWithoutLengthAscii(0, 12), is(" **DATA\u0000\u0000   "));
+    }
+
+    @Test
+    public void shouldGenerateWrapForFixedLengthBlob() throws Exception
+    {
+        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);
+
+        final Object encoder = getTestMessage2Encoder(buffer);
+        final Object decoder = getTestMessage2Decoder(buffer, encoder);
+
+        final UnsafeBuffer encodedData = new UnsafeBuffer("  **DATA**  ".getBytes(StandardCharsets.US_ASCII));
+        putDirectBuffer(encoder, "putTag6", encodedData, 2, 8);
+
+        final UnsafeBuffer decodedData = new UnsafeBuffer();
+        wrapDirectBuffer(decoder, "wrapTag6", decodedData);
+        assertThat(decodedData.getStringWithoutLengthAscii(0, decodedData.capacity()), is("**DATA**"));
+    }
+
+    private JavaGenerator generator()
+    {
+        return new JavaGenerator(ir, BUFFER_NAME, READ_ONLY_BUFFER_NAME, false, false, false, outputManager);
+    }
+
+    private Class<?> compile(final String className) throws Exception
+    {
+        final String fqClassName = ir.applicableNamespace() + "." + className;
+        final Map<String, CharSequence> sources = outputManager.getSources();
+        final Class<?> aClass = CompilerUtil.compileInMemory(fqClassName, sources);
+        if (aClass == null)
+        {
+            System.out.println(sources);
+        }
+
+        return aClass;
+    }
+
+    private Object getTestMessage2Encoder(final UnsafeBuffer buffer) throws Exception
+    {
+        final Object encoder = compile("TestMessage2Encoder").getConstructor().newInstance();
+        return wrap(0, encoder, buffer, BUFFER_CLASS);
+    }
+
+    private Object getTestMessage2Decoder(final UnsafeBuffer buffer, final Object encoder) throws Exception
+    {
+        final Object decoder = compile("TestMessage2Decoder").getConstructor().newInstance();
+        return wrap(buffer, decoder, getSbeBlockLength(encoder), getSbeSchemaVersion(encoder));
+    }
+
+    private static Object wrap(
+        final UnsafeBuffer buffer, final Object decoder, final int blockLength, final int version) throws Exception
+    {
+        decoder
+            .getClass()
+            .getMethod("wrap", READ_ONLY_BUFFER_CLASS, int.class, int.class, int.class)
+            .invoke(decoder, buffer, 0, blockLength, version);
+
+        return decoder;
+    }
+
+    private static Object wrap(
+        final int bufferOffset, final Object flyweight, final MutableDirectBuffer buffer, final Class<?> bufferClass)
+        throws Exception
+    {
+        flyweight
+            .getClass()
+            .getDeclaredMethod("wrap", bufferClass, int.class)
+            .invoke(flyweight, buffer, bufferOffset);
+        return flyweight;
+    }
+
+}

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
@@ -31,7 +31,6 @@ import uk.co.real_logic.sbe.xml.ParserOptions;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.ByteOrder;
-import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -443,92 +442,6 @@ public class JavaGeneratorTest
         assertThat(get(decoder, "vehicleCode"), is("R11R12"));
     }
 
-    @Test
-    public void shouldGeneratePutAndGetByteArrayForFixedLengthBlob() throws Exception
-    {
-        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);
-        generator().generate();
-
-        final Object encoder = wrap(buffer, compileCarEncoder().getConstructor().newInstance());
-        final Object decoder = getCarDecoder(buffer, encoder);
-
-        final byte[] encodedData = "  **DATA**  ".getBytes(StandardCharsets.US_ASCII);
-        byte[] decodedData;
-        int decodedDataLength;
-
-        // Every byte written, every byte read
-        putByteArray(encoder, "putSomeFixedLengthBlob", encodedData, 2, 8);
-        decodedData = "            ".getBytes(StandardCharsets.US_ASCII);
-        decodedDataLength = getByteArray(decoder, "getSomeFixedLengthBlob", decodedData, 1, 8);
-        assertThat(decodedDataLength, is(8));
-        assertThat(new String(decodedData, StandardCharsets.US_ASCII), is(" **DATA**   "));
-
-        // Every byte written, less bytes read
-        putByteArray(encoder, "putSomeFixedLengthBlob", encodedData, 2, 8);
-        decodedData = "            ".getBytes(StandardCharsets.US_ASCII);
-        decodedDataLength = getByteArray(decoder, "getSomeFixedLengthBlob", decodedData, 1, 6);
-        assertThat(decodedDataLength, is(6));
-        assertThat(new String(decodedData, StandardCharsets.US_ASCII), is(" **DATA     "));
-
-        // Less bytes written (padding), every byte read
-        putByteArray(encoder, "putSomeFixedLengthBlob", encodedData, 2, 6);
-        decodedData = "            ".getBytes(StandardCharsets.US_ASCII);
-        decodedDataLength = getByteArray(decoder, "getSomeFixedLengthBlob", decodedData, 1, 8);
-        assertThat(decodedDataLength, is(8));
-        assertThat(new String(decodedData, StandardCharsets.US_ASCII), is(" **DATA\u0000\u0000   "));
-    }
-
-    @Test
-    public void shouldGeneratePutAndGetDirectBufferForFixedLengthBlob() throws Exception
-    {
-        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);
-        generator().generate();
-
-        final Object encoder = wrap(buffer, compileCarEncoder().getConstructor().newInstance());
-        final Object decoder = getCarDecoder(buffer, encoder);
-
-        final UnsafeBuffer encodedData = new UnsafeBuffer("  **DATA**  ".getBytes(StandardCharsets.US_ASCII));
-        UnsafeBuffer decodedData;
-        int decodedDataLength;
-
-        // Every byte written, every byte read
-        putDirectBuffer(encoder, "putSomeFixedLengthBlob", encodedData, 2, 8);
-        decodedData = new UnsafeBuffer("            ".getBytes(StandardCharsets.US_ASCII));
-        decodedDataLength = getDirectBuffer(decoder, "getSomeFixedLengthBlob", decodedData, 1, 8);
-        assertThat(decodedDataLength, is(8));
-        assertThat(decodedData.getStringWithoutLengthAscii(0, 12), is(" **DATA**   "));
-
-        // Every byte written, less bytes read
-        putDirectBuffer(encoder, "putSomeFixedLengthBlob", encodedData, 2, 8);
-        decodedData = new UnsafeBuffer("            ".getBytes(StandardCharsets.US_ASCII));
-        decodedDataLength = getDirectBuffer(decoder, "getSomeFixedLengthBlob", decodedData, 1, 6);
-        assertThat(decodedDataLength, is(6));
-        assertThat(decodedData.getStringWithoutLengthAscii(0, 12), is(" **DATA     "));
-
-        // Less bytes written (padding), every byte read
-        putDirectBuffer(encoder, "putSomeFixedLengthBlob", encodedData, 2, 6);
-        decodedData = new UnsafeBuffer("            ".getBytes(StandardCharsets.US_ASCII));
-        decodedDataLength = getDirectBuffer(decoder, "getSomeFixedLengthBlob", decodedData, 1, 8);
-        assertThat(decodedDataLength, is(8));
-        assertThat(decodedData.getStringWithoutLengthAscii(0, 12), is(" **DATA\u0000\u0000   "));
-    }
-
-    @Test
-    public void shouldGenerateWrapForFixedLengthBlob() throws Exception
-    {
-        final UnsafeBuffer buffer = new UnsafeBuffer(new byte[4096]);
-        generator().generate();
-
-        final Object encoder = wrap(buffer, compileCarEncoder().getConstructor().newInstance());
-        final Object decoder = getCarDecoder(buffer, encoder);
-
-        final UnsafeBuffer encodedData = new UnsafeBuffer("  **DATA**  ".getBytes(StandardCharsets.US_ASCII));
-        putDirectBuffer(encoder, "putSomeFixedLengthBlob", encodedData, 2, 8);
-
-        final UnsafeBuffer decodedData = new UnsafeBuffer();
-        wrapDirectBuffer(decoder, "wrapSomeFixedLengthBlob", decodedData);
-        assertThat(decodedData.getStringWithoutLengthAscii(0, decodedData.capacity()), is("**DATA**"));
-    }
 
     private Class<?> getModelClass(final Object encoder) throws ClassNotFoundException
     {

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ReflectionUtil.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ReflectionUtil.java
@@ -15,6 +15,8 @@
  */
 package uk.co.real_logic.sbe.generation.java;
 
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
 import uk.co.real_logic.sbe.generation.Generators;
 
 public final class ReflectionUtil
@@ -108,6 +110,61 @@ public final class ReflectionUtil
         final Object value) throws Exception
     {
         object.getClass().getMethod(name, type).invoke(object, value);
+    }
+
+    static void putByteArray(
+        final Object encoder,
+        final String name,
+        final byte[] value,
+        final int offset,
+        final int length) throws Exception
+    {
+        encoder.getClass().getDeclaredMethod(name, byte[].class, int.class, int.class)
+            .invoke(encoder, value, offset, length);
+    }
+
+    static int getByteArray(
+        final Object decoder,
+        final String name,
+        final byte[] dst,
+        final int dstOffset,
+        final int length) throws Exception
+    {
+        return (Integer)decoder.getClass().getDeclaredMethod(name, byte[].class, int.class, int.class)
+            .invoke(decoder, dst, dstOffset, length);
+    }
+
+    static void putDirectBuffer(
+        final Object encoder,
+        final String name,
+        final DirectBuffer value,
+        final int offset,
+        final int length) throws Exception
+    {
+        encoder.getClass().getDeclaredMethod(name, DirectBuffer.class, int.class, int.class)
+                .invoke(encoder, value, offset, length);
+    }
+
+    static int getDirectBuffer(
+        final Object decoder,
+        final String name,
+        final MutableDirectBuffer dst,
+        final int dstOffset,
+        final int length) throws Exception
+    {
+        return (Integer)decoder.getClass().getDeclaredMethod(name, MutableDirectBuffer.class, int.class, int.class)
+            .invoke(decoder, dst, dstOffset, length);
+    }
+
+    static void wrapDirectBuffer(
+        final Object decoder,
+        final String name,
+        final DirectBuffer dst) throws Exception
+    {
+        decoder
+            .getClass()
+            .getDeclaredMethod(name, DirectBuffer.class)
+            .invoke(decoder, dst);
     }
 
     static Object getByte(final Class<?> clazz, final byte value) throws Exception

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/SchemaExtensionTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/SchemaExtensionTest.java
@@ -28,13 +28,14 @@ import uk.co.real_logic.sbe.xml.IrGenerator;
 import uk.co.real_logic.sbe.xml.MessageSchema;
 import uk.co.real_logic.sbe.xml.ParserOptions;
 
+import java.nio.charset.StandardCharsets;
+import java.util.Arrays;
 import java.util.Map;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
 import static org.junit.jupiter.api.Assertions.*;
-import static uk.co.real_logic.sbe.generation.java.ReflectionUtil.get;
-import static uk.co.real_logic.sbe.generation.java.ReflectionUtil.set;
+import static uk.co.real_logic.sbe.generation.java.ReflectionUtil.*;
 import static uk.co.real_logic.sbe.xml.XmlSchemaParser.parse;
 
 public class SchemaExtensionTest
@@ -184,6 +185,7 @@ public class SchemaExtensionTest
         }
     }
 
+    @SuppressWarnings("MethodLength")
     @Test
     public void testMessage2() throws Exception
     {
@@ -204,24 +206,44 @@ public class SchemaExtensionTest
             final Object setEncoder = encoder.getClass().getMethod("tag5").invoke(encoder);
             set(setEncoder, "firstChoice", boolean.class, false);
             set(setEncoder, "secondChoice", boolean.class, true);
+
+            final byte[] data = "  **DATA**  ".getBytes(StandardCharsets.US_ASCII);
+            putByteArray(encoder, "putTag6", data, 2, 8);
         }
 
         { // Decode version 0
+            final byte[] data = new byte[12];
+            Arrays.fill(data, (byte)' ');
+            final UnsafeBuffer dataBuffer = new UnsafeBuffer(new byte[12]);
+            dataBuffer.setMemory(0, 12, (byte)' ');
+
             final Object decoderVersion0 = getMessage2Decoder(buffer, 4, 0);
             assertEquals(100, get(decoderVersion0, "tag1"));
             assertEquals(Integer.MIN_VALUE, get(decoderVersion0, "tag2"));
             assertNull(get(decoderVersion0, "tag3"));
             assertThat(get(decoderVersion0, "tag4").toString(), is("NULL_VAL"));
             assertNull(get(decoderVersion0, "tag5"));
+            assertEquals(0, getByteArray(decoderVersion0, "getTag6", data, 1, 8));
+            assertEquals("            ", new String(data, StandardCharsets.US_ASCII));
+            assertEquals(0, getDirectBuffer(decoderVersion0, "getTag6", dataBuffer, 3, 8));
+            assertEquals("            ", dataBuffer.getStringWithoutLengthAscii(0, 12));
+            wrapDirectBuffer(decoderVersion0, "wrapTag6", dataBuffer);
+            assertEquals("", dataBuffer.getStringWithoutLengthAscii(0, dataBuffer.capacity()));
 
             assertEquals(0, decoderVersion0.getClass().getMethod("tag1SinceVersion").invoke(null));
             assertEquals(2, decoderVersion0.getClass().getMethod("tag2SinceVersion").invoke(null));
             assertEquals(1, decoderVersion0.getClass().getMethod("tag3SinceVersion").invoke(null));
             assertEquals(4, decoderVersion0.getClass().getMethod("tag4SinceVersion").invoke(null));
             assertEquals(3, decoderVersion0.getClass().getMethod("tag5SinceVersion").invoke(null));
+            assertEquals(6, decoderVersion0.getClass().getMethod("tag6SinceVersion").invoke(null));
         }
 
         { // Decode version 1
+            final byte[] data = new byte[12];
+            Arrays.fill(data, (byte)' ');
+            final UnsafeBuffer dataBuffer = new UnsafeBuffer(new byte[12]);
+            dataBuffer.setMemory(0, 12, (byte)' ');
+
             final Object decoderVersion1 = getMessage2Decoder(buffer, 8, 1);
             assertEquals(100, get(decoderVersion1, "tag1"));
             assertEquals(Integer.MIN_VALUE, get(decoderVersion1, "tag2"));
@@ -230,9 +252,20 @@ public class SchemaExtensionTest
             assertEquals(300, get(compositeDecoder2, "value"));
             assertThat(get(decoderVersion1, "tag4").toString(), is("NULL_VAL"));
             assertNull(get(decoderVersion1, "tag5"));
+            assertEquals(0, getByteArray(decoderVersion1, "getTag6", data, 1, 8));
+            assertEquals("            ", new String(data, StandardCharsets.US_ASCII));
+            assertEquals(0, getDirectBuffer(decoderVersion1, "getTag6", dataBuffer, 3, 8));
+            assertEquals("            ", dataBuffer.getStringWithoutLengthAscii(0, 12));
+            wrapDirectBuffer(decoderVersion1, "wrapTag6", dataBuffer);
+            assertEquals("", dataBuffer.getStringWithoutLengthAscii(0, dataBuffer.capacity()));
         }
 
         { // Decode version 2
+            final byte[] data = new byte[12];
+            Arrays.fill(data, (byte)' ');
+            final UnsafeBuffer dataBuffer = new UnsafeBuffer(new byte[12]);
+            dataBuffer.setMemory(0, 12, (byte)' ');
+
             final Object decoderVersion2 = getMessage2Decoder(buffer, 8, 2);
             assertEquals(100, get(decoderVersion2, "tag1"));
             assertEquals(200, get(decoderVersion2, "tag2"));
@@ -241,9 +274,20 @@ public class SchemaExtensionTest
             assertEquals(300, get(compositeDecoder2, "value"));
             assertThat(get(decoderVersion2, "tag4").toString(), is("NULL_VAL"));
             assertNull(get(decoderVersion2, "tag5"));
+            assertEquals(0, getByteArray(decoderVersion2, "getTag6", data, 1, 8));
+            assertEquals("            ", new String(data, StandardCharsets.US_ASCII));
+            assertEquals(0, getDirectBuffer(decoderVersion2, "getTag6", dataBuffer, 3, 8));
+            assertEquals("            ", dataBuffer.getStringWithoutLengthAscii(0, 12));
+            wrapDirectBuffer(decoderVersion2, "wrapTag6", dataBuffer);
+            assertEquals("", dataBuffer.getStringWithoutLengthAscii(0, dataBuffer.capacity()));
         }
 
         { // Decode version 3
+            final byte[] data = new byte[12];
+            Arrays.fill(data, (byte)' ');
+            final UnsafeBuffer dataBuffer = new UnsafeBuffer(new byte[12]);
+            dataBuffer.setMemory(0, 12, (byte)' ');
+
             final Object decoderVersion3 = getMessage2Decoder(buffer, 12, 3);
             assertEquals(100, get(decoderVersion3, "tag1"));
             assertEquals(200, get(decoderVersion3, "tag2"));
@@ -255,9 +299,20 @@ public class SchemaExtensionTest
             assertNotNull(setDecoder);
             assertEquals(false, get(setDecoder, "firstChoice"));
             assertEquals(true, get(setDecoder, "secondChoice"));
+            assertEquals(0, getByteArray(decoderVersion3, "getTag6", data, 1, 8));
+            assertEquals("            ", new String(data, StandardCharsets.US_ASCII));
+            assertEquals(0, getDirectBuffer(decoderVersion3, "getTag6", dataBuffer, 3, 8));
+            assertEquals("            ", dataBuffer.getStringWithoutLengthAscii(0, 12));
+            wrapDirectBuffer(decoderVersion3, "wrapTag6", dataBuffer);
+            assertEquals("", dataBuffer.getStringWithoutLengthAscii(0, dataBuffer.capacity()));
         }
 
         { // Decode version 4
+            final byte[] data = new byte[12];
+            Arrays.fill(data, (byte)' ');
+            final UnsafeBuffer dataBuffer = new UnsafeBuffer(new byte[12]);
+            dataBuffer.setMemory(0, 12, (byte)' ');
+
             final Object decoderVersion4 = getMessage2Decoder(buffer, 12, 4);
             assertEquals(100, get(decoderVersion4, "tag1"));
             assertEquals(200, get(decoderVersion4, "tag2"));
@@ -270,6 +325,64 @@ public class SchemaExtensionTest
             assertNotNull(setDecoder);
             assertEquals(false, get(setDecoder, "firstChoice"));
             assertEquals(true, get(setDecoder, "secondChoice"));
+            assertEquals(0, getByteArray(decoderVersion4, "getTag6", data, 1, 8));
+            assertEquals("            ", new String(data, StandardCharsets.US_ASCII));
+            assertEquals(0, getDirectBuffer(decoderVersion4, "getTag6", dataBuffer, 3, 8));
+            assertEquals("            ", dataBuffer.getStringWithoutLengthAscii(0, 12));
+            wrapDirectBuffer(decoderVersion4, "wrapTag6", dataBuffer);
+            assertEquals("", dataBuffer.getStringWithoutLengthAscii(0, dataBuffer.capacity()));
+        }
+
+        { // Decode version 5
+            final byte[] data = new byte[12];
+            Arrays.fill(data, (byte)' ');
+            final UnsafeBuffer dataBuffer = new UnsafeBuffer(new byte[12]);
+            dataBuffer.setMemory(0, 12, (byte)' ');
+
+            final Object decoderVersion5 = getMessage2Decoder(buffer, 12, 5);
+            assertEquals(100, get(decoderVersion5, "tag1"));
+            assertEquals(200, get(decoderVersion5, "tag2"));
+            final Object compositeDecoder4 = get(decoderVersion5, "tag3");
+            assertNotNull(compositeDecoder4);
+            assertEquals(300, get(compositeDecoder4, "value"));
+            final Object enumConstant = getAEnumConstant(decoderVersion5, "AEnum", 1);
+            assertEquals(enumConstant, get(decoderVersion5, "tag4"));
+            final Object setDecoder = get(decoderVersion5, "tag5");
+            assertNotNull(setDecoder);
+            assertEquals(false, get(setDecoder, "firstChoice"));
+            assertEquals(true, get(setDecoder, "secondChoice"));
+            assertEquals(0, getByteArray(decoderVersion5, "getTag6", data, 1, 8));
+            assertEquals("            ", new String(data, StandardCharsets.US_ASCII));
+            assertEquals(0, getDirectBuffer(decoderVersion5, "getTag6", dataBuffer, 3, 8));
+            assertEquals("            ", dataBuffer.getStringWithoutLengthAscii(0, 12));
+            wrapDirectBuffer(decoderVersion5, "wrapTag6", dataBuffer);
+            assertEquals("", dataBuffer.getStringWithoutLengthAscii(0, dataBuffer.capacity()));
+        }
+
+        { // Decode version 6
+            final byte[] data = new byte[12];
+            Arrays.fill(data, (byte)' ');
+            final UnsafeBuffer dataBuffer = new UnsafeBuffer(new byte[12]);
+            dataBuffer.setMemory(0, 12, (byte)' ');
+
+            final Object decoderVersion6 = getMessage2Decoder(buffer, 12, 6);
+            assertEquals(100, get(decoderVersion6, "tag1"));
+            assertEquals(200, get(decoderVersion6, "tag2"));
+            final Object compositeDecoder4 = get(decoderVersion6, "tag3");
+            assertNotNull(compositeDecoder4);
+            assertEquals(300, get(compositeDecoder4, "value"));
+            final Object enumConstant = getAEnumConstant(decoderVersion6, "AEnum", 1);
+            assertEquals(enumConstant, get(decoderVersion6, "tag4"));
+            final Object setDecoder = get(decoderVersion6, "tag5");
+            assertNotNull(setDecoder);
+            assertEquals(false, get(setDecoder, "firstChoice"));
+            assertEquals(true, get(setDecoder, "secondChoice"));
+            assertEquals(8, getByteArray(decoderVersion6, "getTag6", data, 1, 8));
+            assertEquals(" **DATA**   ", new String(data, StandardCharsets.US_ASCII));
+            assertEquals(8, getDirectBuffer(decoderVersion6, "getTag6", dataBuffer, 3, 8));
+            assertEquals("   **DATA** ", dataBuffer.getStringWithoutLengthAscii(0, 12));
+            wrapDirectBuffer(decoderVersion6, "wrapTag6", dataBuffer);
+            assertEquals("**DATA**", dataBuffer.getStringWithoutLengthAscii(0, dataBuffer.capacity()));
         }
     }
 

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/SchemaExtensionTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/SchemaExtensionTest.java
@@ -223,6 +223,7 @@ public class SchemaExtensionTest
             assertNull(get(decoderVersion0, "tag3"));
             assertThat(get(decoderVersion0, "tag4").toString(), is("NULL_VAL"));
             assertNull(get(decoderVersion0, "tag5"));
+            // tag6 (fixed-size data)
             assertEquals(0, getByteArray(decoderVersion0, "getTag6", data, 1, 8));
             assertEquals("            ", new String(data, StandardCharsets.US_ASCII));
             assertEquals(0, getDirectBuffer(decoderVersion0, "getTag6", dataBuffer, 3, 8));
@@ -252,6 +253,7 @@ public class SchemaExtensionTest
             assertEquals(300, get(compositeDecoder2, "value"));
             assertThat(get(decoderVersion1, "tag4").toString(), is("NULL_VAL"));
             assertNull(get(decoderVersion1, "tag5"));
+            // tag6 (fixed-size data)
             assertEquals(0, getByteArray(decoderVersion1, "getTag6", data, 1, 8));
             assertEquals("            ", new String(data, StandardCharsets.US_ASCII));
             assertEquals(0, getDirectBuffer(decoderVersion1, "getTag6", dataBuffer, 3, 8));
@@ -266,7 +268,7 @@ public class SchemaExtensionTest
             final UnsafeBuffer dataBuffer = new UnsafeBuffer(new byte[12]);
             dataBuffer.setMemory(0, 12, (byte)' ');
 
-            final Object decoderVersion2 = getMessage2Decoder(buffer, 8, 2);
+            final Object decoderVersion2 = getMessage2Decoder(buffer, 12, 2);
             assertEquals(100, get(decoderVersion2, "tag1"));
             assertEquals(200, get(decoderVersion2, "tag2"));
             final Object compositeDecoder2 = get(decoderVersion2, "tag3");
@@ -274,6 +276,7 @@ public class SchemaExtensionTest
             assertEquals(300, get(compositeDecoder2, "value"));
             assertThat(get(decoderVersion2, "tag4").toString(), is("NULL_VAL"));
             assertNull(get(decoderVersion2, "tag5"));
+            // tag6 (fixed-size data)
             assertEquals(0, getByteArray(decoderVersion2, "getTag6", data, 1, 8));
             assertEquals("            ", new String(data, StandardCharsets.US_ASCII));
             assertEquals(0, getDirectBuffer(decoderVersion2, "getTag6", dataBuffer, 3, 8));
@@ -288,7 +291,7 @@ public class SchemaExtensionTest
             final UnsafeBuffer dataBuffer = new UnsafeBuffer(new byte[12]);
             dataBuffer.setMemory(0, 12, (byte)' ');
 
-            final Object decoderVersion3 = getMessage2Decoder(buffer, 12, 3);
+            final Object decoderVersion3 = getMessage2Decoder(buffer, 13, 3);
             assertEquals(100, get(decoderVersion3, "tag1"));
             assertEquals(200, get(decoderVersion3, "tag2"));
             final Object compositeDecoder3 = get(decoderVersion3, "tag3");
@@ -299,6 +302,7 @@ public class SchemaExtensionTest
             assertNotNull(setDecoder);
             assertEquals(false, get(setDecoder, "firstChoice"));
             assertEquals(true, get(setDecoder, "secondChoice"));
+            // tag6 (fixed-size data)
             assertEquals(0, getByteArray(decoderVersion3, "getTag6", data, 1, 8));
             assertEquals("            ", new String(data, StandardCharsets.US_ASCII));
             assertEquals(0, getDirectBuffer(decoderVersion3, "getTag6", dataBuffer, 3, 8));
@@ -313,7 +317,7 @@ public class SchemaExtensionTest
             final UnsafeBuffer dataBuffer = new UnsafeBuffer(new byte[12]);
             dataBuffer.setMemory(0, 12, (byte)' ');
 
-            final Object decoderVersion4 = getMessage2Decoder(buffer, 12, 4);
+            final Object decoderVersion4 = getMessage2Decoder(buffer, 14, 4);
             assertEquals(100, get(decoderVersion4, "tag1"));
             assertEquals(200, get(decoderVersion4, "tag2"));
             final Object compositeDecoder4 = get(decoderVersion4, "tag3");
@@ -325,6 +329,7 @@ public class SchemaExtensionTest
             assertNotNull(setDecoder);
             assertEquals(false, get(setDecoder, "firstChoice"));
             assertEquals(true, get(setDecoder, "secondChoice"));
+            // tag6 (fixed-size data)
             assertEquals(0, getByteArray(decoderVersion4, "getTag6", data, 1, 8));
             assertEquals("            ", new String(data, StandardCharsets.US_ASCII));
             assertEquals(0, getDirectBuffer(decoderVersion4, "getTag6", dataBuffer, 3, 8));
@@ -339,7 +344,7 @@ public class SchemaExtensionTest
             final UnsafeBuffer dataBuffer = new UnsafeBuffer(new byte[12]);
             dataBuffer.setMemory(0, 12, (byte)' ');
 
-            final Object decoderVersion5 = getMessage2Decoder(buffer, 12, 5);
+            final Object decoderVersion5 = getMessage2Decoder(buffer, 14, 5);
             assertEquals(100, get(decoderVersion5, "tag1"));
             assertEquals(200, get(decoderVersion5, "tag2"));
             final Object compositeDecoder4 = get(decoderVersion5, "tag3");
@@ -351,6 +356,7 @@ public class SchemaExtensionTest
             assertNotNull(setDecoder);
             assertEquals(false, get(setDecoder, "firstChoice"));
             assertEquals(true, get(setDecoder, "secondChoice"));
+            // tag6 (fixed-size data)
             assertEquals(0, getByteArray(decoderVersion5, "getTag6", data, 1, 8));
             assertEquals("            ", new String(data, StandardCharsets.US_ASCII));
             assertEquals(0, getDirectBuffer(decoderVersion5, "getTag6", dataBuffer, 3, 8));
@@ -365,7 +371,7 @@ public class SchemaExtensionTest
             final UnsafeBuffer dataBuffer = new UnsafeBuffer(new byte[12]);
             dataBuffer.setMemory(0, 12, (byte)' ');
 
-            final Object decoderVersion6 = getMessage2Decoder(buffer, 12, 6);
+            final Object decoderVersion6 = getMessage2Decoder(buffer, 22, 6);
             assertEquals(100, get(decoderVersion6, "tag1"));
             assertEquals(200, get(decoderVersion6, "tag2"));
             final Object compositeDecoder4 = get(decoderVersion6, "tag3");
@@ -377,6 +383,7 @@ public class SchemaExtensionTest
             assertNotNull(setDecoder);
             assertEquals(false, get(setDecoder, "firstChoice"));
             assertEquals(true, get(setDecoder, "secondChoice"));
+            // tag6 (fixed-size data)
             assertEquals(8, getByteArray(decoderVersion6, "getTag6", data, 1, 8));
             assertEquals(" **DATA**   ", new String(data, StandardCharsets.US_ASCII));
             assertEquals(8, getDirectBuffer(decoderVersion6, "getTag6", dataBuffer, 3, 8));

--- a/sbe-tool/src/test/resources/code-generation-schema.xml
+++ b/sbe-tool/src/test/resources/code-generation-schema.xml
@@ -39,7 +39,6 @@
         <type name="ModelYear" primitiveType="uint16"/>
         <type name="VehicleCode" primitiveType="char" length="6" characterEncoding="ASCII"/>
         <type name="someNumbers" primitiveType="int32" length="5"/>
-        <type name="someFixedLengthBlob" primitiveType="uint8" length="8"/>
         <type name="Ron" primitiveType="uint8" minValue="90" maxValue="110"/>
         <composite name="Engine">
             <type name="capacity" primitiveType="uint16"/>
@@ -74,7 +73,6 @@
         <field name="extras" id="7" type="OptionalExtras"/>
         <field name="discountedModel" id="8" type="Model" presence="constant" valueRef="Model.C"/>
         <field name="engine" id="9" type="Engine"/>
-        <field name="someFixedLengthBlob" id="300" type="someFixedLengthBlob"/>
         <group name="fuelFigures" id="10" dimensionType="groupSizeEncoding">
             <field name="speed" id="11" type="uint16"/>
             <field name="mpg" id="12" type="float"/>

--- a/sbe-tool/src/test/resources/code-generation-schema.xml
+++ b/sbe-tool/src/test/resources/code-generation-schema.xml
@@ -39,6 +39,7 @@
         <type name="ModelYear" primitiveType="uint16"/>
         <type name="VehicleCode" primitiveType="char" length="6" characterEncoding="ASCII"/>
         <type name="someNumbers" primitiveType="int32" length="5"/>
+        <type name="someFixedLengthBlob" primitiveType="uint8" length="8"/>
         <type name="Ron" primitiveType="uint8" minValue="90" maxValue="110"/>
         <composite name="Engine">
             <type name="capacity" primitiveType="uint16"/>
@@ -73,6 +74,7 @@
         <field name="extras" id="7" type="OptionalExtras"/>
         <field name="discountedModel" id="8" type="Model" presence="constant" valueRef="Model.C"/>
         <field name="engine" id="9" type="Engine"/>
+        <field name="someFixedLengthBlob" id="300" type="someFixedLengthBlob"/>
         <group name="fuelFigures" id="10" dimensionType="groupSizeEncoding">
             <field name="speed" id="11" type="uint16"/>
             <field name="mpg" id="12" type="float"/>

--- a/sbe-tool/src/test/resources/extension-schema.xml
+++ b/sbe-tool/src/test/resources/extension-schema.xml
@@ -2,7 +2,7 @@
 <sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
                    package="code.generation.test"
                    id="1"
-                   version="5"
+                   version="6"
                    description="Unit Test">
     <types>
         <composite name="messageHeader" description="Message identifiers and length of message root">
@@ -31,6 +31,7 @@
             <choice name="FirstChoice">0</choice>
             <choice name="SecondChoice">1</choice>
         </set>
+        <type name="AFixedSizeBlob" primitiveType="uint8" length="8" sinceVersion="6"/>
     </types>
     <!--
         Version 0: schema created
@@ -39,6 +40,7 @@
         Version 3: AEnum, ASet introduced; tag4 added to TestMessage1, tag5 added to TestMessage2
         Version 4: tag5 added to TestMessage1, tag4 added to TestMessage2
         Version 5: tag6 added to TestMessage1
+        Version 6: tag6 added to TestMessage2
     -->
     <sbe:message name="TestMessage1" id="1">
         <field name="tag1" id="1" type="int32"/>
@@ -54,5 +56,6 @@
         <field name="tag2" id="2" type="AType" sinceVersion="2"/>
         <field name="tag5" id="5" type="ASet" sinceVersion="3"/>
         <field name="tag4" id="4" type="AEnum" sinceVersion="4"/>
+        <field name="tag6" id="6" type="AFixedSizeBlob"/>
     </sbe:message>
 </sbe:messageSchema>


### PR DESCRIPTION
There are some cases when message contains byte array of fixed size which is not an ASCII string - e.g. hmac signatures. Declaring them as fixed-size uint8 array currently generates only generic array accessor to put/get one element at a time. Declaring them as strings generate bulk put/get methods which accept byte[], but string semantics - e.g. charset - do not really apply to the field.
This PR adds bulk get/put methods for fixed-length data (described in the "Fixed-length data" section of the spec).

_Encoder_
  `public void putData(byte[] buffer, int offset, int length);`
  `public void putData(DirectBuffer buffer, int offset, int length);`
These methods behave like var-length counterparts, but pad smaller payloads to the required length with zeros. I couldn't find anything in the spec on the padding, but this looks like least-surprising behaviour - e.g. the following hypothetical code would behave as if new buffer is allocated every time, even if it's in fact reused 
```
  int actualLength = fillData(data);
  encoder.putData(data, 0, actualLength)
```
Expected typical usage is actually that caller will provide all bytes.


_Decoder_
  `public int getData(byte[] buffer, int offset, int length);`
  `public int getData(MutableDirectByteBuffer buffer, int offset, int length);`
  `public void wrapData(DirectByteBuffer buffer);`
These methods behave similar to var-length counterparts:
 - read min of the provided and actual length
 - getData will return 0 when decoding older version of the message w/o the field
 - wrapData will result in empty buffer when decoding older version

It also seems like there was a bug when generated wrapData() did not properly handled older versions (missing return) - this should be fixed.