### PR TITLE
[Java] Support binary vardata in json printer

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/json/JsonTokenListener.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/json/JsonTokenListener.java
@@ -16,6 +16,7 @@
 package uk.co.real_logic.sbe.json;
 
 import org.agrona.DirectBuffer;
+import org.agrona.PrintBufferUtil;
 import uk.co.real_logic.sbe.PrimitiveValue;
 import uk.co.real_logic.sbe.ir.Encoding;
 import uk.co.real_logic.sbe.ir.Token;
@@ -230,7 +231,10 @@ public class JsonTokenListener implements TokenListener
 
             final byte[] tempBuffer = new byte[length];
             buffer.getBytes(bufferIndex, tempBuffer, 0, length);
-            final String str = new String(tempBuffer, 0, length, typeToken.encoding().characterEncoding());
+
+            final String charsetName = typeToken.encoding().characterEncoding();
+            final String str = charsetName != null ? new String(tempBuffer, 0, length, charsetName) :
+                PrintBufferUtil.hexDump(tempBuffer);
 
             escape(str);
 

--- a/sbe-tool/src/test/resources/json-printer-test-schema.xml
+++ b/sbe-tool/src/test/resources/json-printer-test-schema.xml
@@ -23,6 +23,10 @@
         </composite>
         <type name="uuid_t" primitiveType="int64" length="2"/>
         <type name="cupHolderCount_t" primitiveType="uint8"/>
+        <composite name="varDataEncoding">
+            <type name="length" primitiveType="uint32" maxValue="1073741824"/>
+            <type name="varData" primitiveType="uint8" length="0"/>
+        </composite>
     </types>
     <types>
         <type name="ModelYear" primitiveType="uint16"/>
@@ -77,4 +81,11 @@
         <data name="model" id="18" type="varStringEncoding"/>
         <data name="activationCode" id="19" type="varStringEncoding"/>
     </sbe:message>
+
+    <sbe:message name="Credentials" id="2">
+        <data name="login" id="1" type="varStringEncoding"/>
+        <!-- variable length encoding with embedded length in composite -->
+        <data id="2" name="encryptedPassword" type="varDataEncoding"/>
+    </sbe:message>
+
 </sbe:messageSchema>


### PR DESCRIPTION
When there is no character encoding for vardata (which is normal for binary) JsonPrinter fails with NPE inside string construction with null encoding. Changed behaviour so that hex dump of data is appended instead.