### PR TITLE
Added semantic version as a static public member

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/c/CGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/c/CGenerator.java
@@ -1894,7 +1894,7 @@ public class CGenerator implements CodeGenerator
         final String schemaVersionType = cTypeName(ir.headerStructure().schemaVersionType());
         final String semanticType = token.encoding().semanticType() == null ? "" : token.encoding().semanticType();
         final String messageHeaderStruct = formatScopedName(scope, "messageHeader");
-        final String semanticVersion = ir.semanticVersion();
+        final String semanticVersion = ir.semanticVersion() == null ? "" : ir.semanticVersion();
 
         return String.format("\n" +
             "SBE_ONE_DEF uint64_t %10$s_sbe_position(\n" +

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/c/CGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/c/CGenerator.java
@@ -1894,6 +1894,7 @@ public class CGenerator implements CodeGenerator
         final String schemaVersionType = cTypeName(ir.headerStructure().schemaVersionType());
         final String semanticType = token.encoding().semanticType() == null ? "" : token.encoding().semanticType();
         final String messageHeaderStruct = formatScopedName(scope, "messageHeader");
+        final String semanticVersion = ir.semanticVersion();
 
         return String.format("\n" +
             "SBE_ONE_DEF uint64_t %10$s_sbe_position(\n" +
@@ -1972,6 +1973,11 @@ public class CGenerator implements CodeGenerator
             "SBE_ONE_DEF %7$s %10$s_sbe_schema_version(void)\n" +
             "{\n" +
             "    return %8$s;\n" +
+            "}\n\n" +
+
+            "SBE_ONE_DEF const char* %10$s_sbe_semantic_version(void)\n" +
+            "{\n" +
+            "    return \"%12$s\";\n" +
             "}\n\n" +
 
             "SBE_ONE_DEF const char *%10$s_sbe_semantic_type(void)\n" +
@@ -2093,7 +2099,8 @@ public class CGenerator implements CodeGenerator
             generateLiteral(ir.headerStructure().schemaVersionType(), Integer.toString(ir.version())),
             semanticType,
             structName,
-            messageHeaderStruct);
+            messageHeaderStruct,
+            semanticVersion);
     }
 
     private CharSequence generateFieldFunctions(

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -1973,6 +1973,7 @@ public class CppGenerator implements CodeGenerator
         final String schemaVersionType = cppTypeName(ir.headerStructure().schemaVersionType());
         final String semanticType = token.encoding().semanticType() == null ? "" : token.encoding().semanticType();
         final String headerType = ir.headerStructure().tokens().get(0).name();
+        final String semanticVersion = ir.semanticVersion();
 
         return String.format(
             "private:\n" +
@@ -1992,7 +1993,8 @@ public class CppGenerator implements CodeGenerator
             "    static const %1$s SBE_BLOCK_LENGTH = %2$s;\n" +
             "    static const %3$s SBE_TEMPLATE_ID = %4$s;\n" +
             "    static const %5$s SBE_SCHEMA_ID = %6$s;\n" +
-            "    static const %7$s SBE_SCHEMA_VERSION = %8$s;\n\n" +
+            "    static const %7$s SBE_SCHEMA_VERSION = %8$s;\n" +
+            "    static const std::string SBE_SEMANTIC_VERSION = \"%13$s\";\n\n" +
 
             "    enum MetaAttribute\n" +
             "    {\n" +
@@ -2151,7 +2153,8 @@ public class CppGenerator implements CodeGenerator
             semanticType,
             className,
             generateConstructorsAndOperators(className),
-            formatClassName(headerType));
+            formatClassName(headerType),
+            semanticVersion);
     }
 
     private void generateFields(

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -1994,7 +1994,7 @@ public class CppGenerator implements CodeGenerator
             "    static const %3$s SBE_TEMPLATE_ID = %4$s;\n" +
             "    static const %5$s SBE_SCHEMA_ID = %6$s;\n" +
             "    static const %7$s SBE_SCHEMA_VERSION = %8$s;\n" +
-            "    static const std::string SBE_SEMANTIC_VERSION = \"%13$s\";\n\n" +
+            "    static constexpr const char* SBE_SEMANTIC_VERSION = \"%13$s\";\n\n" +
 
             "    enum MetaAttribute\n" +
             "    {\n" +

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -1994,7 +1994,7 @@ public class CppGenerator implements CodeGenerator
             "    static const %3$s SBE_TEMPLATE_ID = %4$s;\n" +
             "    static const %5$s SBE_SCHEMA_ID = %6$s;\n" +
             "    static const %7$s SBE_SCHEMA_VERSION = %8$s;\n" +
-            "    static constexpr const char* SBE_SEMANTIC_VERSION = \"%13$s\";\n\n" +
+            "    static SBE_CONSTEXPR const char* SBE_SEMANTIC_VERSION = \"%13$s\";\n\n" +
 
             "    enum MetaAttribute\n" +
             "    {\n" +
@@ -2039,6 +2039,11 @@ public class CppGenerator implements CodeGenerator
             "    SBE_NODISCARD static SBE_CONSTEXPR %7$s sbeSchemaVersion() SBE_NOEXCEPT\n" +
             "    {\n" +
             "        return %8$s;\n" +
+            "    }\n\n" +
+
+            "    SBE_NODISCARD static SBE_CONSTEXPR const char* sbeSemanticVersion() SBE_NOEXCEPT\n" +
+            "    {\n" +
+            "        return \"%13$s\";\n" +
             "    }\n\n" +
 
             "    SBE_NODISCARD static SBE_CONSTEXPR const char *sbeSemanticType() SBE_NOEXCEPT\n" +

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -169,6 +169,7 @@ public class CppGenerator implements CodeGenerator
                 generateDisplay(sb, msgToken.name(), fields, groups, varData);
                 sb.append(generateMessageLength(groups, varData, BASE_INDENT));
                 sb.append("};\n");
+                sb.append(generateStaticVariablesInitialization(className));
                 sb.append(CppUtil.closingBraces(ir.namespaces().length)).append("#endif\n");
                 out.append(sb);
             }
