### PR TITLE
[C++] Use generated literal as the constant one to be shifted in the bitset code.

### DIFF
--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/cpp/CppGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/cpp/CppGeneratorTest.java
@@ -1,0 +1,58 @@
+/*
+ * Copyright 2013-2020 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.sbe.generation.cpp;
+
+import org.agrona.generation.StringWriterOutputManager;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import uk.co.real_logic.sbe.Tests;
+import uk.co.real_logic.sbe.ir.Ir;
+import uk.co.real_logic.sbe.xml.IrGenerator;
+import uk.co.real_logic.sbe.xml.MessageSchema;
+import uk.co.real_logic.sbe.xml.ParserOptions;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static uk.co.real_logic.sbe.xml.XmlSchemaParser.parse;
+
+public class CppGeneratorTest
+{
+    private final StringWriterOutputManager outputManager = new StringWriterOutputManager();
+    private Ir ir;
+
+    @BeforeEach
+    public void setUp() throws Exception
+    {
+        final ParserOptions options = ParserOptions.builder().stopOnError(true).build();
+        final MessageSchema schema = parse(Tests.getLocalResource("code-generation-schema.xml"), options);
+        final IrGenerator irg = new IrGenerator();
+        ir = irg.generate(schema);
+
+        outputManager.clear();
+        outputManager.setPackageName(ir.applicableNamespace());
+    }
+
+    @Test
+    public void shouldUseGeneratedLiteralForConstantOneWhenGeneratingBitsetCode() throws Exception
+    {
+        final CppGenerator generator = new CppGenerator(ir, outputManager);
+        generator.generate();
+
+        final String source = outputManager.getSource("code.generation.test.OptionalExtras").toString();
+        assertFalse(source.contains("1u << "));
+        assertTrue(source.contains("static_cast<std::uint8_t>(1) << "));
+    }
+}

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/cpp/CppGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/cpp/CppGeneratorTest.java
@@ -16,7 +16,6 @@
 package uk.co.real_logic.sbe.generation.cpp;
 
 import org.agrona.generation.StringWriterOutputManager;
-import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import uk.co.real_logic.sbe.Tests;
 import uk.co.real_logic.sbe.ir.Ir;
@@ -30,29 +29,22 @@ import static uk.co.real_logic.sbe.xml.XmlSchemaParser.parse;
 
 public class CppGeneratorTest
 {
-    private final StringWriterOutputManager outputManager = new StringWriterOutputManager();
-    private Ir ir;
-
-    @BeforeEach
-    public void setUp() throws Exception
-    {
-        final ParserOptions options = ParserOptions.builder().stopOnError(true).build();
-        final MessageSchema schema = parse(Tests.getLocalResource("code-generation-schema.xml"), options);
-        final IrGenerator irg = new IrGenerator();
-        ir = irg.generate(schema);
-
-        outputManager.clear();
-        outputManager.setPackageName(ir.applicableNamespace());
-    }
-
     @Test
     public void shouldUseGeneratedLiteralForConstantOneWhenGeneratingBitsetCode() throws Exception
     {
+        final ParserOptions options = ParserOptions.builder().stopOnError(true).build();
+        final MessageSchema schema = parse(Tests.getLocalResource("issue827.xml"), options);
+        final IrGenerator irg = new IrGenerator();
+        final Ir ir = irg.generate(schema);
+        final StringWriterOutputManager outputManager = new StringWriterOutputManager();
+        outputManager.clear();
+        outputManager.setPackageName(ir.applicableNamespace());
+
         final CppGenerator generator = new CppGenerator(ir, outputManager);
         generator.generate();
 
-        final String source = outputManager.getSource("code.generation.test.OptionalExtras").toString();
+        final String source = outputManager.getSource("issue827.FlagsSet").toString();
         assertFalse(source.contains("1u << "));
-        assertTrue(source.contains("static_cast<std::uint8_t>(1) << "));
+        assertTrue(source.contains("UINT64_C(0x1) << "));
     }
 }

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/cpp/CppGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/cpp/CppGeneratorTest.java
@@ -37,7 +37,6 @@ public class CppGeneratorTest
         final IrGenerator irg = new IrGenerator();
         final Ir ir = irg.generate(schema);
         final StringWriterOutputManager outputManager = new StringWriterOutputManager();
-        outputManager.clear();
         outputManager.setPackageName(ir.applicableNamespace());
 
         final CppGenerator generator = new CppGenerator(ir, outputManager);

--- a/sbe-tool/src/test/resources/issue827.xml
+++ b/sbe-tool/src/test/resources/issue827.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   package="issue827"
+                   id="827"
+                   version="1"
+                   semanticVersion="1.0"
+                   description="issue 661 test case"
+                   byteOrder="bigEndian">
+    <types>
+        <set name="FlagsSet" encodingType="uint64">
+            <choice name="Bit0" description="Bit 0">0</choice>
+            <choice name="Bit35" description="Bit 35">35</choice>
+        </set>
+        <composite name="messageHeader" description="Message identifiers and length of message root">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+    </types>
+    <sbe:message name="test" id="1" description="issue 827 test">
+	<field name="set0" type="FlagsSet" id="1"/>
+    </sbe:message>
+</sbe:messageSchema>


### PR DESCRIPTION
Fixes #827.