### PR TITLE
Generating Rust code should support multiple schema files with same package name

### DIFF
--- a/rust/benches/car_benchmark.rs
+++ b/rust/benches/car_benchmark.rs
@@ -28,7 +28,7 @@ fn encode(state: &mut State) -> SbeResult<usize> {
     let mut acceleration = AccelerationEncoder::default();
     let mut extras = OptionalExtras::default();
 
-    car = car.wrap(WriteBuf::new(buffer), message_header::ENCODED_LENGTH);
+    car = car.wrap(WriteBuf::new(buffer), message_header_codec::ENCODED_LENGTH);
     car = car.header(0).parent()?;
 
     car.code(Model::A);

--- a/rust/benches/md_benchmark.rs
+++ b/rust/benches/md_benchmark.rs
@@ -22,7 +22,7 @@ fn encode_md(state: &mut State) -> SbeResult<usize> {
     let mut market_data = MarketDataIncrementalRefreshTradesEncoder::default();
     let mut md_inc_grp = MdIncGrpEncoder::default();
 
-    market_data = market_data.wrap(WriteBuf::new(buffer), message_header::ENCODED_LENGTH);
+    market_data = market_data.wrap(WriteBuf::new(buffer), message_header_codec::ENCODED_LENGTH);
     market_data = market_data.header(0).parent()?;
 
     market_data.transact_time(1234);

--- a/rust/tests/baseline_test.rs
+++ b/rust/tests/baseline_test.rs
@@ -33,7 +33,7 @@ fn decode_car_and_assert_expected_content(buffer: &[u8]) -> SbeResult<()> {
 
     let buf = ReadBuf::new(buffer);
     let header = MessageHeaderDecoder::default().wrap(buf, 0);
-    assert_eq!(car::SBE_TEMPLATE_ID, header.template_id());
+    assert_eq!(car_codec::SBE_TEMPLATE_ID, header.template_id());
     car = car.header(header);
 
     // Car...
@@ -167,7 +167,7 @@ fn encode_car_from_scratch() -> SbeResult<(usize, Vec<u8>)> {
 
     car = car.wrap(
         WriteBuf::new(buffer.as_mut_slice()),
-        message_header::ENCODED_LENGTH,
+        message_header_codec::ENCODED_LENGTH,
     );
     car = car.header(0).parent()?;
 

--- a/rust/tests/big_endian_test.rs
+++ b/rust/tests/big_endian_test.rs
@@ -30,7 +30,7 @@ fn decode_car_and_assert_expected_content(buffer: &[u8]) -> SbeResult<()> {
 
     let buf = ReadBuf::new(buffer);
     let header = MessageHeaderDecoder::default().wrap(buf, 0);
-    assert_eq!(car::SBE_TEMPLATE_ID, header.template_id());
+    assert_eq!(car_codec::SBE_TEMPLATE_ID, header.template_id());
     car = car.header(header);
 
     // Car...
@@ -161,7 +161,7 @@ fn encode_car_from_scratch() -> SbeResult<(usize, Vec<u8>)> {
 
     car = car.wrap(
         WriteBuf::new(buffer.as_mut_slice()),
-        message_header::ENCODED_LENGTH,
+        message_header_codec::ENCODED_LENGTH,
     );
     car = car.header(0).parent()?;
 

--- a/rust/tests/extension_test.rs
+++ b/rust/tests/extension_test.rs
@@ -32,7 +32,7 @@ fn decode_car_and_assert_expected_content(buffer: &[u8]) -> SbeResult<()> {
 
     let buf = ReadBuf::new(buffer);
     let header = MessageHeaderDecoder::default().wrap(buf, 0);
-    assert_eq!(car::SBE_TEMPLATE_ID, header.template_id());
+    assert_eq!(car_codec::SBE_TEMPLATE_ID, header.template_id());
     car = car.header(header);
 
     // Car...
@@ -168,7 +168,7 @@ fn encode_car_from_scratch() -> SbeResult<(usize, Vec<u8>)> {
 
     car = car.wrap(
         WriteBuf::new(buffer.as_mut_slice()),
-        message_header::ENCODED_LENGTH,
+        message_header_codec::ENCODED_LENGTH,
     );
     car = car.header(0).parent()?;
 

--- a/rust/tests/issue_435_test.rs
+++ b/rust/tests/issue_435_test.rs
@@ -3,7 +3,7 @@ use ::issue_435::*;
 fn create_encoder(buffer: &mut Vec<u8>) -> Issue435Encoder {
     let issue_435 = Issue435Encoder::default().wrap(
         WriteBuf::new(buffer.as_mut_slice()),
-        message_header::ENCODED_LENGTH,
+        message_header_codec::ENCODED_LENGTH,
     );
     let mut header = issue_435.header(0);
     header.s(*SetRef::default().set_one(true));
@@ -12,9 +12,9 @@ fn create_encoder(buffer: &mut Vec<u8>) -> Issue435Encoder {
 
 #[test]
 fn issue_435_ref_test() -> SbeResult<()> {
-    assert_eq!(9, message_header::ENCODED_LENGTH);
-    assert_eq!(1, issue_435::SBE_BLOCK_LENGTH);
-    assert_eq!(0, issue_435::SBE_SCHEMA_VERSION);
+    assert_eq!(9, message_header_codec::ENCODED_LENGTH);
+    assert_eq!(1, issue_435_codec::SBE_BLOCK_LENGTH);
+    assert_eq!(0, issue_435_codec::SBE_SCHEMA_VERSION);
 
     // encode...
     let mut buffer = vec![0u8; 256];
@@ -24,10 +24,10 @@ fn issue_435_ref_test() -> SbeResult<()> {
     // decode...
     let buf = ReadBuf::new(buffer.as_slice());
     let header = MessageHeaderDecoder::default().wrap(buf, 0);
-    assert_eq!(issue_435::SBE_BLOCK_LENGTH, header.block_length());
-    assert_eq!(issue_435::SBE_SCHEMA_VERSION, header.version());
-    assert_eq!(issue_435::SBE_TEMPLATE_ID, header.template_id());
-    assert_eq!(issue_435::SBE_SCHEMA_ID, header.schema_id());
+    assert_eq!(issue_435_codec::SBE_BLOCK_LENGTH, header.block_length());
+    assert_eq!(issue_435_codec::SBE_SCHEMA_VERSION, header.version());
+    assert_eq!(issue_435_codec::SBE_TEMPLATE_ID, header.template_id());
+    assert_eq!(issue_435_codec::SBE_SCHEMA_ID, header.schema_id());
     assert_eq!(*SetRef::default().set_one(true), header.s());
 
     let decoder = Issue435Decoder::default().header(header);

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/SbeTool.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/SbeTool.java
@@ -164,7 +164,7 @@ public class SbeTool
      * Specifies token that should be appended to keywords to avoid compilation errors.
      * <p>
      * If none is supplied then use of keywords results in an error during schema parsing. The
-     * underscore character is a good example fo a token to use.
+     * underscore character is a good example of a token to use.
      */
     public static final String KEYWORD_APPEND_TOKEN = "sbe.keyword.append.token";
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/MessageCoderDef.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/MessageCoderDef.java
@@ -147,7 +147,7 @@ class MessageCoderDef implements RustGenerator.ParentDef
         indent(out, 3, "let acting_version = header.version();\n\n");
         indent(out, 3, "self.wrap(\n");
         indent(out, 4, "header.parent().unwrap(),\n");
-        indent(out, 4, "message_header::ENCODED_LENGTH,\n");
+        indent(out, 4, "message_header_codec::ENCODED_LENGTH,\n");
         indent(out, 4, "acting_block_length,\n");
         indent(out, 4, "acting_version,\n");
         indent(out, 3, ")\n");

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustOutputManager.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustOutputManager.java
@@ -21,10 +21,11 @@ import org.agrona.generation.OutputManager;
 import java.io.File;
 import java.io.IOException;
 import java.io.Writer;
-import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 
 import static java.io.File.separatorChar;
+import static java.nio.charset.StandardCharsets.UTF_8;
 import static uk.co.real_logic.sbe.generation.rust.RustUtil.toLowerSnakeCase;
 
 /**
@@ -36,8 +37,19 @@ public class RustOutputManager implements OutputManager
     private final File rootDir;
     private final File srcDir;
 
+    static File createDir(final String dirName)
+    {
+        final File dir = new File(dirName);
+        if (!dir.exists() && !dir.mkdirs())
+        {
+            throw new IllegalStateException("Unable to create directory: " + dirName);
+        }
+        return dir;
+    }
+
     /**
      * Create a new {@link OutputManager} for generating rust source files into a given module.
+     *
      * @param baseDirName for the generated source code.
      * @param packageName for the generated source code relative to the baseDirName.
      */
@@ -52,12 +64,7 @@ public class RustOutputManager implements OutputManager
         rootDir = new File(libDirName);
 
         final String srcDirName = libDirName + separatorChar + "src";
-
-        srcDir = new File(srcDirName);
-        if (!srcDir.exists() && !srcDir.mkdirs())
-        {
-            throw new IllegalStateException("Unable to create directory: " + srcDirName);
-        }
+        srcDir = createDir(srcDirName);
     }
 
     /**
@@ -70,15 +77,17 @@ public class RustOutputManager implements OutputManager
      * @return a {@link java.io.Writer} to which the source code should be written.
      * @throws IOException if an issue occurs when creating the file.
      */
-    @Override public Writer createOutput(final String name) throws IOException
+    @Override
+    public Writer createOutput(final String name) throws IOException
     {
         final String fileName = toLowerSnakeCase(name) + ".rs";
         final File targetFile = new File(srcDir, fileName);
-        return Files.newBufferedWriter(targetFile.toPath(), StandardCharsets.UTF_8);
+        return Files.newBufferedWriter(targetFile.toPath(), UTF_8);
     }
 
     /**
-     *
+     * Creates a new Cargo.toml file
+     * <p>
      * @return a {@link java.io.Writer} to which the crate definition should be written.
      * @throws IOException if an issue occurs when creating the file.
      */
@@ -86,7 +95,12 @@ public class RustOutputManager implements OutputManager
     {
         final String fileName = "Cargo.toml";
         final File targetFile = new File(rootDir, fileName);
-        return Files.newBufferedWriter(targetFile.toPath(), StandardCharsets.UTF_8);
+        return Files.newBufferedWriter(targetFile.toPath(), UTF_8);
+    }
+
+    Path getSrcDirPath()
+    {
+        return srcDir.toPath();
     }
 
 }

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustUtil.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustUtil.java
@@ -122,6 +122,11 @@ public class RustUtil
         return Generators.toUpperFirstChar(structName);
     }
 
+    static String codecModName(final String prefix)
+    {
+        return toLowerSnakeCase(prefix + "Codec");
+    }
+
     static String codecName(final String structName, final CodecType codecType)
     {
         return formatStructName(structName + codecType.name());


### PR DESCRIPTION
The generated `lib.rs` file now only contains common sbe code, all generated enums, bitSets, composites, etc. will be written to their own file.