### PR TITLE
[Java] Charset encoding handling improvements.

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -939,7 +939,7 @@ public class JavaGenerator implements CodeGenerator
                 generateGet(lengthType, "limit", byteOrderStr),
                 characterEncoding);
 
-            if (characterEncoding.contains("ASCII"))
+            if (isAsciiEncoding(characterEncoding))
             {
                 new Formatter(sb).format("\n" +
                     indent + "    public int get%1$s(final Appendable appendable)\n" +
@@ -1050,7 +1050,7 @@ public class JavaGenerator implements CodeGenerator
     {
         final PrimitiveType lengthPutType = PrimitiveType.UINT32 == lengthType ? PrimitiveType.INT32 : lengthType;
 
-        if (characterEncoding.contains("ASCII"))
+        if (isAsciiEncoding(characterEncoding))
         {
             new Formatter(sb).format("\n" +
                 indent + "    public %1$s %2$s(final String value)\n" +
@@ -2042,7 +2042,7 @@ public class JavaGenerator implements CodeGenerator
                 fieldLength,
                 charset(encoding.characterEncoding()));
 
-            if (encoding.characterEncoding().contains("ASCII"))
+            if (isAsciiEncoding(encoding.characterEncoding()))
             {
                 new Formatter(sb).format("\n" +
                     indent + "    public int get%1$s(final Appendable value)\n" +
@@ -2240,7 +2240,7 @@ public class JavaGenerator implements CodeGenerator
             fieldLength,
             offset);
 
-        if (encoding.characterEncoding().contains("ASCII"))
+        if (isAsciiEncoding(encoding.characterEncoding()))
         {
             new Formatter(sb).format("\n" +
                 indent + "    public %1$s %2$s(final String src)\n" +
@@ -2387,7 +2387,7 @@ public class JavaGenerator implements CodeGenerator
             sb.append("\n")
                 .append(indent).append("    public static String ").append(propName).append("CharacterEncoding()\n")
                 .append(indent).append("    {\n")
-                .append(indent).append("        return \"").append(characterEncoding).append("\";\n")
+                .append(indent).append("        return ").append(charsetName(characterEncoding)).append(";\n")
                 .append(indent).append("    }\n");
         }
     }
@@ -3537,7 +3537,7 @@ public class JavaGenerator implements CodeGenerator
             }
             else
             {
-                if (characterEncoding.contains("ASCII") || characterEncoding.contains("ascii"))
+                if (isAsciiEncoding(characterEncoding))
                 {
                     append(sb, indent, "builder.append('\\'');");
                     append(sb, indent, formatGetterName(varDataToken.name()) + "(builder);");

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -2275,7 +2275,8 @@ public class JavaGenerator implements CodeGenerator
                 indent + "    public %s %s(final String src)\n" +
                 indent + "    {\n" +
                 indent + "        final int length = %d;\n" +
-                indent + "        final byte[] bytes = null == src ? new byte[0] : src.getBytes(%s);\n" +
+                indent + "        final byte[] bytes = (null == src || src.isEmpty()) ?" +
+                " org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : src.getBytes(%s);\n" +
                 indent + "        if (bytes.length > length)\n" +
                 indent + "        {\n" +
                 indent + "            throw new IndexOutOfBoundsException(" +

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -921,23 +921,14 @@ public class JavaGenerator implements CodeGenerator
                 indent + "        }\n\n" +
                 indent + "        final byte[] tmp = new byte[dataLength];\n" +
                 indent + "        buffer.getBytes(limit + headerLength, tmp, 0, dataLength);\n\n" +
-                indent + "        final String value;\n" +
-                indent + "        try\n" +
-                indent + "        {\n" +
-                indent + "            value = new String(tmp, \"%6$s\");\n" +
-                indent + "        }\n" +
-                indent + "        catch (final java.io.UnsupportedEncodingException ex)\n" +
-                indent + "        {\n" +
-                indent + "            throw new RuntimeException(ex);\n" +
-                indent + "        }\n\n" +
-                indent + "        return value;\n" +
+                indent + "        return new String(tmp, %6$s);\n" +
                 indent + "    }\n",
                 formatPropertyName(propertyName),
                 generateStringNotPresentCondition(token.version(), indent),
                 sizeOfLengthField,
                 PrimitiveType.UINT32 == lengthType ? "(int)" : "",
                 generateGet(lengthType, "limit", byteOrderStr),
-                characterEncoding);
+                charset(characterEncoding));
 
             if (isAsciiEncoding(characterEncoding))
             {
@@ -1099,16 +1090,8 @@ public class JavaGenerator implements CodeGenerator
             new Formatter(sb).format("\n" +
                 indent + "    public %1$s %2$s(final String value)\n" +
                 indent + "    {\n" +
-                indent + "        final byte[] bytes;\n" +
-                indent + "        try\n" +
-                indent + "        {\n" +
-                indent + "            bytes = null == value || value.isEmpty() ?" +
-                " org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes(\"%3$s\");\n" +
-                indent + "        }\n" +
-                indent + "        catch (final java.io.UnsupportedEncodingException ex)\n" +
-                indent + "        {\n" +
-                indent + "            throw new RuntimeException(ex);\n" +
-                indent + "        }\n\n" +
+                indent + "        final byte[] bytes = (null == value || value.isEmpty()) ?" +
+                " org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes(%3$s);\n\n" +
                 indent + "        final int length = bytes.length;\n" +
                 indent + "        if (length > %4$d)\n" +
                 indent + "        {\n" +
@@ -1123,7 +1106,7 @@ public class JavaGenerator implements CodeGenerator
                 indent + "    }\n",
                 className,
                 formatPropertyName(propertyName),
-                characterEncoding,
+                charset(characterEncoding),
                 maxLengthValue,
                 sizeOfLengthField,
                 generatePut(lengthPutType, "limit", "length", byteOrderStr));

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -2274,15 +2274,10 @@ public class JavaGenerator implements CodeGenerator
                 indent + "            throw new IndexOutOfBoundsException(" +
                 "\"CharSequence too large for copy: byte length=\" + srcLength);\n" +
                 indent + "        }\n\n" +
-                indent + "        for (int i = 0; i < srcLength; ++i)\n" +
+                indent + "        buffer.putStringWithoutLengthAscii(offset + %4$d, src);\n\n" +
+                indent + "        for (int start = srcLength; start < length; ++start)\n" +
                 indent + "        {\n" +
-                indent + "            final char charValue = src.charAt(i);\n" +
-                indent + "            final byte byteValue = charValue > 127 ? (byte)'?' : (byte)charValue;\n" +
-                indent + "            buffer.putByte(offset + %4$d + i, byteValue);\n" +
-                indent + "        }\n\n" +
-                indent + "        for (int i = srcLength; i < length; ++i)\n" +
-                indent + "        {\n" +
-                indent + "            buffer.putByte(offset + %4$d + i, (byte)0);\n" +
+                indent + "            buffer.putByte(offset + %4$d + start, (byte)0);\n" +
                 indent + "        }\n\n" +
                 indent + "        return this;\n" +
                 indent + "    }\n",

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaUtil.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaUtil.java
@@ -28,8 +28,8 @@ import java.lang.reflect.Modifier;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.Map;
-import java.util.TreeMap;
 
 /**
  * Utilities for mapping between {@link uk.co.real_logic.sbe.ir.Ir} and the Java language.
@@ -95,7 +95,7 @@ public class JavaUtil
     /**
      * Indexes known charset aliases to the name of the instance in {@link StandardCharsets}.
      */
-    static final TreeMap<String, String> STD_CHARSETS = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
+    static final HashMap<String, String> STD_CHARSETS = new HashMap<>();
 
     static
     {
@@ -253,6 +253,17 @@ public class JavaUtil
     public static boolean isAsciiEncoding(final String encoding)
     {
         return "US_ASCII".equals(STD_CHARSETS.get(encoding));
+    }
+
+    /**
+     * Checks if the given encoding represents a UTF-8 charset.
+     *
+     * @param encoding as a string name (e.g. unicode-1-1-utf-8).
+     * @return {@code true} if the encoding denotes a UTF-8 charset.
+     */
+    public static boolean isUtf8Encoding(final String encoding)
+    {
+        return "UTF_8".equals(STD_CHARSETS.get(encoding));
     }
 
     /**

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaUtil.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaUtil.java
@@ -18,19 +18,18 @@ package uk.co.real_logic.sbe.generation.java;
 import org.agrona.Strings;
 import uk.co.real_logic.sbe.PrimitiveType;
 import uk.co.real_logic.sbe.SbeTool;
+import uk.co.real_logic.sbe.ValidationUtil;
 import uk.co.real_logic.sbe.generation.Generators;
 import uk.co.real_logic.sbe.ir.Token;
-import uk.co.real_logic.sbe.ValidationUtil;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 import java.nio.charset.Charset;
 import java.nio.charset.StandardCharsets;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.Map;
-
-import static java.lang.reflect.Modifier.STATIC;
+import java.util.TreeMap;
 
 /**
  * Utilities for mapping between {@link uk.co.real_logic.sbe.ir.Ir} and the Java language.
@@ -96,7 +95,7 @@ public class JavaUtil
     /**
      * Indexes known charset aliases to the name of the instance in {@link StandardCharsets}.
      */
-    private static final Map<String, String> STD_CHARSETS = new HashMap<>();
+    static final TreeMap<String, String> STD_CHARSETS = new TreeMap<>(String.CASE_INSENSITIVE_ORDER);
 
     static
     {
@@ -104,11 +103,25 @@ public class JavaUtil
         {
             for (final Field field : StandardCharsets.class.getDeclaredFields())
             {
-                if (Charset.class.isAssignableFrom(field.getType()) && ((field.getModifiers() & STATIC) == STATIC))
+                if (Charset.class.isAssignableFrom(field.getType()) && Modifier.isStatic(field.getModifiers()) &&
+                    Modifier.isPublic(field.getModifiers()))
                 {
                     final Charset charset = (Charset)field.get(null);
-                    STD_CHARSETS.put(charset.name(), field.getName());
-                    charset.aliases().forEach((alias) -> STD_CHARSETS.put(alias, field.getName()));
+                    final String name = field.getName();
+                    String oldName = STD_CHARSETS.put(charset.name(), name);
+                    if (null != oldName)
+                    {
+                        throw new IllegalStateException("Duplicate charset alias: old=" + oldName + ", new=" + name);
+                    }
+                    for (final String alias : charset.aliases())
+                    {
+                        oldName = STD_CHARSETS.put(alias, name);
+                        if (null != oldName)
+                        {
+                            throw new IllegalStateException("Duplicate charset alias: old=" + oldName + ", new=" +
+                                alias);
+                        }
+                    }
                 }
             }
         }
@@ -209,6 +222,36 @@ public class JavaUtil
         {
             return "java.nio.charset.Charset.forName(\"" + encoding + "\")";
         }
+    }
+
+    /**
+     * Code to fetch the name of the {@link Charset} given the encoding.
+     *
+     * @param encoding as a string name (eg. UTF-8).
+     * @return the code to fetch the associated Charset name.
+     */
+    public static String charsetName(final String encoding)
+    {
+        final String charsetName = STD_CHARSETS.get(encoding);
+        if (charsetName != null)
+        {
+            return "java.nio.charset.StandardCharsets." + charsetName + ".name()";
+        }
+        else
+        {
+            return "\"" + encoding + "\"";
+        }
+    }
+
+    /**
+     * Checks if the given encoding represents an ASCII charset.
+     *
+     * @param encoding as a string name (e.g. ASCII).
+     * @return {@code true} if the encoding denotes an ASCII charset.
+     */
+    public static boolean isAsciiEncoding(final String encoding)
+    {
+        return "US_ASCII".equals(STD_CHARSETS.get(encoding));
     }
 
     /**

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaUtil.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaUtil.java
@@ -220,7 +220,8 @@ public class JavaUtil
         }
         else
         {
-            return "java.nio.charset.Charset.forName(\"" + encoding + "\")";
+            final String canonicalName = Charset.isSupported(encoding) ? Charset.forName(encoding).name() : encoding;
+            return "java.nio.charset.Charset.forName(\"" + canonicalName + "\")";
         }
     }
 
@@ -239,7 +240,7 @@ public class JavaUtil
         }
         else
         {
-            return "\"" + encoding + "\"";
+            return "\"" + (Charset.isSupported(encoding) ? Charset.forName(encoding).name() : encoding) + "\"";
         }
     }
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecDecoder.java
@@ -299,7 +299,7 @@ public final class FrameCodecDecoder
 
     public static String packageNameCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String packageNameMetaAttribute(final MetaAttribute metaAttribute)
@@ -407,7 +407,7 @@ public final class FrameCodecDecoder
 
     public static String namespaceNameCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String namespaceNameMetaAttribute(final MetaAttribute metaAttribute)
@@ -515,7 +515,7 @@ public final class FrameCodecDecoder
 
     public static String semanticVersionCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String semanticVersionMetaAttribute(final MetaAttribute metaAttribute)

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecDecoder.java
@@ -382,17 +382,7 @@ public final class FrameCodecDecoder
         final byte[] tmp = new byte[dataLength];
         buffer.getBytes(limit + headerLength, tmp, 0, dataLength);
 
-        final String value;
-        try
-        {
-            value = new String(tmp, "UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
-
-        return value;
+        return new String(tmp, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     public static int namespaceNameId()
@@ -490,17 +480,7 @@ public final class FrameCodecDecoder
         final byte[] tmp = new byte[dataLength];
         buffer.getBytes(limit + headerLength, tmp, 0, dataLength);
 
-        final String value;
-        try
-        {
-            value = new String(tmp, "UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
-
-        return value;
+        return new String(tmp, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     public static int semanticVersionId()
@@ -598,17 +578,7 @@ public final class FrameCodecDecoder
         final byte[] tmp = new byte[dataLength];
         buffer.getBytes(limit + headerLength, tmp, 0, dataLength);
 
-        final String value;
-        try
-        {
-            value = new String(tmp, "UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
-
-        return value;
+        return new String(tmp, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     public String toString()

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecEncoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecEncoder.java
@@ -267,7 +267,7 @@ public final class FrameCodecEncoder
 
     public static String packageNameCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String packageNameMetaAttribute(final MetaAttribute metaAttribute)
@@ -351,7 +351,7 @@ public final class FrameCodecEncoder
 
     public static String namespaceNameCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String namespaceNameMetaAttribute(final MetaAttribute metaAttribute)
@@ -435,7 +435,7 @@ public final class FrameCodecEncoder
 
     public static String semanticVersionCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String semanticVersionMetaAttribute(final MetaAttribute metaAttribute)

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecEncoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecEncoder.java
@@ -319,15 +319,7 @@ public final class FrameCodecEncoder
 
     public FrameCodecEncoder packageName(final String value)
     {
-        final byte[] bytes;
-        try
-        {
-            bytes = null == value || value.isEmpty() ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes("UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
+        final byte[] bytes = (null == value || value.isEmpty()) ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
         final int length = bytes.length;
         if (length > 65534)
@@ -403,15 +395,7 @@ public final class FrameCodecEncoder
 
     public FrameCodecEncoder namespaceName(final String value)
     {
-        final byte[] bytes;
-        try
-        {
-            bytes = null == value || value.isEmpty() ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes("UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
+        final byte[] bytes = (null == value || value.isEmpty()) ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
         final int length = bytes.length;
         if (length > 65534)
@@ -487,15 +471,7 @@ public final class FrameCodecEncoder
 
     public FrameCodecEncoder semanticVersion(final String value)
     {
-        final byte[] bytes;
-        try
-        {
-            bytes = null == value || value.isEmpty() ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes("UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
+        final byte[] bytes = (null == value || value.isEmpty()) ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
         final int length = bytes.length;
         if (length > 65534)

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecDecoder.java
@@ -699,17 +699,7 @@ public final class TokenCodecDecoder
         final byte[] tmp = new byte[dataLength];
         buffer.getBytes(limit + headerLength, tmp, 0, dataLength);
 
-        final String value;
-        try
-        {
-            value = new String(tmp, "UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
-
-        return value;
+        return new String(tmp, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     public static int constValueId()
@@ -807,17 +797,7 @@ public final class TokenCodecDecoder
         final byte[] tmp = new byte[dataLength];
         buffer.getBytes(limit + headerLength, tmp, 0, dataLength);
 
-        final String value;
-        try
-        {
-            value = new String(tmp, "UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
-
-        return value;
+        return new String(tmp, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     public static int minValueId()
@@ -915,17 +895,7 @@ public final class TokenCodecDecoder
         final byte[] tmp = new byte[dataLength];
         buffer.getBytes(limit + headerLength, tmp, 0, dataLength);
 
-        final String value;
-        try
-        {
-            value = new String(tmp, "UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
-
-        return value;
+        return new String(tmp, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     public static int maxValueId()
@@ -1023,17 +993,7 @@ public final class TokenCodecDecoder
         final byte[] tmp = new byte[dataLength];
         buffer.getBytes(limit + headerLength, tmp, 0, dataLength);
 
-        final String value;
-        try
-        {
-            value = new String(tmp, "UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
-
-        return value;
+        return new String(tmp, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     public static int nullValueId()
@@ -1131,17 +1091,7 @@ public final class TokenCodecDecoder
         final byte[] tmp = new byte[dataLength];
         buffer.getBytes(limit + headerLength, tmp, 0, dataLength);
 
-        final String value;
-        try
-        {
-            value = new String(tmp, "UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
-
-        return value;
+        return new String(tmp, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     public static int characterEncodingId()
@@ -1239,17 +1189,7 @@ public final class TokenCodecDecoder
         final byte[] tmp = new byte[dataLength];
         buffer.getBytes(limit + headerLength, tmp, 0, dataLength);
 
-        final String value;
-        try
-        {
-            value = new String(tmp, "UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
-
-        return value;
+        return new String(tmp, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     public static int epochId()
@@ -1347,17 +1287,7 @@ public final class TokenCodecDecoder
         final byte[] tmp = new byte[dataLength];
         buffer.getBytes(limit + headerLength, tmp, 0, dataLength);
 
-        final String value;
-        try
-        {
-            value = new String(tmp, "UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
-
-        return value;
+        return new String(tmp, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     public static int timeUnitId()
@@ -1455,17 +1385,7 @@ public final class TokenCodecDecoder
         final byte[] tmp = new byte[dataLength];
         buffer.getBytes(limit + headerLength, tmp, 0, dataLength);
 
-        final String value;
-        try
-        {
-            value = new String(tmp, "UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
-
-        return value;
+        return new String(tmp, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     public static int semanticTypeId()
@@ -1563,17 +1483,7 @@ public final class TokenCodecDecoder
         final byte[] tmp = new byte[dataLength];
         buffer.getBytes(limit + headerLength, tmp, 0, dataLength);
 
-        final String value;
-        try
-        {
-            value = new String(tmp, "UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
-
-        return value;
+        return new String(tmp, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     public static int descriptionId()
@@ -1671,17 +1581,7 @@ public final class TokenCodecDecoder
         final byte[] tmp = new byte[dataLength];
         buffer.getBytes(limit + headerLength, tmp, 0, dataLength);
 
-        final String value;
-        try
-        {
-            value = new String(tmp, "UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
-
-        return value;
+        return new String(tmp, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     public static int referencedNameId()
@@ -1779,17 +1679,7 @@ public final class TokenCodecDecoder
         final byte[] tmp = new byte[dataLength];
         buffer.getBytes(limit + headerLength, tmp, 0, dataLength);
 
-        final String value;
-        try
-        {
-            value = new String(tmp, "UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
-
-        return value;
+        return new String(tmp, java.nio.charset.StandardCharsets.UTF_8);
     }
 
     public String toString()

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecDecoder.java
@@ -616,7 +616,7 @@ public final class TokenCodecDecoder
 
     public static String nameCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String nameMetaAttribute(final MetaAttribute metaAttribute)
@@ -724,7 +724,7 @@ public final class TokenCodecDecoder
 
     public static String constValueCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String constValueMetaAttribute(final MetaAttribute metaAttribute)
@@ -832,7 +832,7 @@ public final class TokenCodecDecoder
 
     public static String minValueCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String minValueMetaAttribute(final MetaAttribute metaAttribute)
@@ -940,7 +940,7 @@ public final class TokenCodecDecoder
 
     public static String maxValueCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String maxValueMetaAttribute(final MetaAttribute metaAttribute)
@@ -1048,7 +1048,7 @@ public final class TokenCodecDecoder
 
     public static String nullValueCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String nullValueMetaAttribute(final MetaAttribute metaAttribute)
@@ -1156,7 +1156,7 @@ public final class TokenCodecDecoder
 
     public static String characterEncodingCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String characterEncodingMetaAttribute(final MetaAttribute metaAttribute)
@@ -1264,7 +1264,7 @@ public final class TokenCodecDecoder
 
     public static String epochCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String epochMetaAttribute(final MetaAttribute metaAttribute)
@@ -1372,7 +1372,7 @@ public final class TokenCodecDecoder
 
     public static String timeUnitCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String timeUnitMetaAttribute(final MetaAttribute metaAttribute)
@@ -1480,7 +1480,7 @@ public final class TokenCodecDecoder
 
     public static String semanticTypeCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String semanticTypeMetaAttribute(final MetaAttribute metaAttribute)
@@ -1588,7 +1588,7 @@ public final class TokenCodecDecoder
 
     public static String descriptionCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String descriptionMetaAttribute(final MetaAttribute metaAttribute)
@@ -1696,7 +1696,7 @@ public final class TokenCodecDecoder
 
     public static String referencedNameCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String referencedNameMetaAttribute(final MetaAttribute metaAttribute)

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecEncoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecEncoder.java
@@ -567,7 +567,7 @@ public final class TokenCodecEncoder
 
     public static String nameCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String nameMetaAttribute(final MetaAttribute metaAttribute)
@@ -651,7 +651,7 @@ public final class TokenCodecEncoder
 
     public static String constValueCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String constValueMetaAttribute(final MetaAttribute metaAttribute)
@@ -735,7 +735,7 @@ public final class TokenCodecEncoder
 
     public static String minValueCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String minValueMetaAttribute(final MetaAttribute metaAttribute)
@@ -819,7 +819,7 @@ public final class TokenCodecEncoder
 
     public static String maxValueCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String maxValueMetaAttribute(final MetaAttribute metaAttribute)
@@ -903,7 +903,7 @@ public final class TokenCodecEncoder
 
     public static String nullValueCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String nullValueMetaAttribute(final MetaAttribute metaAttribute)
@@ -987,7 +987,7 @@ public final class TokenCodecEncoder
 
     public static String characterEncodingCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String characterEncodingMetaAttribute(final MetaAttribute metaAttribute)
@@ -1071,7 +1071,7 @@ public final class TokenCodecEncoder
 
     public static String epochCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String epochMetaAttribute(final MetaAttribute metaAttribute)
@@ -1155,7 +1155,7 @@ public final class TokenCodecEncoder
 
     public static String timeUnitCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String timeUnitMetaAttribute(final MetaAttribute metaAttribute)
@@ -1239,7 +1239,7 @@ public final class TokenCodecEncoder
 
     public static String semanticTypeCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String semanticTypeMetaAttribute(final MetaAttribute metaAttribute)
@@ -1323,7 +1323,7 @@ public final class TokenCodecEncoder
 
     public static String descriptionCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String descriptionMetaAttribute(final MetaAttribute metaAttribute)
@@ -1407,7 +1407,7 @@ public final class TokenCodecEncoder
 
     public static String referencedNameCharacterEncoding()
     {
-        return "UTF-8";
+        return java.nio.charset.StandardCharsets.UTF_8.name();
     }
 
     public static String referencedNameMetaAttribute(final MetaAttribute metaAttribute)

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecEncoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecEncoder.java
@@ -619,15 +619,7 @@ public final class TokenCodecEncoder
 
     public TokenCodecEncoder name(final String value)
     {
-        final byte[] bytes;
-        try
-        {
-            bytes = null == value || value.isEmpty() ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes("UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
+        final byte[] bytes = (null == value || value.isEmpty()) ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
         final int length = bytes.length;
         if (length > 65534)
@@ -703,15 +695,7 @@ public final class TokenCodecEncoder
 
     public TokenCodecEncoder constValue(final String value)
     {
-        final byte[] bytes;
-        try
-        {
-            bytes = null == value || value.isEmpty() ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes("UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
+        final byte[] bytes = (null == value || value.isEmpty()) ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
         final int length = bytes.length;
         if (length > 65534)
@@ -787,15 +771,7 @@ public final class TokenCodecEncoder
 
     public TokenCodecEncoder minValue(final String value)
     {
-        final byte[] bytes;
-        try
-        {
-            bytes = null == value || value.isEmpty() ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes("UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
+        final byte[] bytes = (null == value || value.isEmpty()) ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
         final int length = bytes.length;
         if (length > 65534)
@@ -871,15 +847,7 @@ public final class TokenCodecEncoder
 
     public TokenCodecEncoder maxValue(final String value)
     {
-        final byte[] bytes;
-        try
-        {
-            bytes = null == value || value.isEmpty() ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes("UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
+        final byte[] bytes = (null == value || value.isEmpty()) ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
         final int length = bytes.length;
         if (length > 65534)
@@ -955,15 +923,7 @@ public final class TokenCodecEncoder
 
     public TokenCodecEncoder nullValue(final String value)
     {
-        final byte[] bytes;
-        try
-        {
-            bytes = null == value || value.isEmpty() ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes("UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
+        final byte[] bytes = (null == value || value.isEmpty()) ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
         final int length = bytes.length;
         if (length > 65534)
@@ -1039,15 +999,7 @@ public final class TokenCodecEncoder
 
     public TokenCodecEncoder characterEncoding(final String value)
     {
-        final byte[] bytes;
-        try
-        {
-            bytes = null == value || value.isEmpty() ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes("UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
+        final byte[] bytes = (null == value || value.isEmpty()) ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
         final int length = bytes.length;
         if (length > 65534)
@@ -1123,15 +1075,7 @@ public final class TokenCodecEncoder
 
     public TokenCodecEncoder epoch(final String value)
     {
-        final byte[] bytes;
-        try
-        {
-            bytes = null == value || value.isEmpty() ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes("UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
+        final byte[] bytes = (null == value || value.isEmpty()) ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
         final int length = bytes.length;
         if (length > 65534)
@@ -1207,15 +1151,7 @@ public final class TokenCodecEncoder
 
     public TokenCodecEncoder timeUnit(final String value)
     {
-        final byte[] bytes;
-        try
-        {
-            bytes = null == value || value.isEmpty() ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes("UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
+        final byte[] bytes = (null == value || value.isEmpty()) ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
         final int length = bytes.length;
         if (length > 65534)
@@ -1291,15 +1227,7 @@ public final class TokenCodecEncoder
 
     public TokenCodecEncoder semanticType(final String value)
     {
-        final byte[] bytes;
-        try
-        {
-            bytes = null == value || value.isEmpty() ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes("UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
+        final byte[] bytes = (null == value || value.isEmpty()) ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
         final int length = bytes.length;
         if (length > 65534)
@@ -1375,15 +1303,7 @@ public final class TokenCodecEncoder
 
     public TokenCodecEncoder description(final String value)
     {
-        final byte[] bytes;
-        try
-        {
-            bytes = null == value || value.isEmpty() ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes("UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
+        final byte[] bytes = (null == value || value.isEmpty()) ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
         final int length = bytes.length;
         if (length > 65534)
@@ -1459,15 +1379,7 @@ public final class TokenCodecEncoder
 
     public TokenCodecEncoder referencedName(final String value)
     {
-        final byte[] bytes;
-        try
-        {
-            bytes = null == value || value.isEmpty() ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes("UTF-8");
-        }
-        catch (final java.io.UnsupportedEncodingException ex)
-        {
-            throw new RuntimeException(ex);
-        }
+        final byte[] bytes = (null == value || value.isEmpty()) ? org.agrona.collections.ArrayUtil.EMPTY_BYTE_ARRAY : value.getBytes(java.nio.charset.StandardCharsets.UTF_8);
 
         final int length = bytes.length;
         if (length > 65534)

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/EncodedDataType.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/xml/EncodedDataType.java
@@ -94,12 +94,12 @@ public class EncodedDataType extends Type
 
         if (PrimitiveType.CHAR == primitiveType)
         {
-            characterEncoding = getAttributeValue(node, "characterEncoding", "US-ASCII").trim().toUpperCase();
+            characterEncoding = getAttributeValue(node, "characterEncoding", "US-ASCII").trim();
         }
         else
         {
             final String characterEncoding = getAttributeValueOrNull(node, "characterEncoding");
-            this.characterEncoding = characterEncoding == null ? null : characterEncoding.trim().toUpperCase();
+            this.characterEncoding = characterEncoding == null ? null : characterEncoding.trim();
         }
 
         if (presence() == CONSTANT)

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/CharacterEncodingTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/CharacterEncodingTest.java
@@ -1,0 +1,157 @@
+/*
+ * Copyright 2013-2021 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.sbe.generation.java;
+
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.generation.StringWriterOutputManager;
+import org.junit.jupiter.api.Test;
+import uk.co.real_logic.sbe.ir.Ir;
+import uk.co.real_logic.sbe.xml.IrGenerator;
+import uk.co.real_logic.sbe.xml.MessageSchema;
+import uk.co.real_logic.sbe.xml.ParserOptions;
+
+import java.io.ByteArrayInputStream;
+import java.util.HashSet;
+import java.util.Map;
+
+import static java.nio.charset.StandardCharsets.US_ASCII;
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+import static uk.co.real_logic.sbe.generation.java.JavaUtil.STD_CHARSETS;
+import static uk.co.real_logic.sbe.xml.XmlSchemaParser.parse;
+
+public class CharacterEncodingTest
+{
+    private static final String XML_SCHEMA;
+
+    static
+    {
+        final StringBuilder buffer =
+            new StringBuilder("<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?>\n")
+            .append("<sbe:messageSchema xmlns:sbe=\"http://fixprotocol.io/2016/sbe\"\n")
+            .append("                   package=\"code.generation.test\"\n")
+            .append("                   id=\"6\"\n")
+            .append("                   version=\"0\"\n")
+            .append("                   semanticVersion=\"5.2\"\n")
+            .append("                   description=\"Example schema\"\n")
+            .append("                   byteOrder=\"littleEndian\">\n")
+            .append("    <types>\n")
+            .append("        <composite name=\"messageHeader\" ")
+            .append("description=\"Message identifiers and length of message root\">\n")
+            .append("            <type name=\"blockLength\" primitiveType=\"uint16\"/>\n")
+            .append("            <type name=\"templateId\" primitiveType=\"uint16\"/>\n")
+            .append("            <type name=\"schemaId\" primitiveType=\"uint16\"/>\n")
+            .append("            <type name=\"version\" primitiveType=\"uint16\"/>\n")
+            .append("        </composite>\n");
+
+        final HashSet<String> asciiCharsetNames = new HashSet<>();
+        asciiCharsetNames.add(US_ASCII.name());
+        asciiCharsetNames.addAll(US_ASCII.aliases());
+
+        int i = 0;
+        for (final String alias : STD_CHARSETS.keySet())
+        {
+            buffer.append("        <type name=\"type_fixed_")
+                .append(i)
+                .append("\" primitiveType=\"char\" semanticType=\"String\" length=\"3\" characterEncoding=\"")
+                .append(alias)
+                .append("\"/>\n");
+            buffer.append("        <composite name=\"type_var_")
+                .append(i)
+                .append("\">\n")
+                .append("            <type name=\"length\" primitiveType=\"uint32\" maxValue=\"1073741824\"/>\n")
+                .append("            <type name=\"varData\" primitiveType=\"uint8\" length=\"0\" characterEncoding=\"")
+                .append(alias)
+                .append("\"/>\n")
+                .append("        </composite>\n");
+            i++;
+        }
+        buffer.append("        <type name=\"type_fixed_custom\" primitiveType=\"char\" semanticType=\"String\"")
+            .append(" length=\"2\"")
+            .append(" characterEncoding=\"custom-encoding\"/>\n");
+        buffer.append("        <composite name=\"type_var_custom\">\n")
+            .append("            <type name=\"length\" primitiveType=\"uint32\" maxValue=\"1073741824\"/>\n")
+            .append("            <type name=\"varData\" primitiveType=\"uint8\" length=\"0\"")
+            .append(" characterEncoding=\"custom-encoding\"/>\n        </composite>\n");
+
+        buffer.append("    </types>\n")
+            .append("    <sbe:message name=\"EncodingTest\" id=\"1\" description=\"Multiple encodings\">\n");
+        i = 0;
+        for (int j = 0, size = STD_CHARSETS.size(); j < size; j++)
+        {
+            buffer.append("        <field name=\"f_").append(i).append("\" id=\"").append(i)
+                .append("\"  type=\"type_fixed_").append(i).append("\"/>\n");
+            i++;
+        }
+        buffer.append("<field name=\"f_custom\" id=\"").append(i++).append("\" type=\"type_fixed_custom\"/>");
+
+        for (int j = 0, size = STD_CHARSETS.size(); j < size; j++)
+        {
+            buffer.append("        <data name=\"var_").append(i).append("\" id=\"").append(i)
+                .append("\"  type=\"type_var_").append(j).append("\"/>\n");
+            i++;
+        }
+        buffer.append("<data name=\"var_custom\" id=\"").append(i).append("\" type=\"type_var_custom\"/>");
+
+        buffer.append("    </sbe:message>\n")
+            .append("</sbe:messageSchema>");
+        XML_SCHEMA = buffer.toString();
+    }
+
+    @Test
+    public void shouldUseStandardCharsetsForWellKnowEncodings() throws Exception
+    {
+        final ParserOptions options = ParserOptions.builder().stopOnError(true).build();
+        final MessageSchema schema =
+            parse(new ByteArrayInputStream(XML_SCHEMA.getBytes(UTF_8)), options);
+        final IrGenerator irg = new IrGenerator();
+        final Ir ir = irg.generate(schema);
+
+        final StringWriterOutputManager outputManager = new StringWriterOutputManager();
+        outputManager.setPackageName(ir.applicableNamespace());
+        final JavaGenerator generator = new JavaGenerator(
+            ir, MutableDirectBuffer.class.getName(), DirectBuffer.class.getName(), false, false, false, outputManager);
+
+        generator.generate();
+        final Map<String, CharSequence> sources = outputManager.getSources();
+        final String encoderSources = sources.get("code.generation.test.EncodingTestEncoder").toString();
+        final String decoderSources = sources.get("code.generation.test.EncodingTestDecoder").toString();
+        verifyCharacterEncodingMethods(encoderSources);
+        verifyCharacterEncodingMethods(decoderSources);
+    }
+
+    private void verifyCharacterEncodingMethods(final String code)
+    {
+        int i = 0;
+        for (final String charset : STD_CHARSETS.values())
+        {
+            assertContainsCharacterEncodingMethod(
+                "f_" + (i++), "java.nio.charset.StandardCharsets." + charset + ".name()", code);
+        }
+        assertContainsCharacterEncodingMethod("f_custom", "\"CUSTOM-ENCODING\"", code);
+    }
+
+    private static void assertContainsCharacterEncodingMethod(
+        final String fieldName, final String expectedEncoding, final String sources)
+    {
+        final String expectedOne =
+            "    public static String " + fieldName + "CharacterEncoding()\n" +
+            "    {\n        return " + expectedEncoding + ";\n    }";
+        assertThat(sources, containsString(expectedOne));
+    }
+}

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/CharacterEncodingTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/CharacterEncodingTest.java
@@ -30,6 +30,7 @@ import java.util.Map;
 
 import static java.nio.charset.StandardCharsets.US_ASCII;
 import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.hamcrest.CoreMatchers.not;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.core.StringContains.containsString;
 import static uk.co.real_logic.sbe.generation.java.JavaUtil.STD_CHARSETS;
@@ -131,8 +132,11 @@ public class CharacterEncodingTest
         final Map<String, CharSequence> sources = outputManager.getSources();
         final String encoderSources = sources.get("code.generation.test.EncodingTestEncoder").toString();
         final String decoderSources = sources.get("code.generation.test.EncodingTestDecoder").toString();
+
         verifyCharacterEncodingMethods(encoderSources);
         verifyCharacterEncodingMethods(decoderSources);
+        assertThat(encoderSources, not(containsString("java.io.UnsupportedEncodingException")));
+        assertThat(decoderSources, not(containsString("java.io.UnsupportedEncodingException")));
     }
 
     private void verifyCharacterEncodingMethods(final String code)

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/CharacterEncodingTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/CharacterEncodingTest.java
@@ -136,7 +136,9 @@ public class CharacterEncodingTest
         verifyCharacterEncodingMethods(encoderSources);
         verifyCharacterEncodingMethods(decoderSources);
         assertThat(encoderSources, not(containsString("java.io.UnsupportedEncodingException")));
+        assertThat(encoderSources, not(containsString("new byte[0]")));
         assertThat(decoderSources, not(containsString("java.io.UnsupportedEncodingException")));
+        assertThat(decoderSources, not(containsString("new byte[0]")));
     }
 
     private void verifyCharacterEncodingMethods(final String code)

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/CharacterEncodingTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/CharacterEncodingTest.java
@@ -86,10 +86,10 @@ public class CharacterEncodingTest
             .append(" characterEncoding=\"custom-encoding\"/>\n        </composite>\n");
         buffer.append("        <type name=\"type_std_alias\" primitiveType=\"char\" semanticType=\"String\"")
             .append(" length=\"5\"")
-            .append(" characterEncoding=\"lAtIn1\"/>\n");
+            .append(" characterEncoding=\"latin1\"/>\n");
         buffer.append("        <type name=\"type_non_std_alias\" primitiveType=\"char\" semanticType=\"String\"")
             .append(" length=\"5\"")
-            .append(" characterEncoding=\"cp912\"/>\n");
+            .append(" characterEncoding=\"csISOLatin2\"/>\n");
 
         buffer.append("    </types>\n")
             .append("    <sbe:message name=\"EncodingTest\" id=\"1\" description=\"Multiple encodings\">\n");
@@ -149,7 +149,7 @@ public class CharacterEncodingTest
                     encoderSources, containsString("getBytes(java.nio.charset.StandardCharsets." + charset + ")"));
             }
         }
-        assertThat(encoderSources, containsString("getBytes(java.nio.charset.Charset.forName(\"CUSTOM-ENCODING\"))"));
+        assertThat(encoderSources, containsString("getBytes(java.nio.charset.Charset.forName(\"custom-encoding\"))"));
         assertThat(encoderSources, containsString("getBytes(java.nio.charset.Charset.forName(\"ISO-8859-2\"))"));
         assertThat(encoderSources, allOf(not(containsString("\"cp912\"")), not(containsString("\"CP912\""))));
         final int encodeFromStringStartIndex = encoderSources.indexOf("f_std_alias(final String src)");
@@ -165,7 +165,7 @@ public class CharacterEncodingTest
         {
             assertThat(decoderSources, containsString("end, java.nio.charset.StandardCharsets." + charset + ")"));
         }
-        assertThat(decoderSources, containsString("end, java.nio.charset.Charset.forName(\"CUSTOM-ENCODING\"))"));
+        assertThat(decoderSources, containsString("end, java.nio.charset.Charset.forName(\"custom-encoding\"))"));
         assertThat(decoderSources, containsString("end, java.nio.charset.Charset.forName(\"ISO-8859-2\"))"));
         assertThat(decoderSources, allOf(not(containsString("\"cp912\"")), not(containsString("\"CP912\""))));
     }
@@ -178,7 +178,7 @@ public class CharacterEncodingTest
             assertContainsCharacterEncodingMethod(
                 "f_" + (i++), "java.nio.charset.StandardCharsets." + charset + ".name()", code);
         }
-        assertContainsCharacterEncodingMethod("f_custom", "\"CUSTOM-ENCODING\"", code);
+        assertContainsCharacterEncodingMethod("f_custom", "\"custom-encoding\"", code);
         assertContainsCharacterEncodingMethod(
             "f_std_alias", "java.nio.charset.StandardCharsets.ISO_8859_1.name()", code);
         assertContainsCharacterEncodingMethod("f_non_std_alias", "\"ISO-8859-2\"", code);

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/xml/EncodedDataTypeTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/xml/EncodedDataTypeTest.java
@@ -414,6 +414,49 @@ public class EncodedDataTypeTest
             is(parse(nullVal, PrimitiveType.INT8)));
     }
 
+    @Test
+    public void shouldReturnCharacterEncodingWhenSpecified() throws Exception
+    {
+        final String testXmlString =
+            "<types>" +
+            "    <type name=\"testTypeCharacterEncoding\" primitiveType=\"char\" length=\"3\" " +
+            "characterEncoding=\"cp912\"/>" +
+            "</types>";
+
+        final Map<String, Type> map = parseTestXmlWithMap("/types/type", testXmlString);
+
+        assertThat((((EncodedDataType)map.get("testTypeCharacterEncoding")).characterEncoding()), is("cp912"));
+    }
+
+    @Test
+    public void shouldReturnCharacterEncodingWhenSpecifiedNonCharType() throws Exception
+    {
+        final String testXmlString =
+            "<types>" +
+            "    <type name=\"testTypeCharacterEncodingNonChar\" primitiveType=\"uint8\" " +
+            "characterEncoding=\"  windows-1251\n\r\"/>" +
+            "</types>";
+
+        final Map<String, Type> map = parseTestXmlWithMap("/types/type", testXmlString);
+
+        assertThat(
+            (((EncodedDataType)map.get("testTypeCharacterEncodingNonChar")).characterEncoding()), is("windows-1251"));
+    }
+
+    @Test
+    public void shouldReturnUsAsciiWhenCharacterEncodingNotSpecifiedForTypeChar() throws Exception
+    {
+        final String testXmlString =
+            "<types>" +
+            "    <type name=\"testCharDefaultCharacterEncoding\" primitiveType=\"char\" length=\"5\"/>" +
+            "</types>";
+
+        final Map<String, Type> map = parseTestXmlWithMap("/types/type", testXmlString);
+
+        assertThat(
+            (((EncodedDataType)map.get("testCharDefaultCharacterEncoding")).characterEncoding()), is("US-ASCII"));
+    }
+
     private static Map<String, Type> parseTestXmlWithMap(final String xPathExpr, final String xml)
         throws ParserConfigurationException, XPathExpressionException, IOException, SAXException
     {


### PR DESCRIPTION
This PR contains several improvements to how charset encoding is handled by the `JavaGenerator`:
- Add support for case-insensitive aliases for standard charsets, e.g. `lAtIN1` will be resolved to `StandardCharsets.ISO_8859_1`. This is similar to how `Charset.forName(String)` works.
- Use `StandardCharsets` when generating static `CharacterEncoding` methods, e.g. `java.nio.charset.StandardCharsets.ISO_8859_1.name()` will be used instead of a string `"latin1"` (when `characterEncoding=latin1`).
- Use canonical names for charsets. The standard charsets are canonical by definition since the constants are used. For non-standard charsets the canonical name is resolved at the code generation time, e.g. if `characterEncoding=cp912` is specified the resolved name will be `ISO-8859-2` and will be used everywhere the original name would have been used. If the charset does not exist at the code generation time then the raw value is used.
- Use `putStringWithoutLengthAscii` for methods taking a `CharSequence`.
- Always use a `Charset` instance when converting to/from String. This eliminates most of the `try/catch` blocks in the generated code.
- Avoid creation of an empty `byte[]` when input string is null or empty.
- Treat character encodings as case-sensitive.