@@ -1973,7 +1974,7 @@ public class CppGenerator implements CodeGenerator
         final String schemaVersionType = cppTypeName(ir.headerStructure().schemaVersionType());
         final String semanticType = token.encoding().semanticType() == null ? "" : token.encoding().semanticType();
         final String headerType = ir.headerStructure().tokens().get(0).name();
-        final String semanticVersion = ir.semanticVersion();
+        final String semanticVersion = ir.semanticVersion() == null ? "" : ir.semanticVersion();
 
         return String.format(
             "private:\n" +
@@ -1994,7 +1995,7 @@ public class CppGenerator implements CodeGenerator
             "    static const %3$s SBE_TEMPLATE_ID = %4$s;\n" +
             "    static const %5$s SBE_SCHEMA_ID = %6$s;\n" +
             "    static const %7$s SBE_SCHEMA_VERSION = %8$s;\n" +
-            "    static SBE_CONSTEXPR const char* SBE_SEMANTIC_VERSION = \"%13$s\";\n\n" +
+            "    static const std::string SBE_SEMANTIC_VERSION;\n\n" +
 
             "    enum MetaAttribute\n" +
             "    {\n" +
@@ -2041,7 +2042,7 @@ public class CppGenerator implements CodeGenerator
             "        return %8$s;\n" +
             "    }\n\n" +
 
-            "    SBE_NODISCARD static SBE_CONSTEXPR const char* sbeSemanticVersion() SBE_NOEXCEPT\n" +
+            "    SBE_NODISCARD static const std::string sbeSemanticVersion() SBE_NOEXCEPT\n" +
             "    {\n" +
             "        return \"%13$s\";\n" +
             "    }\n\n" +
@@ -3191,5 +3192,16 @@ public class CppGenerator implements CodeGenerator
             generateMessageLengthArgs(groups, varData, indent + INDENT, true)[0]);
 
         return sb;
