### PR TITLE
[Rust] bugfix: nested composite name should not be based on field name

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -568,6 +568,7 @@ task generateRustTestCodecs(type: JavaExec) {
     args = ['sbe-tool/src/test/resources/issue435.xml',
             'sbe-tool/src/test/resources/issue895.xml',
             'sbe-tool/src/test/resources/example-bigendian-test-schema.xml',
+            'sbe-tool/src/test/resources/nested-composite-name.xml',
     ]
 }
 

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -14,6 +14,7 @@ examples_uk_co_real_logic_sbe_benchmarks_fix = { path = "../generated/rust/uk_co
 issue_435 = { path = "../generated/rust/issue435" }
 issue_895 = { path = "../generated/rust/issue895" }
 baseline_bigendian = { path = "../generated/rust/baseline-bigendian" }
+nested_composite_name = { path = "../generated/rust/nested-composite-name" }
 
 [dev-dependencies]
 criterion = "0.3"

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -473,7 +473,7 @@ public class RustGenerator implements CodeGenerator
         final String name) throws IOException
     {
         final String encoderName = toLowerSnakeCase(encoderName(name));
-        final String encoderTypeName = encoderName(formatStructName(typeToken.name()));
+        final String encoderTypeName = encoderName(formatStructName(typeToken.applicableTypeName()));
         indent(sb, level, "/// COMPOSITE ENCODER\n");
         indent(sb, level, "#[inline]\n");
         indent(sb, level, "pub fn %s(self) -> %2$s<Self> {\n",
@@ -533,7 +533,7 @@ public class RustGenerator implements CodeGenerator
         final String name) throws IOException
     {
         final String decoderName = toLowerSnakeCase(decoderName(name));
-        final String decoderTypeName = decoderName(formatStructName(typeToken.name()));
+        final String decoderTypeName = decoderName(formatStructName(typeToken.applicableTypeName()));
         indent(sb, level, "/// COMPOSITE DECODER\n");
         indent(sb, level, "#[inline]\n");
         if (fieldToken.version() > 0)

--- a/sbe-tool/src/test/resources/nested-composite-name.xml
+++ b/sbe-tool/src/test/resources/nested-composite-name.xml
@@ -1,0 +1,29 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   xmlns:xi="http://www.w3.org/2001/XInclude"
+                   package="nested-composite-name"
+                   id="1"
+                   version="0"
+                   semanticVersion="5.2"
+                   description="test case for nested composite field where the field name from the composite name"
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="MyComposite">
+            <ref name="myFieldName" type="MyNestedComposite"/> <!-- The field name here is different from the nested composite name -->
+        </composite>
+        <composite name="MyNestedComposite">
+            <type name="irrelevantField" primitiveType="uint16"/>
+        </composite>
+        <composite name="messageHeader">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId"  primitiveType="uint16"/>
+            <type name="schemaId"    primitiveType="uint16"/>
+            <type name="version"     primitiveType="uint16"/>
+        </composite>
+    </types>
+    <sbe:message name="MyMessage" id="1" description="Nested composite name different from field name">
+        <field name="irrelevantHeader" id="1" type="messageHeader"/>
+        <field name="irrelevantField" id="2" type="MyComposite"/>
+    </sbe:message>
+</sbe:messageSchema>
+


### PR DESCRIPTION
I was refactoring the generated Rust codec to be more idiomatic, and discovered that the existing Rust codec generator uses the wrong type name for nested composite field:

Minimal schema file to trigger error:
```xml
<?xml version="1.0" encoding="UTF-8"?>
<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
                   xmlns:xi="http://www.w3.org/2001/XInclude"
                   package="nested-composite-name"
                   id="1"
                   version="0"
                   semanticVersion="5.2"
                   description="test case for nested composite field where the field name from the composite name"
                   byteOrder="littleEndian">
    <types>
        <composite name="MyComposite">
            <ref name="myFieldName" type="MyNestedComposite"/> <!-- The field name here is different from the nested composite name -->
        </composite>
        <composite name="MyNestedComposite">
            <type name="irrelevantField" primitiveType="uint16"/>
        </composite>
        <composite name="messageHeader">
            <type name="blockLength" primitiveType="uint16"/>
            <type name="templateId"  primitiveType="uint16"/>
            <type name="schemaId"    primitiveType="uint16"/>
            <type name="version"     primitiveType="uint16"/>
        </composite>
    </types>
    <sbe:message name="MyMessage" id="1" description="Nested composite name different from field name">
        <field name="irrelevantHeader" id="1" type="messageHeader"/>
        <field name="irrelevantField" id="2" type="MyComposite"/>
    </sbe:message>
</sbe:messageSchema>
```

Generated Rust output (current version):
```rust
// my_composite_codec.rs
// ...
        #[inline]
        pub fn my_field_name_encoder(self) -> MyFieldNameEncoder<Self> {
                                           // ^---- Incorrect name based on field name
            let offset = self.offset;
            MyFieldNameEncoder::default().wrap(self, offset)
         // ^---- Same here
        }

```

Generated Rust output (fixed version):
```rust
// my_composite_codec.rs
// ...
        #[inline]
        pub fn my_field_name_encoder(self) -> MyNestedCompositeEncoder<Self> {
                                           // ^---- This is the correct name
            let offset = self.offset;
            MyNestedCompositeEncoder::default().wrap(self, offset)
         // ^---- Same here
        }
```