### PR TITLE
C++ code generation: check composite and bitset version

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -2746,7 +2746,24 @@ public class CppGenerator implements CodeGenerator
 
             case BEGIN_SET:
             case BEGIN_COMPOSITE:
-                sb.append(indent).append("builder << ").append(fieldName).append("();\n");
+                if (0 == typeToken.version())
+                {
+                    sb.append(indent).append("builder << ").append(fieldName).append("();\n");
+                }
+                else
+                {
+                    new Formatter(sb).format(
+                        indent + "if (%1$sInActingVersion())\n" +
+                        indent + "{\n" +
+                        indent + "    builder << %1$s();\n" +
+                        indent + "}\n" +
+                        indent + "else\n" +
+                        indent + "{\n" +
+                        indent + "    builder << %2$s;\n" +
+                        indent + "}\n",
+                        fieldName,
+                        typeToken.signal() == Signal.BEGIN_SET ? "\"[]\"" : "\"{}\"");
+                }
                 break;
         }
 


### PR DESCRIPTION
Previously, the C++ generated code did not check the version before writing composite and bitset fields to the output stream. This leads to undefined behavior. I've updated the generated code to first check if the field is in the acting version before writing it to the stream.