### PR TITLE
improve rust performance

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
@@ -183,7 +183,6 @@ class LibRsDef
             = new LinkedHashSet<>(TYPE_NAME_BY_PRIMITIVE_TYPE_MAP.values());
         final String endianness = byteOrder == LITTLE_ENDIAN ? "le" : "be";
 
-        // get_u8_at
         uniquePrimitiveTypes.remove("u8");
         indent(writer, 0, "\n");
         indent(writer, 1, "#[inline]\n");
@@ -234,6 +233,7 @@ class LibRsDef
         final LinkedHashSet<String> uniquePrimitiveTypes
             = new LinkedHashSet<>(TYPE_NAME_BY_PRIMITIVE_TYPE_MAP.values());
         final String endianness = byteOrder == LITTLE_ENDIAN ? "le" : "be";
+
         uniquePrimitiveTypes.remove("u8");
         indent(writer, 1, "#[inline]\n");
         indent(writer, 1, "pub fn put_u8_at(&mut self, index: usize, value: u8) {\n");

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
@@ -175,7 +175,7 @@ class LibRsDef
         indent(writer, 1, "}\n\n");
 
         indent(writer, 1, "#[inline]\n");
-        indent(writer, 1, "pub fn get_bytes_at<const COUNT: usize>(slice: &[u8], index: usize) -> [u8; COUNT] {\n");
+        indent(writer, 1, "pub(crate) fn get_bytes_at<const COUNT: usize>(slice: &[u8], index: usize) -> [u8; COUNT] {\n");
         indent(writer, 2, "slice[index..index+COUNT].try_into().expect(\"slice with incorrect length\")\n");
         indent(writer, 1, "}\n");
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
@@ -175,8 +175,8 @@ class LibRsDef
         indent(writer, 1, "}\n\n");
 
         indent(writer, 1, "#[inline]\n");
-        indent(writer, 1, "pub(crate) fn get_bytes_at<const COUNT: usize>(slice: &[u8], index: usize) -> [u8; COUNT] {\n");
-        indent(writer, 2, "slice[index..index+COUNT].try_into().expect(\"slice with incorrect length\")\n");
+        indent(writer, 1, "pub(crate) fn get_bytes_at<const N: usize>(slice: &[u8], index: usize) -> [u8; N] {\n");
+        indent(writer, 2, "slice[index..index+N].try_into().expect(\"slice with incorrect length\")\n");
         indent(writer, 1, "}\n");
 
         final LinkedHashSet<String> uniquePrimitiveTypes

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -376,6 +376,12 @@ public class RustGenerator implements CodeGenerator
             indent(sb, level + 1, "let offset = self.%s;\n", getBufOffset(typeToken));
             indent(sb, level + 1, "let buf = self.get_buf_mut();\n");
 
+            if (rustPrimitiveType == "u8") {
+                indent(sb, level + 1, "buf.put_bytes_at(offset, value);\n");
+                indent(sb, level, "}\n\n");
+                return;
+            }
+
             for (int i = 0; i < arrayLength; i++)
             {
                 if (i == 0)
@@ -646,6 +652,14 @@ public class RustGenerator implements CodeGenerator
         }
 
         indent(sb, level + 1, "let buf = self.get_buf();\n");
+        if (rustPrimitiveType == "u8")
+        {
+            indent(sb, level + 1, "ReadBuf::get_bytes_at(buf.data, self.%s)\n",
+                    getBufOffset(typeToken));
+            indent(sb, level, "}\n\n");
+            return;
+        }
+
         indent(sb, level + 1, "[\n");
         for (int i = 0; i < arrayLength; i++)
         {

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -376,7 +376,8 @@ public class RustGenerator implements CodeGenerator
             indent(sb, level + 1, "let offset = self.%s;\n", getBufOffset(typeToken));
             indent(sb, level + 1, "let buf = self.get_buf_mut();\n");
 
-            if (rustPrimitiveType == "u8") {
+            if (rustPrimitiveType.equals("u8"))
+            {
                 indent(sb, level + 1, "buf.put_bytes_at(offset, value);\n");
                 indent(sb, level, "}\n\n");
                 return;
@@ -652,10 +653,10 @@ public class RustGenerator implements CodeGenerator
         }
 
         indent(sb, level + 1, "let buf = self.get_buf();\n");
-        if (rustPrimitiveType == "u8")
+        if (rustPrimitiveType.equals("u8"))
         {
             indent(sb, level + 1, "ReadBuf::get_bytes_at(buf.data, self.%s)\n",
-                    getBufOffset(typeToken));
+                getBufOffset(typeToken));
             indent(sb, level, "}\n\n");
             return;
         }


### PR DESCRIPTION
improve rust performance (also more idiomatic)

- specialize `get_u8_at` & `put_u8_at`
- use `copy_from_slice` instead of `split_at` when r/w u8 arrays

<img width="436" alt="Screenshot 2023-06-10 at 16 53 45" src="https://github.com/real-logic/simple-binary-encoding/assets/5133901/4e083ba2-9cf0-449b-aab7-2b238ffa2c78">