+    }
+
+    private CharSequence generateStaticVariablesInitialization(final String className)
+    {
+        final String semanticVersion = ir.semanticVersion() == null ? "" : ir.semanticVersion();
+
+        return String.format(
+            "\n" +
+            "const std::string %1$s::SBE_SEMANTIC_VERSION = \"%2$s\";\n\n",
+            className,
+            semanticVersion);
     }
 }

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -1995,7 +1995,7 @@ public class CppGenerator implements CodeGenerator
             "    static const %3$s SBE_TEMPLATE_ID = %4$s;\n" +
             "    static const %5$s SBE_SCHEMA_ID = %6$s;\n" +
             "    static const %7$s SBE_SCHEMA_VERSION = %8$s;\n" +
-            "    static const std::string SBE_SEMANTIC_VERSION;\n\n" +
+            "    static const char* SBE_SEMANTIC_VERSION;\n\n" +
 
             "    enum MetaAttribute\n" +
             "    {\n" +
@@ -2042,7 +2042,7 @@ public class CppGenerator implements CodeGenerator
             "        return %8$s;\n" +
             "    }\n\n" +
 
-            "    SBE_NODISCARD static const std::string sbeSemanticVersion() SBE_NOEXCEPT\n" +
+            "    SBE_NODISCARD static const char *sbeSemanticVersion() SBE_NOEXCEPT\n" +
             "    {\n" +
             "        return \"%13$s\";\n" +
             "    }\n\n" +
@@ -3200,7 +3200,7 @@ public class CppGenerator implements CodeGenerator
 
         return String.format(
             "\n" +
-            "const std::string %1$s::SBE_SEMANTIC_VERSION = \"%2$s\";\n\n",
+            "const char* %1$s::SBE_SEMANTIC_VERSION = \"%2$s\";\n\n",
             className,
             semanticVersion);
     }

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -1163,7 +1163,7 @@ public class CSharpGenerator implements CodeGenerator
         final String schemaIdType = cSharpTypeName(ir.headerStructure().schemaIdType());
         final String schemaVersionType = cSharpTypeName(ir.headerStructure().schemaVersionType());
         final String semanticType = token.encoding().semanticType() == null ? "" : token.encoding().semanticType();
-        final String semanticVersion = ir.semanticVersion();
+        final String semanticVersion = ir.semanticVersion() == null ? "" : ir.semanticVersion();
 
         return String.format(
             indent + INDENT + "public const %1$s BlockLength = %2$s;\n" +

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -1163,13 +1163,15 @@ public class CSharpGenerator implements CodeGenerator
         final String schemaIdType = cSharpTypeName(ir.headerStructure().schemaIdType());
         final String schemaVersionType = cSharpTypeName(ir.headerStructure().schemaVersionType());
         final String semanticType = token.encoding().semanticType() == null ? "" : token.encoding().semanticType();
+        final String semanticVersion = ir.semanticVersion();
 
         return String.format(
             indent + INDENT + "public const %1$s BlockLength = %2$s;\n" +
             indent + INDENT + "public const %3$s TemplateId = %4$s;\n" +
             indent + INDENT + "public const %5$s SchemaId = %6$s;\n" +
             indent + INDENT + "public const %7$s SchemaVersion = %8$s;\n" +
-            indent + INDENT + "public const string SemanticType = \"%9$s\";\n\n" +
+            indent + INDENT + "public const string SemanticType = \"%9$s\";\n" +
+            indent + INDENT + "public const string SemanticVersion = \"%11$s\";\n\n" +
             indent + INDENT + "private readonly %10$s _parentMessage;\n" +
             indent + INDENT + "private DirectBuffer _buffer;\n" +
             indent + INDENT + "private int _offset;\n" +
@@ -1238,7 +1240,8 @@ public class CSharpGenerator implements CodeGenerator
             schemaVersionType,
             generateLiteral(ir.headerStructure().schemaVersionType(), Integer.toString(ir.version())),
             semanticType,
-            className);
+            className,
+            semanticVersion);
     }
 
     private CharSequence generateFields(final List<Token> tokens, final String indent)

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangGenerator.java
@@ -2099,7 +2099,7 @@ public class GolangGenerator implements CodeGenerator
         final String templateIdType = golangTypeName(ir.headerStructure().templateIdType());
         final String schemaIdType = golangTypeName(ir.headerStructure().schemaIdType());
         final String schemaVersionType = golangTypeName(ir.headerStructure().schemaVersionType());
