### PR TITLE
[Go] Fix for decoding into a struct with pre-allocated slices.

### DIFF
--- a/gocode/src/group_with_data/TestMessages_test.go
+++ b/gocode/src/group_with_data/TestMessages_test.go
@@ -23,7 +23,7 @@ func TestEncodeDecodeTestMessage1(t *testing.T) {
 		t.Fail()
 	}
 
-	var out TestMessage1 = *new(TestMessage1)
+	var out = *new(TestMessage1)
 	if err := out.Decode(m, buf, in.SbeSchemaVersion(), in.SbeBlockLength(), true); err != nil {
 		t.Log("Decoding Error", err)
 		t.Fail()
@@ -71,7 +71,7 @@ func TestEncodeDecodeTestMessage2(t *testing.T) {
 		t.Fail()
 	}
 
-	var out TestMessage2 = *new(TestMessage2)
+	var out = *new(TestMessage2)
 	if err := out.Decode(m, buf, in.SbeSchemaVersion(), in.SbeBlockLength(), true); err != nil {
 		t.Log("Decoding Error", err)
 		t.Fail()
@@ -129,7 +129,7 @@ func TestEncodeDecodeTestMessage3(t *testing.T) {
 		t.Fail()
 	}
 
-	var out TestMessage3 = *new(TestMessage3)
+	var out = *new(TestMessage3)
 	if err := out.Decode(m, buf, in.SbeSchemaVersion(), in.SbeBlockLength(), true); err != nil {
 		t.Log("Decoding Error", err)
 		t.Fail()
@@ -186,7 +186,7 @@ func TestEncodeDecodeTestMessage4(t *testing.T) {
 		t.Fail()
 	}
 
-	var out TestMessage4 = *new(TestMessage4)
+	var out = *new(TestMessage4)
 	if err := out.Decode(m, buf, in.SbeSchemaVersion(), in.SbeBlockLength(), true); err != nil {
 		t.Log("Decoding Error", err)
 		t.Fail()
@@ -210,5 +210,91 @@ func TestEncodeDecodeTestMessage4(t *testing.T) {
 			t.Fail()
 		}
 	}
+	return
+}
+
+func TestEncodeDecodeTestPreAlloc(t *testing.T) {
+	m := NewSbeGoMarshaller()
+
+	in := TestMessage4{
+		Tag1: 9876,
+		Entries: []TestMessage4Entries{
+			{
+				VarDataField1: []byte("abcdef"),
+				VarDataField2: []byte("ghij"),
+			},
+			{
+				VarDataField1: []byte("abc"),
+				VarDataField2: []byte("gh"),
+			},
+		},
+	}
+
+	var buf = new(bytes.Buffer)
+	if err := in.Encode(m, buf, true); err != nil {
+		t.Log("Encoding Error", err)
+		t.Fail()
+	}
+
+	var out = *new(TestMessage4)
+	if err := out.Decode(m, buf, in.SbeSchemaVersion(), in.SbeBlockLength(), true); err != nil {
+		t.Log("Decoding Error", err)
+		t.Fail()
+	}
+
+	if in.Tag1 != out.Tag1 {
+		t.Logf("in.Tag1 != out.Tag1")
+		t.Fail()
+	}
+
+	for i := 0; i < len(in.Entries); i++ {
+		if !bytes.Equal(in.Entries[i].VarDataField1, out.Entries[i].VarDataField1) {
+			t.Logf("in.Entries[%d].VarDataField (%v)!= out.Entries[%d].VarDataField (%v)", i, i, in.Entries[i].VarDataField1, out.Entries[i].VarDataField1)
+			t.Fail()
+		}
+		if !bytes.Equal(in.Entries[i].VarDataField2, out.Entries[i].VarDataField2) {
+			t.Logf("in.Entries[%d].VarDataField (%v) != out.Entries[%d].VarDataField (%v)", i, i, in.Entries[i].VarDataField2, out.Entries[i].VarDataField2)
+			t.Fail()
+		}
+	}
+
+	// new messages with newer group elements, shorter vardata
+	in = TestMessage4{
+		Tag1: 9876,
+		Entries: []TestMessage4Entries{
+			{
+				VarDataField1: []byte("abc"),
+				VarDataField2: []byte("ghijk"),
+			},
+		},
+	}
+
+	buf.Reset()
+	if err := in.Encode(m, buf, true); err != nil {
+		t.Log("Encoding Error", err)
+		t.Fail()
+	}
+
+	if err := out.Decode(m, buf, in.SbeSchemaVersion(), in.SbeBlockLength(), true); err != nil {
+		t.Log("Decoding Error", err)
+		t.Fail()
+	}
+
+	if in.Tag1 != out.Tag1 {
+		t.Logf("in.Tag1 != out.Tag1")
+		t.Fail()
+	}
+
+	for i := 0; i < len(in.Entries); i++ {
+		if !bytes.Equal(in.Entries[i].VarDataField1, out.Entries[i].VarDataField1) {
+			t.Logf("in.Entries[%d].VarDataField (%v)!= out.Entries[%d].VarDataField (%v)", i, i, in.Entries[i].VarDataField1, out.Entries[i].VarDataField1)
+			t.Fail()
+		}
+		if !bytes.Equal(in.Entries[i].VarDataField2, out.Entries[i].VarDataField2) {
+			t.Logf("in.Entries[%d].VarDataField (%v) != out.Entries[%d].VarDataField (%v)", i, i, in.Entries[i].VarDataField2, out.Entries[i].VarDataField2)
+			t.Fail()
+		}
+	}
+
 	return
 }

--- a/gocode/src/mktdata/preallocated_test.go
+++ b/gocode/src/mktdata/preallocated_test.go
@@ -1,0 +1,69 @@
+package mktdata
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"testing"
+)
+
+func TestPreallocated(t *testing.T) {
+	in := &MDIncrementalRefreshBook32{
+		TransactTime: 1,
+		NoMDEntries: []MDIncrementalRefreshBook32NoMDEntries{
+			{
+				MDEntryPx:   PRICENULL{},
+				MDEntrySize: 5,
+				SecurityID:  1,
+			},
+			{
+				MDEntryPx:   PRICENULL{},
+				MDEntrySize: 6,
+				SecurityID:  1,
+			},
+		},
+	}
+	min := NewSbeGoMarshaller()
+
+	buf := &bytes.Buffer{}
+	if err := in.Encode(min, buf, true); err != nil {
+		fmt.Println("Encoding Error", err)
+		os.Exit(1)
+	}
+
+	out := &MDIncrementalRefreshBook32{}
+	if err := out.Decode(min, buf, in.SbeSchemaVersion(), in.SbeBlockLength(), true); err != nil {
+		fmt.Println("Decoding Error", err)
+		os.Exit(1)
+	}
+	if len(out.NoMDEntries) != len(in.NoMDEntries) {
+		fmt.Printf("expected %d entries, got %d\n", len(in.NoMDEntries), len(out.NoMDEntries))
+		os.Exit(1)
+	}
+
+	// decode a message with fewer entries on top of existing message
+	in = &MDIncrementalRefreshBook32{
+		TransactTime: 1,
+		NoMDEntries: []MDIncrementalRefreshBook32NoMDEntries{
+			{
+				MDEntryPx:   PRICENULL{},
+				MDEntrySize: 5,
+				SecurityID:  1,
+			},
+		},
+	}
+	buf.Reset()
+	if err := in.Encode(min, buf, true); err != nil {
+		fmt.Println("Encoding Error", err)
+		os.Exit(1)
+	}
+
+	if err := out.Decode(min, buf, in.SbeSchemaVersion(), in.SbeBlockLength(), true); err != nil {
+		fmt.Println("Decoding Error", err)
+		os.Exit(1)
+	}
+	if len(out.NoMDEntries) != len(in.NoMDEntries) {
+		fmt.Printf("expected %d entries, got %d\n", len(in.NoMDEntries), len(out.NoMDEntries))
+		os.Exit(1)
+	}
+}

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangGenerator.java
@@ -1164,6 +1164,7 @@ public class GolangGenerator implements CodeGenerator
             "\t\tif cap(%1$c.%2$s) < int(%2$sLength) {\n" +
             "\t\t\t%1$s.%2$s = make([]%5$s, %2$sLength)\n" +
             "\t\t}\n" +
+            "\t\t%1$c.%2$s = %1$c.%2$s[:%2$sLength]\n" +
             "\t\tif err := _m.ReadBytes(_r, %1$c.%2$s); err != nil {\n" +
             "\t\t\treturn err\n" +
             "\t\t}\n" +
@@ -1271,6 +1272,7 @@ public class GolangGenerator implements CodeGenerator
             "\t\tif cap(%1$c.%2$s) < int(%2$sNumInGroup) {\n" +
             "\t\t\t%1$s.%2$s = make([]%3$s%2$s, %2$sNumInGroup)\n" +
             "\t\t}\n" +
+            "\t\t%1$c.%2$s = %1$c.%2$s[:%2$sNumInGroup]\n" +
             "\t\tfor i, _ := range %1$s.%2$s {\n" +
             "\t\t\tif err := %1$s.%2$s[i].Decode(_m, _r, actingVersion, uint(%4$sBlockLength)); err != nil {\n" +
             "\t\t\t\treturn err\n" +


### PR DESCRIPTION
This change allows you to call `Decode()` on an sbe struct where the struct has pre-allocated slices. Before, the code would allocate a new slice if the capacity on the existing slice was less than the number of groups in the message. If the old slice had a greater capacity, it wouldn't truncate the number of elements to the new length. The same issue with vardata fields.