### PR TITLE
[C] Fixing argument order for *_wrap_and_apply_header

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/c/CGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/c/CGenerator.java
@@ -1965,7 +1965,7 @@ public class CGenerator implements CodeGenerator
             "    struct %11$s *const hdr)\n" +
             "{\n" +
             "    %11$s_wrap(\n" +
-            "        hdr, buffer + offset, 0, buffer_length, %11$s_sbe_schema_version());\n\n" +
+            "        hdr, buffer + offset, 0, %11$s_sbe_schema_version(), buffer_length);\n\n" +
 
             "    %11$s_set_blockLength(hdr, %10$s_sbe_block_length());\n" +
             "    %11$s_set_templateId(hdr, %10$s_sbe_template_id());\n" +


### PR DESCRIPTION
Fixes #822 

Generated C code has a bug in the generated function *_wrap_and_apply_header() It seems like an easy mistake to make as there is very little consistency in argument order between version and bufferLength in the generated code.