-        final String semanticVersion = ir.semanticVersion();
+        final String semanticVersion = ir.semanticVersion() == null ? "" : ir.semanticVersion();
 
         generateEncodeDecode(sb, typeName, tokens, true, true);
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangGenerator.java
@@ -2099,6 +2099,7 @@ public class GolangGenerator implements CodeGenerator
         final String templateIdType = golangTypeName(ir.headerStructure().templateIdType());
         final String schemaIdType = golangTypeName(ir.headerStructure().schemaIdType());
         final String schemaVersionType = golangTypeName(ir.headerStructure().schemaVersionType());
+        final String semanticVersion = ir.semanticVersion();
 
         generateEncodeDecode(sb, typeName, tokens, true, true);
 
@@ -2117,6 +2118,9 @@ public class GolangGenerator implements CodeGenerator
             "}\n" +
             "\nfunc (*%1$s) SbeSemanticType() (semanticType []byte) {\n" +
             "\treturn []byte(\"%10$s\")\n" +
+            "}\n" +
+            "\nfunc (*%1$s) SbeSemanticVersion() (semanticVersion string) {\n" +
+            "\treturn \"%11$s\"\n" +
             "}\n",
             typeName,
             blockLengthType,
@@ -2127,7 +2131,8 @@ public class GolangGenerator implements CodeGenerator
             generateLiteral(ir.headerStructure().schemaIdType(), Integer.toString(ir.id())),
             schemaVersionType,
             generateLiteral(ir.headerStructure().schemaVersionType(), Integer.toString(ir.version())),
-            semanticType));
+            semanticType,
+            semanticVersion));
     }
 
     // Used for groups which need to know the schema's definition

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -2611,10 +2611,12 @@ public class JavaGenerator implements CodeGenerator
         final String schemaIdAccessorType = shouldGenerateInterfaces ? "int" : schemaIdType;
         final String schemaVersionType = javaTypeName(ir.headerStructure().schemaVersionType());
         final String schemaVersionAccessorType = shouldGenerateInterfaces ? "int" : schemaVersionType;
+        final String semanticVersion = ir.semanticVersion();
 
         return String.format(
             "    public static final %5$s SCHEMA_ID = %6$s;\n" +
             "    public static final %7$s SCHEMA_VERSION = %8$s;\n" +
+            "    public static final String SEMANTIC_VERSION = \"%11$s\";\n" +
             "    public static final int ENCODED_LENGTH = %2$d;\n" +
             "    public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.%4$s;\n\n" +
             "    private int offset;\n" +
@@ -2657,7 +2659,8 @@ public class JavaGenerator implements CodeGenerator
             schemaVersionType,
             generateLiteral(ir.headerStructure().schemaVersionType(), Integer.toString(ir.version())),
             schemaIdAccessorType,
-            schemaVersionAccessorType);
+            schemaVersionAccessorType,
+            semanticVersion);
     }
 
     private CharSequence generateDecoderFlyweightCode(final String className, final Token token)
@@ -2735,6 +2738,7 @@ public class JavaGenerator implements CodeGenerator
         final String schemaVersionType = javaTypeName(headerStructure.schemaVersionType());
         final String schemaVersionAccessorType = shouldGenerateInterfaces ? "int" : schemaVersionType;
         final String semanticType = token.encoding().semanticType() == null ? "" : token.encoding().semanticType();
