### PR TITLE
Generate stubs for non used composites

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/Ir.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/Ir.java
@@ -115,6 +115,17 @@ public class Ir
         messagesByIdMap.put(messageId, new ArrayList<>(messageTokens));
     }
 
+    public void addComposite(final String name, final List<Token> tokens)
+    {
+        if (typesByNameMap.containsKey(name)) {
+            return;
+        }
+
+        Verify.notNull(tokens, "tokens");
+        captureTypes(tokens, 0, tokens.size() - 1);
+        updateComponentTokenCounts(tokens);
+    }
+
     /**
      * Get the getMessage for a given identifier.
      *

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/IrGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/IrGenerator.java
@@ -46,6 +46,7 @@ public class IrGenerator
         this.schema = schema;
 
         final List<Token> headerTokens = generateForHeader(schema);
+
         final Ir ir = new Ir(
             schema.packageName(),
             namespace,
@@ -60,6 +61,14 @@ public class IrGenerator
         {
             final long msgId = message.id();
             ir.addMessage(msgId, generateForMessage(schema, msgId));
+        }
+
+
+        for (String name : schema.types()) {
+            Type obj = schema.getType(name);
+            if(obj instanceof CompositeType) {
+                ir.addComposite(name, generateForComposite((CompositeType)obj));
+            }
         }
 
         return ir;
@@ -94,6 +103,15 @@ public class IrGenerator
         tokenList.clear();
 
         add(schema.messageHeader(), 0, null);
+
+        return tokenList;
+    }
+
+    private List<Token> generateForComposite(final CompositeType composite)
+    {
+        tokenList.clear();
+
+        add(composite, 0, null);
 
         return tokenList;
     }

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/MessageSchema.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/MessageSchema.java
@@ -59,7 +59,6 @@ public class MessageSchema
         final String headerType = getAttributeValueOrNull(schemaNode, "headerType");
         this.headerType = null == headerType ? HEADER_TYPE_DEFAULT : headerType;
         Verify.present(typeByNameMap, this.headerType, "Message header");
-
         ((CompositeType)typeByNameMap.get(this.headerType)).checkForWellFormedMessageHeader(schemaNode);
     }
 
@@ -143,6 +142,11 @@ public class MessageSchema
     public Type getType(final String typeName)
     {
         return typeByNameMap.get(typeName);
+    }
+
+    public Collection<String> types()
+    {
+        return typeByNameMap.keySet();
     }
 
     /**


### PR DESCRIPTION
Currently the `sbe-tool` generates stubs only for composites which are being used in a `sbe:message`. For my purposes I need generate stubs for all the composites, not only referenced in the messages. This patch allows to do this.  