### PR TITLE
DirectBuffer - Support ArraySegment for underlying array

### DIFF
--- a/csharp/sbe-dll/DirectBuffer.cs
+++ b/csharp/sbe-dll/DirectBuffer.cs
@@ -64,18 +64,18 @@ namespace Org.SbeTool.Sbe.Dll
             Wrap(pBuffer, bufferLength);
         }
 
-                /// <summary>
-        /// Attach a view to an unmanaged buffer owned by external code
+        /// <summary>
+        /// Attach a view to a buffer owned by external code
         /// </summary>
-        /// <param name="buffer">Unmanaged byte buffer</param>
+        /// <param name="buffer">byte buffer</param>
         public DirectBuffer(ArraySegment<byte> buffer) : this(buffer, null)
         {
         }
 
         /// <summary>
-        /// Attach a view to an unmanaged buffer owned by external code
+        /// Attach a view to a buffer owned by external code
         /// </summary>
-        /// <param name="buffer">Unmanaged byte buffer</param>
+        /// <param name="buffer">byte buffer</param>
         /// <param name="bufferOverflow">delegate to allow reallocation of buffer</param>
         public DirectBuffer(ArraySegment<byte> buffer, BufferOverflowDelegate bufferOverflow)
         {

--- a/csharp/sbe-tests/DirectBufferTests.cs
+++ b/csharp/sbe-tests/DirectBufferTests.cs
@@ -67,6 +67,40 @@ namespace Org.SbeTool.Sbe.Tests
         }
 
         [TestMethod]
+        public void ConstructFromByteArray()
+        {
+            var buffer = new byte[16];
+
+            const int value = 5;
+            const int index = 0;
+            
+            using (var directBuffer = new DirectBuffer(buffer))
+            {
+                directBuffer.Int64PutLittleEndian(index, value);
+                Assert.AreEqual(value, buffer[index]);
+            }
+        }
+
+        [TestMethod]
+        public void ConstructFromArraySegment()
+        {
+            const int value = 5;
+            const int index = 0;
+            const int offset = 512;
+            const int size = 1024;
+
+            var bigBuffer = new byte[size];
+            var buffer = new ArraySegment<byte>(bigBuffer, offset, size - offset);
+            
+            using (var directBuffer = new DirectBuffer(buffer))
+            {
+                directBuffer.Int64PutLittleEndian(index, value);
+                Assert.AreEqual(value, bigBuffer[offset + index]);
+                Assert.AreEqual(value, buffer.AsSpan<byte>()[index]);
+            }
+        }
+
+        [TestMethod]
         public void Recycle()
         {
             var directBuffer = new DirectBuffer();


### PR DESCRIPTION
What: Support ArraySegment for underlying array

Why: It's useful to be able to read an SBE message from a view (i.e. ArraySegment) on a big array of bytes.

How: similar to the `byte[]` case, pin the ArraySegment's underlying buffer so the GC doesn't move it, then offset the created pointer by the ArraySegment offset so that we point to the right memory.

Testing: run unit tests locally with `./runtests`