### PR TITLE
[Go] Fix tokens passed to generateComposite (#849)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -621,6 +621,7 @@ task generateGolangCodecsWithXSD(type: JavaExec) {
             'sbe-tool/src/test/resources/issue661.xml',
             'sbe-tool/src/test/resources/issue847.xml',
             'sbe-tool/src/test/resources/issue848.xml',
+            'sbe-tool/src/test/resources/issue849.xml',
             'sbe-tool/src/test/resources/since-deprecated-test-schema.xml',
             'sbe-tool/src/test/resources/example-bigendian-test-schema.xml',
             'gocode/resources/example-composite.xml',

--- a/gocode/Makefile
+++ b/gocode/Makefile
@@ -72,7 +72,7 @@ test: $(DEP)
 		go install \
 		;done))
 	(export GOPATH=$(GOPATH) && \
-		(for t in baseline-bigendian mktdata group_with_data group_with_data_extension composite_elements composite since-deprecated simple issue435 issue472 issue483 issue488 issue560 issue847 issue848; do \
+		(for t in baseline-bigendian mktdata group_with_data group_with_data_extension composite_elements composite since-deprecated simple issue435 issue472 issue483 issue488 issue560 issue847 issue848 issue849; do \
 		cd $(GOPATH)/src/$$t && \
 		go build && \
 		go fmt && \

--- a/gocode/src/issue849/issue849_test.go
+++ b/gocode/src/issue849/issue849_test.go
@@ -1,0 +1,9 @@
+package issue849
+
+import (
+	"testing"
+)
+
+func TestNothing(t *testing.T) {
+	// placeholder, really just looking for clean builds
+}

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangGenerator.java
@@ -2045,8 +2045,8 @@ public class GolangGenerator implements CodeGenerator
 
                 case BEGIN_COMPOSITE:
                     // recurse
-                    generateComposite(tokens.subList(i, tokens.size()), typeName);
-                    i += token.componentTokenCount() - 2;
+                    generateComposite(tokens.subList(i, i + token.componentTokenCount()), typeName);
+                    i += token.componentTokenCount() - 1;
 
                     sb.append("\t").append(propertyName)
                         .append(generateWhitespace(longest - propertyName.length() + 1))

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangGenerator.java
@@ -1305,7 +1305,7 @@ public class GolangGenerator implements CodeGenerator
             "\t\t\t%1$s.%2$s = make([]%3$s%2$s, %2$sNumInGroup)\n" +
             "\t\t}\n" +
             "\t\t%1$c.%2$s = %1$c.%2$s[:%2$sNumInGroup]\n" +
-            "\t\tfor i, _ := range %1$s.%2$s {\n" +
+            "\t\tfor i := range %1$s.%2$s {\n" +
             "\t\t\tif err := %1$s.%2$s[i].Decode(_m, _r, actingVersion, uint(%4$sBlockLength)); err != nil {\n" +
             "\t\t\t\treturn err\n" +
             "\t\t\t}\n" +

--- a/sbe-tool/src/test/resources/issue849.xml
+++ b/sbe-tool/src/test/resources/issue849.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+    package="issue849"
+    id="1"
+    version="0"
+    semanticVersion="1.0"
+    description="test case 849 20210512"
+    byteOrder="littleEndian">
+    <types>
+        <composite name="Comp1" description="Comp1">
+            <type name="abc"  primitiveType="uint32"/>
+            <type name="wxyz" primitiveType="uint32"/>
+        </composite>
+        <composite name="Comp2" description="Comp2">
+            <type name="eenie"  primitiveType="uint32"/>
+            <ref  name="c1"   type="Comp1"/>
+            <type name="meanie" primitiveType="uint32"/>
+        </composite>
+        <composite name="Comp3" description="Comp3">
+            <type name="moe"  primitiveType="uint32"/>
+            <ref  name="c2"   type="Comp2"/>
+            <type name="roe"  primitiveType="uint32"/>
+        </composite>
+        <composite name="Comp4" description="Comp4">
+            <type name="roe"  primitiveType="uint32"/>
+        </composite>
+        <composite name="messageHeader" description="MH">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId"  primitiveType="uint16"/>
+            <type name="schemaId"    primitiveType="uint16"/>
+            <type name="version"     primitiveType="uint16"/>
+            <ref  name="c1"          type="Comp1"/>
+            <type name="lmn"         primitiveType="uint32"/>
+            <ref  name="c2"          type="Comp2"/>
+            <type name="opq"         primitiveType="uint32"/>
+        </composite>
+    </types>
+    <sbe:message name="barmsg" id="4">
+        <field name="header" id="1" type="messageHeader"/>
+        <field name="c3"     id="2" type="Comp3"/>
+        <field name="c4"     id="3" type="Comp4"/>
+    </sbe:message>
+</sbe:messageSchema>


### PR DESCRIPTION
Too many tokens were passed to `generateComposite` causing weird
errors like(#844 and #849).

Also adds a `gofmt` fix.