### PR TITLE
[Java] Expose actingVersion

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -2716,6 +2716,11 @@ public class JavaGenerator implements CodeGenerator
             "        final int decodedLength = encodedLength();\n" +
             "        limit(currentLimit);\n\n" +
             "        return decodedLength;\n" +
+            "    }\n\n" +
+
+            "    public int actingVersion()\n" +
+            "    {\n" +
+            "        return actingVersion;\n" +
             "    }\n\n";
 
         return generateFlyweightCode(DECODER, className, token, methods, readOnlyBuffer);

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecDecoder.java
@@ -120,6 +120,11 @@ public final class FrameCodecDecoder
         return decodedLength;
     }
 
+    public int actingVersion()
+    {
+        return actingVersion;
+    }
+
     public int encodedLength()
     {
         return limit - offset;

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecDecoder.java
@@ -120,6 +120,11 @@ public final class TokenCodecDecoder
         return decodedLength;
     }
 
+    public int actingVersion()
+    {
+        return actingVersion;
+    }
+
     public int encodedLength()
     {
         return limit - offset;


### PR DESCRIPTION
Handy method should one need to compare the version of the current message to the version of the template.
If the version is identical, we know we can copy the raw bytes, instead of making a field-by-field copy of the message.