### PR TITLE
Fixes for Rust Composites

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
@@ -81,7 +81,7 @@ class LibRsDef
             // add re-export of modules
             for (final String module : modules)
             {
-                indent(libRs, 0, "pub use %s::*;\n", toLowerSnakeCase(module));
+                indent(libRs, 0, "pub use crate::%s::*;\n", toLowerSnakeCase(module));
             }
             indent(libRs, 0, "\n");
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -542,7 +542,7 @@ public class RustGenerator implements CodeGenerator
                 decoderName,
                 decoderTypeName);
 
-            indent(sb, level + 1, "if self.acting_version < %d {\n", fieldToken.version());
+            indent(sb, level + 1, "if self.acting_version > 0 && self.acting_version < %d {\n", fieldToken.version());
             indent(sb, level + 2, "return Either::Left(self);\n");
             indent(sb, level + 1, "}\n\n");
 
@@ -576,7 +576,7 @@ public class RustGenerator implements CodeGenerator
 
         if (bitsetToken.version() > 0)
         {
-            indent(sb, level + 1, "if self.acting_version < %d {\n", bitsetToken.version());
+            indent(sb, level + 1, "if self.acting_version > 0 && self.acting_version < %d {\n", bitsetToken.version());
             indent(sb, level + 2, "return %s::default();\n", structTypeName);
             indent(sb, level + 1, "}\n\n");
         }
@@ -636,8 +636,8 @@ public class RustGenerator implements CodeGenerator
 
         if (fieldToken.version() > 0)
         {
-            indent(sb, level + 1, "if self.acting_version < %d {\n", fieldToken.version());
-            indent(sb, level + 2, "return [%s, %d];\n", encoding.applicableNullValue(), arrayLength);
+            indent(sb, level + 1, "if self.acting_version > 0 && self.acting_version < %d {\n", fieldToken.version());
+            indent(sb, level + 2, "return [%s; %d];\n", encoding.applicableNullValue(), arrayLength);
             indent(sb, level + 1, "}\n\n");
         }
 
@@ -737,7 +737,7 @@ public class RustGenerator implements CodeGenerator
 
         if (fieldToken.version() > 0)
         {
-            indent(sb, level + 1, "if self.acting_version < %d {\n", fieldToken.version());
+            indent(sb, level + 1, "if self.acting_version > 0 && self.acting_version < %d {\n", fieldToken.version());
             indent(sb, level + 2, "return None;\n");
             indent(sb, level + 1, "}\n\n");
         }
@@ -790,7 +790,7 @@ public class RustGenerator implements CodeGenerator
 
         if (fieldToken.version() > 0)
         {
-            indent(sb, level + 1, "if self.acting_version < %d {\n", fieldToken.version());
+            indent(sb, level + 1, "if self.acting_version > 0 && self.acting_version < %d {\n", fieldToken.version());
             indent(sb, level + 2, "return %s;\n",
                 generateRustLiteral(encoding.primitiveType(), encoding.applicableNullValue().toString()));
             indent(sb, level + 1, "}\n\n");
@@ -939,7 +939,7 @@ public class RustGenerator implements CodeGenerator
             {
                 if (varDataToken.version() > 0)
                 {
-                    indent(sb, level + 1, "if self.acting_version < %d {\n", varDataToken.version());
+                    indent(sb, level + 1, "if self.acting_version > 0 && self.acting_version < %d {\n", varDataToken.version());
                     indent(sb, level + 2, "return (self.parent.as_ref().unwrap().get_limit(), 0);\n");
                     indent(sb, level + 1, "}\n\n");
                 }
@@ -954,7 +954,7 @@ public class RustGenerator implements CodeGenerator
             {
                 if (varDataToken.version() > 0)
                 {
-                    indent(sb, level + 1, "if self.acting_version < %d {\n", varDataToken.version());
+                    indent(sb, level + 1, "if self.acting_version > 0 && self.acting_version < %d {\n", varDataToken.version());
                     indent(sb, level + 2, "return (self.get_limit(), 0);\n");
                     indent(sb, level + 1, "}\n\n");
                 }
@@ -973,7 +973,7 @@ public class RustGenerator implements CodeGenerator
 
             if (varDataToken.version() > 0)
             {
-                indent(sb, level + 1, "if self.acting_version < %d {\n", varDataToken.version());
+                indent(sb, level + 1, "if self.acting_version > 0 && self.acting_version < %d {\n", varDataToken.version());
                 indent(sb, level + 2, "return &[] as &[u8];\n");
                 indent(sb, level + 1, "}\n\n");
             }
@@ -1354,6 +1354,7 @@ public class RustGenerator implements CodeGenerator
         indent(out, 1, "pub struct %s<P> {\n", encoderName);
         indent(out, 2, "parent: Option<P>,\n");
         indent(out, 2, "offset: usize,\n");
+        indent(out, 2, "acting_version: usize,\n");
         indent(out, 1, "}\n\n");
 
         appendImplWriterForComposite(out, 1, encoderName);
@@ -1413,6 +1414,7 @@ public class RustGenerator implements CodeGenerator
         indent(out, 1, "pub struct %s<P> {\n", decoderName);
         indent(out, 2, "parent: Option<P>,\n");
         indent(out, 2, "offset: usize,\n");
+        indent(out, 2, "acting_version: usize,\n");
         indent(out, 1, "}\n\n");
 
         appendImplReaderForComposite(out, 1, decoderName);

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustUtil.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustUtil.java
@@ -260,7 +260,7 @@ public class RustUtil
     {
         if (shadowsKeyword(name))
         {
-            return name + "_";
+            return "r#" + name;
         }
         else
         {
@@ -310,7 +310,7 @@ public class RustUtil
         {
             for (final ReservedKeyword value : ReservedKeyword.values())
             {
-                LOWER_CASE_NAMES.add(value.name());
+                LOWER_CASE_NAMES.add(value.name().toLowerCase());
             }
         }
 

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustUtilTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustUtilTest.java
@@ -136,6 +136,8 @@ class RustUtilTest
         assertEquals("pricenull_9", formatFunctionName("PRICENULL9"));
         assertEquals("price_9_book", formatFunctionName("PRICE9Book"));
         assertEquals("issue_435", formatFunctionName("issue435"));
+        assertEquals("r#type", formatFunctionName("type"));
+
         assertEquals("upper_case", formatFunctionName("UPPERCase"));
         assertEquals("no_md_entries", formatFunctionName("NoMDEntries"));
         assertEquals("md_entry_type_book", formatFunctionName("MD_EntryTYPEBook"));


### PR DESCRIPTION
Fixed several issues:
1: LibRsDef explicitly use crate:: to disambiguate from built in mods like bool
2: Added acting_version field to Composite structs to fix compilation errors when using Composite structs.  This is an incomplete implementation because the parent doesn't pass the acting_version to the composite because you need to change the signature of wrap(parent, offset) to include the acting_version, so this version just ensures that if the acting_version isn't set on the composite, it disregards the version check.
3: fixed primitiveArrayDecoder to return an empty array of the right size if less than version required.
4: If a name of an element clashes with a rust type, prefix it with r#, which is the preferred way of dealing with clashes with keywords