### PR TITLE
[Rust] Fix clippy lint

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
@@ -131,7 +131,7 @@ class LibRsDef
         indent(writer, 0, "impl core::fmt::Display for SbeErr {\n");
         indent(writer, 1, "#[inline]\n");
         indent(writer, 1, "fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {\n");
-        indent(writer, 2, "write!(f, \"{:?}\", self)\n");
+        indent(writer, 2, "write!(f, \"{self:?}\")\n");
         indent(writer, 1, "}\n");
         indent(writer, 0, "}\n");
 


### PR DESCRIPTION
Creating a Rust codec and linting the generated code using [clippy](https://doc.rust-lang.org/clippy/index.html) gives the following warning:
```
warning: variables can be used directly in the `format!` string
   --> src/lib.rs:123:9
    |
123 |         write!(f, "{:?}", self)
    |         ^^^^^^^^^^^^^^^^^^^^^^^
    |
    = help: for further information visit https://rust-lang.github.io/rust-clippy/master/index.html#uninlined_format_args
    = note: `#[warn(clippy::uninlined_format_args)]` on by default
help: change this to
    |
123 -         write!(f, "{:?}", self)
123 +         write!(f, "{self:?}")
    |

warning: `io_aeron_archive_codecs` (lib) generated 1 warning
```

This PR fixes that. 