### PR TITLE
CppGenerator: operator<< take messages as const-ref

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -2564,7 +2564,7 @@ public class CppGenerator implements CodeGenerator
         new Formatter(sb).format("\n" +
             "template<typename CharT, typename Traits>\n" +
             "friend std::basic_ostream<CharT, Traits> & operator << (\n" +
-            "    std::basic_ostream<CharT, Traits> &builder, %1$s &_writer)\n" +
+            "    std::basic_ostream<CharT, Traits> &builder, const %1$s &_writer)\n" +
             "{\n" +
             "    %1$s writer(\n" +
             "        _writer.m_buffer,\n" +


### PR DESCRIPTION
Dear all,

Following commit 1973c86f84b190d5b2507786e6445970c390ea62, using generated operator<< would require a mutable ref message.
This is unnecessary and can be problematic.
For example when using wrappers such as fmt::streamed ( https://fmt.dev/latest/api.html#std-ostream-support ) that enforce const-correctness.