### PR TITLE
JsonPrinter remove trailing garbage after non-printable char

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/json/JsonTokenListener.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/json/JsonTokenListener.java
@@ -336,12 +336,7 @@ public class JsonTokenListener implements TokenListener
             if (size > 1 && encoding.primitiveType() == CHAR)
             {
                 doubleQuote();
-
-                for (int i = 0; i < size; i++)
-                {
-                    escape((char)buffer.getByte(index + (i * elementSize)));
-                }
-
+                escapePrintableChar(buffer, index, size, elementSize);
                 doubleQuote();
             }
             else
@@ -365,6 +360,22 @@ public class JsonTokenListener implements TokenListener
 
                     output.append(']');
                 }
+            }
+        }
+    }
+
+    private void escapePrintableChar(final DirectBuffer buffer, final int index, final int size, final int elementSize)
+    {
+        for (int i = 0; i < size; i++)
+        {
+            final byte c = buffer.getByte(index + (i * elementSize));
+            if (c > 0)
+            {
+                escape((char)c);
+            }
+            else
+            {
+                break;
             }
         }
     }


### PR DESCRIPTION
SBE toString() won't print trailing garbage after non-printable char; JsonPrinter should have the same functionality...

see CarEncoder toString: 

```
for (int i = 0; i < vehicleCodeLength() && this.vehicleCode(i) > 0; i++)
{
    builder.append((char)this.vehicleCode(i));
}

```