+        final String semanticVersion = ir.semanticVersion();
         final String actingFields = codecType == CodecType.ENCODER ?
             "" :
             "    int actingBlockLength;\n" +
@@ -2745,6 +2749,7 @@ public class JavaGenerator implements CodeGenerator
             "    public static final %3$s TEMPLATE_ID = %4$s;\n" +
             "    public static final %5$s SCHEMA_ID = %6$s;\n" +
             "    public static final %7$s SCHEMA_VERSION = %8$s;\n" +
+            "    public static final String SEMANTIC_VERSION = \"%19$s\";\n" +
             "    public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.%14$s;\n\n" +
             "    private final %9$s parentMessage = this;\n" +
             "    private %11$s buffer;\n" +
@@ -2815,7 +2820,8 @@ public class JavaGenerator implements CodeGenerator
             blockLengthAccessorType,
             templateIdAccessorType,
             schemaIdAccessorType,
-            schemaVersionAccessorType);
+            schemaVersionAccessorType,
+            semanticVersion);
     }
 
     private CharSequence generateEncoderFlyweightCode(final String className, final Token token)

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -2611,7 +2611,7 @@ public class JavaGenerator implements CodeGenerator
         final String schemaIdAccessorType = shouldGenerateInterfaces ? "int" : schemaIdType;
         final String schemaVersionType = javaTypeName(ir.headerStructure().schemaVersionType());
         final String schemaVersionAccessorType = shouldGenerateInterfaces ? "int" : schemaVersionType;
