### PR TITLE
[Rust] Add derive Copy Clone traits for decoders

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
@@ -149,7 +149,7 @@ class LibRsDef
 
     static void generateReadBuf(final Appendable writer, final ByteOrder byteOrder) throws IOException
     {
-        indent(writer, 0, "#[derive(Debug, Default)]\n");
+        indent(writer, 0, "#[derive(Clone, Copy, Debug, Default)]\n");
         indent(writer, 0, "pub struct %s<%s> {\n", READ_BUF_TYPE, BUF_LIFETIME);
         RustUtil.indent(writer, 1, "data: &%s [u8],\n", BUF_LIFETIME);
         indent(writer, 0, "}\n");

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/MessageCoderDef.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/MessageCoderDef.java
@@ -155,7 +155,15 @@ class MessageCoderDef implements RustGenerator.ParentDef
 
     void appendMessageStruct(final Appendable out, final String structName) throws IOException
     {
-        indent(out, 1, "#[derive(Debug, Default)]\n");
+        if (this.codecType == Decoder)
+        {
+            indent(out, 1, "#[derive(Clone, Copy, Debug, Default)]\n");
+        }
+        else
+        {
+            indent(out, 1, "#[derive(Debug, Default)]\n");
+        }
+
         indent(out, 1, "pub struct %s {\n", withLifetime(structName));
         indent(out, 2, "buf: %s,\n", withLifetime(this.codecType.bufType()));
         indent(out, 2, "initial_offset: usize,\n");


### PR DESCRIPTION
Add the `Copy` and `Clone` traits to message decoders.

The Rust [API guidelines](https://rust-lang.github.io/api-guidelines/interoperability.html?highlight=Copy#types-eagerly-implement-common-traits-c-common-traits) recommend eagerly implementing common traits. Since decoders and the `ReadBuf` are views without mutable access into a read-only buffer, there is no harm in copying a decoder (if so, the Rust borrow checker would prevent it from compiling).

