### PR TITLE
[Java] Cope with optional sets not being present when pretty printing decoders for debugging. Issue #976

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -4564,9 +4564,6 @@ public class JavaGenerator implements CodeGenerator
                 break;
 
             case BEGIN_SET:
-                append(sb, indent, "this." + fieldName + "().appendTo(builder);");
-                break;
-
             case BEGIN_COMPOSITE:
             {
                 final String typeName = formatClassName(decoderName(typeToken.applicableTypeName()));


### PR DESCRIPTION
Issue #976

Avoids NPE when set is null when parsing a message in an older protocol version