-        final String semanticVersion = ir.semanticVersion();
+        final String semanticVersion = ir.semanticVersion() == null ? "" : ir.semanticVersion();
 
         return String.format(
             "    public static final %5$s SCHEMA_ID = %6$s;\n" +
@@ -2738,7 +2738,7 @@ public class JavaGenerator implements CodeGenerator
         final String schemaVersionType = javaTypeName(headerStructure.schemaVersionType());
         final String schemaVersionAccessorType = shouldGenerateInterfaces ? "int" : schemaVersionType;
         final String semanticType = token.encoding().semanticType() == null ? "" : token.encoding().semanticType();
-        final String semanticVersion = ir.semanticVersion();
+        final String semanticVersion = ir.semanticVersion() == null ? "" : ir.semanticVersion();
         final String actingFields = codecType == CodecType.ENCODER ?
             "" :
             "    int actingBlockLength;\n" +

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -157,7 +157,7 @@ public class RustGenerator implements CodeGenerator
                 final String templateIdType = rustTypeName(ir.headerStructure().templateIdType());
                 final String schemaIdType = rustTypeName(ir.headerStructure().schemaIdType());
                 final String schemaVersionType = schemaVersionType();
-                final String semanticVersion = ir.semanticVersion();
+                final String semanticVersion = ir.semanticVersion() == null ? "" : ir.semanticVersion();
                 indent(out, 0, "pub const SBE_BLOCK_LENGTH: %s = %d;\n", blockLengthType, msgToken.encodedLength());
                 indent(out, 0, "pub const SBE_TEMPLATE_ID: %s = %d;\n", templateIdType, msgToken.id());
                 indent(out, 0, "pub const SBE_SCHEMA_ID: %s = %d;\n", schemaIdType, ir.id());

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -157,10 +157,12 @@ public class RustGenerator implements CodeGenerator
                 final String templateIdType = rustTypeName(ir.headerStructure().templateIdType());
                 final String schemaIdType = rustTypeName(ir.headerStructure().schemaIdType());
                 final String schemaVersionType = schemaVersionType();
+                final String semanticVersion = ir.semanticVersion();
                 indent(out, 0, "pub const SBE_BLOCK_LENGTH: %s = %d;\n", blockLengthType, msgToken.encodedLength());
                 indent(out, 0, "pub const SBE_TEMPLATE_ID: %s = %d;\n", templateIdType, msgToken.id());
                 indent(out, 0, "pub const SBE_SCHEMA_ID: %s = %d;\n", schemaIdType, ir.id());
-                indent(out, 0, "pub const SBE_SCHEMA_VERSION: %s = %d;\n\n", schemaVersionType, ir.version());
+                indent(out, 0, "pub const SBE_SCHEMA_VERSION: %s = %d;\n", schemaVersionType, ir.version());
+                indent(out, 0, "pub const SBE_SEMANTIC_VERSION: &str = \"%s\";\n\n", semanticVersion);
 
                 MessageCoderDef.generateEncoder(ir, out, msgToken, fields, groups, varData);
                 MessageCoderDef.generateDecoder(ir, out, msgToken, fields, groups, varData);

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecDecoder.java
@@ -15,6 +15,7 @@ public final class FrameCodecDecoder
     public static final int TEMPLATE_ID = 1;
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
+    public static final String SEMANTIC_VERSION = "null";
     public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.LITTLE_ENDIAN;
 
     private final FrameCodecDecoder parentMessage = this;

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecDecoder.java
@@ -15,7 +15,7 @@ public final class FrameCodecDecoder
     public static final int TEMPLATE_ID = 1;
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
-    public static final String SEMANTIC_VERSION = "null";
+    public static final String SEMANTIC_VERSION = "";
     public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.LITTLE_ENDIAN;
 
     private final FrameCodecDecoder parentMessage = this;

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecEncoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecEncoder.java
@@ -15,7 +15,7 @@ public final class FrameCodecEncoder
     public static final int TEMPLATE_ID = 1;
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
-    public static final String SEMANTIC_VERSION = "null";
+    public static final String SEMANTIC_VERSION = "";
     public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.LITTLE_ENDIAN;
 
     private final FrameCodecEncoder parentMessage = this;

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecEncoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecEncoder.java
@@ -15,6 +15,7 @@ public final class FrameCodecEncoder
     public static final int TEMPLATE_ID = 1;
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
+    public static final String SEMANTIC_VERSION = "null";
     public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.LITTLE_ENDIAN;
 
     private final FrameCodecEncoder parentMessage = this;

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/MessageHeaderDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/MessageHeaderDecoder.java
@@ -12,6 +12,7 @@ public final class MessageHeaderDecoder
 {
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
+    public static final String SEMANTIC_VERSION = "null";
     public static final int ENCODED_LENGTH = 8;
     public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.LITTLE_ENDIAN;
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/MessageHeaderDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/MessageHeaderDecoder.java
@@ -12,7 +12,7 @@ public final class MessageHeaderDecoder
 {
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
-    public static final String SEMANTIC_VERSION = "null";
+    public static final String SEMANTIC_VERSION = "";
     public static final int ENCODED_LENGTH = 8;
     public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.LITTLE_ENDIAN;
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/MessageHeaderEncoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/MessageHeaderEncoder.java
@@ -12,6 +12,7 @@ public final class MessageHeaderEncoder
 {
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
+    public static final String SEMANTIC_VERSION = "null";
     public static final int ENCODED_LENGTH = 8;
     public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.LITTLE_ENDIAN;
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/MessageHeaderEncoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/MessageHeaderEncoder.java
@@ -12,7 +12,7 @@ public final class MessageHeaderEncoder
 {
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
-    public static final String SEMANTIC_VERSION = "null";
+    public static final String SEMANTIC_VERSION = "";
     public static final int ENCODED_LENGTH = 8;
     public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.LITTLE_ENDIAN;
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecDecoder.java
@@ -15,6 +15,7 @@ public final class TokenCodecDecoder
     public static final int TEMPLATE_ID = 2;
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
+    public static final String SEMANTIC_VERSION = "null";
     public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.LITTLE_ENDIAN;
 
     private final TokenCodecDecoder parentMessage = this;

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecDecoder.java
@@ -15,7 +15,7 @@ public final class TokenCodecDecoder
     public static final int TEMPLATE_ID = 2;
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
-    public static final String SEMANTIC_VERSION = "null";
+    public static final String SEMANTIC_VERSION = "";
     public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.LITTLE_ENDIAN;
 
     private final TokenCodecDecoder parentMessage = this;

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecEncoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecEncoder.java
@@ -15,7 +15,7 @@ public final class TokenCodecEncoder
     public static final int TEMPLATE_ID = 2;
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
-    public static final String SEMANTIC_VERSION = "null";
+    public static final String SEMANTIC_VERSION = "";
     public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.LITTLE_ENDIAN;
 
     private final TokenCodecEncoder parentMessage = this;

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecEncoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecEncoder.java
@@ -15,6 +15,7 @@ public final class TokenCodecEncoder
     public static final int TEMPLATE_ID = 2;
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
+    public static final String SEMANTIC_VERSION = "null";
     public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.LITTLE_ENDIAN;
 
     private final TokenCodecEncoder parentMessage = this;

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/VarDataEncodingDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/VarDataEncodingDecoder.java
@@ -12,6 +12,7 @@ public final class VarDataEncodingDecoder
 {
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
+    public static final String SEMANTIC_VERSION = "null";
     public static final int ENCODED_LENGTH = -1;
     public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.LITTLE_ENDIAN;
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/VarDataEncodingDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/VarDataEncodingDecoder.java
@@ -12,7 +12,7 @@ public final class VarDataEncodingDecoder
 {
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
-    public static final String SEMANTIC_VERSION = "null";
+    public static final String SEMANTIC_VERSION = "";
     public static final int ENCODED_LENGTH = -1;
     public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.LITTLE_ENDIAN;
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/VarDataEncodingEncoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/VarDataEncodingEncoder.java
@@ -12,7 +12,7 @@ public final class VarDataEncodingEncoder
 {
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
-    public static final String SEMANTIC_VERSION = "null";
+    public static final String SEMANTIC_VERSION = "";
     public static final int ENCODED_LENGTH = -1;
     public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.LITTLE_ENDIAN;
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/VarDataEncodingEncoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/VarDataEncodingEncoder.java
@@ -12,6 +12,7 @@ public final class VarDataEncodingEncoder
 {
     public static final int SCHEMA_ID = 1;
     public static final int SCHEMA_VERSION = 0;
+    public static final String SEMANTIC_VERSION = "null";
     public static final int ENCODED_LENGTH = -1;
     public static final java.nio.ByteOrder BYTE_ORDER = java.nio.ByteOrder.LITTLE_ENDIAN;
 

--- a/sbe-tool/src/test/c/CodeGenTest.cpp
+++ b/sbe-tool/src/test/c/CodeGenTest.cpp
@@ -432,6 +432,7 @@ TEST_F(CodeGenTest, shouldReturnCorrectValuesForCarStaticFields)
     EXPECT_EQ(CGT(car_sbe_schema_id)(), 6u);
     EXPECT_EQ(CGT(car_sbe_schema_version)(), 0u);
     EXPECT_EQ(std::string(CGT(car_sbe_semantic_type)()), std::string(""));
+    EXPECT_EQ(std::string(CGT(car_sbe_semantic_version)()), std::string("5.2"));
 }
 
 TEST_F(CodeGenTest, shouldBeAbleToEncodeMessageHeaderCorrectly)

--- a/sbe-tool/src/test/c/CodeGenTest.cpp
+++ b/sbe-tool/src/test/c/CodeGenTest.cpp
@@ -432,7 +432,7 @@ TEST_F(CodeGenTest, shouldReturnCorrectValuesForCarStaticFields)
     EXPECT_EQ(CGT(car_sbe_schema_id)(), 6u);
     EXPECT_EQ(CGT(car_sbe_schema_version)(), 0u);
     EXPECT_EQ(std::string(CGT(car_sbe_semantic_type)()), std::string(""));
-    EXPECT_EQ(std::string(CGT(car_sbe_semantic_version)()), std::string("5.2"));
+    EXPECT_EQ(CGT(car_sbe_semantic_version)(), "5.2");
 }
 
 TEST_F(CodeGenTest, shouldBeAbleToEncodeMessageHeaderCorrectly)

--- a/sbe-tool/src/test/cpp/CodeGenTest.cpp
+++ b/sbe-tool/src/test/cpp/CodeGenTest.cpp
@@ -331,7 +331,7 @@ TEST_F(CodeGenTest, shouldReturnCorrectValuesForCarStaticFields)
     EXPECT_EQ(Car::sbeSchemaId(), 6u);
     EXPECT_EQ(Car::sbeSchemaVersion(), 0u);
     EXPECT_EQ(std::string(Car::sbeSemanticType()), std::string(""));
-    EXPECT_EQ(std::string(Car::sbeSemanticVersion()), std::string("5.2"));
+    EXPECT_EQ(Car::sbeSemanticVersion(), "5.2");
 }
 
 TEST_F(CodeGenTest, shouldBeAbleToEncodeMessageHeaderCorrectly)

--- a/sbe-tool/src/test/cpp/CodeGenTest.cpp
+++ b/sbe-tool/src/test/cpp/CodeGenTest.cpp
@@ -331,7 +331,7 @@ TEST_F(CodeGenTest, shouldReturnCorrectValuesForCarStaticFields)
     EXPECT_EQ(Car::sbeSchemaId(), 6u);
     EXPECT_EQ(Car::sbeSchemaVersion(), 0u);
     EXPECT_EQ(std::string(Car::sbeSemanticType()), std::string(""));
-    EXPECT_EQ(Car::sbeSemanticVersion, std::string("5.2"));
+    EXPECT_EQ(std::string(Car::sbeSemanticVersion()), std::string("5.2"));
 }
 
 TEST_F(CodeGenTest, shouldBeAbleToEncodeMessageHeaderCorrectly)

--- a/sbe-tool/src/test/cpp/CodeGenTest.cpp
+++ b/sbe-tool/src/test/cpp/CodeGenTest.cpp
@@ -331,7 +331,7 @@ TEST_F(CodeGenTest, shouldReturnCorrectValuesForCarStaticFields)
     EXPECT_EQ(Car::sbeSchemaId(), 6u);
     EXPECT_EQ(Car::sbeSchemaVersion(), 0u);
     EXPECT_EQ(std::string(Car::sbeSemanticType()), std::string(""));
-    EXPECT_EQ(Car::sbeSemanticVersion(), "5.2");
+    EXPECT_EQ(std::string(Car::sbeSemanticVersion()), std::string("5.2"));
 }
 
 TEST_F(CodeGenTest, shouldBeAbleToEncodeMessageHeaderCorrectly)

--- a/sbe-tool/src/test/cpp/CodeGenTest.cpp
+++ b/sbe-tool/src/test/cpp/CodeGenTest.cpp
@@ -331,6 +331,7 @@ TEST_F(CodeGenTest, shouldReturnCorrectValuesForCarStaticFields)
     EXPECT_EQ(Car::sbeSchemaId(), 6u);
     EXPECT_EQ(Car::sbeSchemaVersion(), 0u);
     EXPECT_EQ(std::string(Car::sbeSemanticType()), std::string(""));
+    EXPECT_EQ(Car::sbeSemanticVersion, std::string("5.2"));
 }
 
 TEST_F(CodeGenTest, shouldBeAbleToEncodeMessageHeaderCorrectly)


### PR DESCRIPTION
The semantic version is not currently accessible for the clients using the generated stubs. This pull request adds the semantic version as a static public member in the classes generated by the sbe-tool. It is now possible to obtain the value of the sbe template semantic version direct in the source code using the stubs.