### PR TITLE
[Java] Support camelCase enum type identifiers for value refs

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -3074,7 +3074,8 @@ public class JavaGenerator implements CodeGenerator
 
         if (fieldToken.isConstantEncoding())
         {
-            final String enumValueStr = fieldToken.encoding().constValue().toString();
+            final String enumValueStr = formatClassName(
+                fieldToken.encoding().constValue().toString());
 
             new Formatter(sb).format(
                 "\n" +

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ValueRefWithLowerCaseEnum.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/java/ValueRefWithLowerCaseEnum.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright 2013-2023 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package uk.co.real_logic.sbe.generation.java;
+
+import org.agrona.DirectBuffer;
+import org.agrona.MutableDirectBuffer;
+import org.agrona.generation.StringWriterOutputManager;
+import org.junit.jupiter.api.Test;
+import uk.co.real_logic.sbe.Tests;
+import uk.co.real_logic.sbe.ir.Ir;
+import uk.co.real_logic.sbe.xml.IrGenerator;
+import uk.co.real_logic.sbe.xml.MessageSchema;
+import uk.co.real_logic.sbe.xml.ParserOptions;
+import uk.co.real_logic.sbe.xml.XmlSchemaParser;
+
+import java.io.InputStream;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.core.StringContains.containsString;
+
+class ValueRefWithLowerCaseEnum
+{
+    private static final Class<?> BUFFER_CLASS = MutableDirectBuffer.class;
+    private static final String BUFFER_NAME = BUFFER_CLASS.getName();
+    private static final Class<DirectBuffer> READ_ONLY_BUFFER_CLASS = DirectBuffer.class;
+    private static final String READ_ONLY_BUFFER_NAME = READ_ONLY_BUFFER_CLASS.getName();
+
+    @Test
+    void shouldGenerateConstCharArrayMethods() throws Exception
+    {
+        try (InputStream in = Tests.getLocalResource("value-ref-with-lower-case-enum.xml"))
+        {
+            final ParserOptions options = ParserOptions.builder().stopOnError(true).build();
+            final MessageSchema schema = XmlSchemaParser.parse(in, options);
+            final IrGenerator irg = new IrGenerator();
+            final Ir ir = irg.generate(schema);
+
+            final StringWriterOutputManager outputManager = new StringWriterOutputManager();
+            outputManager.setPackageName(ir.applicableNamespace());
+            final JavaGenerator generator = new JavaGenerator(
+                ir, BUFFER_NAME, READ_ONLY_BUFFER_NAME, false, false, false, outputManager);
+
+            generator.generate();
+            final String sources = outputManager.getSources().toString();
+
+            // Prior to the fix the generated body of the following method was
+            // `return engineType.gas;`
+            final String expected =
+                "    public EngineType engineType()\n" +
+                "    {\n" +
+                "        return EngineType.gas;\n" +
+                "    }";
+            assertThat(sources, containsString(expected));
+        }
+    }
+}

--- a/sbe-tool/src/test/resources/value-ref-with-lower-case-enum.xml
+++ b/sbe-tool/src/test/resources/value-ref-with-lower-case-enum.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   package="issue505"
+                   id="505"
+                   version="0"
+                   semanticVersion="1.0"
+                   description="issue 505 test case">
+    <types>
+        <composite name="messageHeader" description="header">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+
+        <enum name="engineType" encodingType="uint8">
+            <validValue name="gas">0</validValue>
+        </enum>
+    </types>
+
+    <sbe:message name="SomeMessage" id="1">
+        <field name="engineType" type="engineType" id="1" presence="constant" valueRef="engineType.gas"/>
+    </sbe:message>
+</sbe:messageSchema>


### PR DESCRIPTION
The type identifier was previously used as-is (e.g. `carFilterType`) in
the generated code for uses of `valueRef` while generated Java enums
always start with a capital letter (`CarFilterType`).

See the added test in `ValueRefWithLowerCaseEnum.java`.