### PR TITLE
added maximum and minimum meta methods for allowed repeating group count

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -483,6 +483,15 @@ public class JavaGenerator implements CodeGenerator
             blockLengthType, blockLengthOffset, blockLengthValue, byteOrderString(blockLengthToken.encoding()));
 
         final PrimitiveType numInGroupType = numInGroupToken.encoding().primitiveType();
+
+        final String javaTypeName = javaTypeName(numInGroupType);
+        final String minValue = generateLiteral(numInGroupType,
+            numInGroupToken.encoding().applicableMinValue().toString());
+        generatePrimitiveFieldMetaMethod(sb, ind, javaTypeName, "count", "Min", minValue);
+        final String maxValue = generateLiteral(numInGroupType,
+            numInGroupToken.encoding().applicableMaxValue().toString());
+        generatePrimitiveFieldMetaMethod(sb, ind, javaTypeName, "count", "Max", maxValue);
+
         final PrimitiveType newInGroupTypeCast = PrimitiveType.UINT32 == numInGroupType ?
             PrimitiveType.INT32 : numInGroupType;
         final String numInGroupOffset = "limit + " + numInGroupToken.offset();

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/JavaGeneratorTest.java
@@ -442,6 +442,22 @@ public class JavaGeneratorTest
         assertThat(get(decoder, "vehicleCode"), is("R11R12"));
     }
 
+    @Test
+    public void shouldGenerateRepeatingGroupCountLimits() throws Exception
+    {
+        generator().generate();
+
+        final String className = "CarEncoder$FuelFiguresEncoder";
+        final String fqClassName = ir.applicableNamespace() + "." + className;
+
+        final Class<?> clazz = compile(fqClassName);
+        final Method minValue = clazz.getMethod("countMinValue");
+        assertNotNull(minValue);
+        assertEquals(0, minValue.invoke(null));
+        final Method maxValue = clazz.getMethod("countMaxValue");
+        assertNotNull(maxValue);
+        assertEquals(65534, maxValue.invoke(null));
+    }
 
     private Class<?> getModelClass(final Object encoder) throws ClassNotFoundException
     {


### PR DESCRIPTION
Currently there is no way to extract bounds for repeating group count. This may be necessary for pre-publishing validation code or for the message accepting code which may have some (non-SBE) flyweight buffers for business entities.