### PR TITLE
[C#] Fix repeated group buffer overflow

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -207,11 +207,11 @@ public class CSharpGenerator implements CodeGenerator
             indent + INDENT + INDENT + "_parentMessage = parentMessage;\n" +
             indent + INDENT + INDENT + "_buffer = buffer;\n" +
             indent + INDENT + INDENT + "_dimensions.Wrap(buffer, parentMessage.Limit, actingVersion);\n" +
+            indent + INDENT + INDENT + "_parentMessage.Limit = parentMessage.Limit + SbeHeaderSize;\n" +
             indent + INDENT + INDENT + "_blockLength = _dimensions.BlockLength;\n" +
             indent + INDENT + INDENT + "_count = (int) _dimensions.NumInGroup;\n" + // cast safety checked above
             indent + INDENT + INDENT + "_actingVersion = actingVersion;\n" +
             indent + INDENT + INDENT + "_index = 0;\n" +
-            indent + INDENT + INDENT + "_parentMessage.Limit = parentMessage.Limit + SbeHeaderSize;\n" +
             indent + INDENT + "}\n",
             parentMessageClassName));
 
@@ -232,14 +232,14 @@ public class CSharpGenerator implements CodeGenerator
             indent + INDENT + INDENT + "}\n\n" +
             indent + INDENT + INDENT + "_parentMessage = parentMessage;\n" +
             indent + INDENT + INDENT + "_buffer = buffer;\n" +
-            indent + INDENT + INDENT + "_dimensions.Wrap(buffer, parentMessage.Limit, _actingVersion);\n" +
+            indent + INDENT + INDENT + "_dimensions.Wrap(buffer, parentMessage.Limit, SchemaVersion);\n" +
+            indent + INDENT + INDENT + "parentMessage.Limit = parentMessage.Limit + SbeHeaderSize;\n" +
             indent + INDENT + INDENT + "_dimensions.BlockLength = SbeBlockLength;\n" +
             indent + INDENT + INDENT + "_dimensions.NumInGroup = (%5$s) count;\n" +
             indent + INDENT + INDENT + "_index = 0;\n" +
             indent + INDENT + INDENT + "_count = count;\n" +
             indent + INDENT + INDENT + "_blockLength = SbeBlockLength;\n" +
             indent + INDENT + INDENT + "_actingVersion = SchemaVersion;\n" +
-            indent + INDENT + INDENT + "parentMessage.Limit = parentMessage.Limit + SbeHeaderSize;\n" +
             indent + INDENT + "}\n",
             parentMessageClassName,
             numInGroupToken.encoding().applicableMinValue().longValue(),


### PR DESCRIPTION
This actually broke code I was working on in a very nasty way when the buffer size was too small - I was trying to use the DirectBuffer's bufferOverflow delegate and some bytes were getting eaten when expanding the buffer.

Explanation in the commit msg:
----

On a repeated group in the WrapForEncode, the parentMessage.Limit has two purposes:

1. It is used as a buffer offset for the _dimensions helper Wrap method
2. The assignment to it has a side effect of checking that we do not exceed the underlying DirectBuffer's capacity

However notice that currently this assignment happens after writing to the _dimensions helper properties BlockLength and NumInGroup,
i.e. the writes are done *before* we check for buffer overflow. 
Underneath these are direct writes to the byte* managed by the DirectBuffer, resulting in an unchecked, unsafe buffer overflow.
To fix this the Limit has to be increased right after the call to the _dimensions.Wrap, before writes to BlockLength and NumInGroup

The same occurs in the Decode method, only reading unsafe, invalid memory instead of writing to it.
Also fixed _actingVersion was being used before it's assigned in the Encode
