### PR TITLE
Upgrade .NET SDK to 8.0.201.

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -71,7 +71,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        dotnet: [ '3.1.x' ]
+        dotnet: [ '8.0.x' ]
     env:
       DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true
       DOTNET_CLI_TELEMETRY_OPTOUT: 1

--- a/csharp/sbe-benchmarks/sbe-benchmarks.csproj
+++ b/csharp/sbe-benchmarks/sbe-benchmarks.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net461;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Org.SbeTool.Sbe.Benchmarks</RootNamespace>
     <AssemblyName>sbe-benchmarks</AssemblyName>
     <OutputTypeEx>exe</OutputTypeEx>
-    <Copyright>Copyright (C) Bill Segall 2018, MarketFactory Inc 2017, Adaptive 2014. All rights reserved.</Copyright>
+    <Copyright>Copyright (C) Bill Segall 2018, MarketFactory Inc 2017, Adaptive 2014-2024. All rights reserved.</Copyright>
     <Product>SBE</Product>
     <OutputType>Exe</OutputType>
   </PropertyGroup>
@@ -16,9 +16,8 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="BenchmarkDotNet" Version="0.12.1" />
-    <PackageReference Include="BenchmarkDotNet.Annotations" Version="0.12.1" />
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
+    <PackageReference Include="BenchmarkDotNet" Version="0.13.12" />
+    <PackageReference Include="BenchmarkDotNet.Annotations" Version="0.13.12" />
   </ItemGroup>
 
 </Project>

--- a/csharp/sbe-dll/sbe-dll.csproj
+++ b/csharp/sbe-dll/sbe-dll.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFramework>netstandard2.0</TargetFramework>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
     <AssemblyName>SBE</AssemblyName>
     <RootNamespace>Org.SbeTool.Sbe.Dll</RootNamespace>
     <Product>Org.SbeTool.Sbe.Dll</Product>
-    <Copyright>Copyright (C) Bill Segall 2018-2021, MarketFactory Inc 2017, Adaptive 2014. All rights reserved.</Copyright>
+    <Copyright>Copyright (C) Bill Segall 2018-2021, MarketFactory Inc 2017, Adaptive 2014-2024. All rights reserved.</Copyright>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <Authors>Bill Segall, MarketFactory Inc, Adaptive Consulting</Authors>
     <PackageLicenseExpression>Apache-2.0</PackageLicenseExpression>
@@ -35,10 +35,6 @@
       <Pack>true</Pack>
       <PackagePath>tools/sbe-tool-all.jar</PackagePath>
     </None>
-  </ItemGroup>
-
-  <ItemGroup Condition=" '$(TargetFramework)' == 'net45' ">
-    <Reference Include="System.Runtime" />
   </ItemGroup>
 
   <ItemGroup>

--- a/csharp/sbe-generated/sbe-generated.csproj
+++ b/csharp/sbe-generated/sbe-generated.csproj
@@ -1,26 +1,23 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>Org.SbeTool.Sbe.Generated</RootNamespace>
     <AssemblyName>Org.SbeTool.Sbe.Generated</AssemblyName>
-    <Copyright>Copyright (C) Bill Segall 2018, MarketFactory Inc 2017, Adaptive 2014. All rights reserved.</Copyright>
+    <Copyright>Copyright (C) Bill Segall 2018, MarketFactory Inc 2017, Adaptive 2014-2024. All rights reserved.</Copyright>
+    <LangVersion>9</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Debug' ">
-    <DefineConstants>TRACE,SBE_ENABLE_PRECEDENCE_CHECKS</DefineConstants>
+    <DefineConstants>TRACE;SBE_ENABLE_PRECEDENCE_CHECKS</DefineConstants>
   </PropertyGroup>
 
   <PropertyGroup Condition=" '$(Configuration)' == 'Release' ">
-    <DefineConstants>TRACE,SBE_ENABLE_PRECEDENCE_CHECKS</DefineConstants>
+    <DefineConstants>TRACE;SBE_ENABLE_PRECEDENCE_CHECKS</DefineConstants>
   </PropertyGroup>
 
   <ItemGroup>
     <ProjectReference Include="..\sbe-dll\sbe-dll.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/csharp/sbe-samples-car/sbe-samples-car.csproj
+++ b/csharp/sbe-samples-car/sbe-samples-car.csproj
@@ -1,7 +1,7 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>exe</OutputType>
     <RootNamespace>Org.SbeTool.Sbe.Example.Car</RootNamespace>
     <AssemblyName>Org.SbeTool.Sbe.Example.Car</AssemblyName>
@@ -14,10 +14,6 @@
   <ItemGroup>
     <ProjectReference Include="..\sbe-dll\sbe-dll.csproj" />
     <ProjectReference Include="..\sbe-generated\sbe-generated.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
   </ItemGroup>
 
 </Project>

--- a/csharp/sbe-samples-extension/sbe-samples-extension.csproj
+++ b/csharp/sbe-samples-extension/sbe-samples-extension.csproj
@@ -1,11 +1,11 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFrameworks>net45;netstandard2.0</TargetFrameworks>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputTypeEx>exe</OutputTypeEx>
     <RootNamespace>Org.SbeTool.Sbe.Example.Extension</RootNamespace>
     <AssemblyName>Org.SbeTool.Sbe.Example.Extension</AssemblyName>
-    <Copyright>Copyright (C) Bill Segall 2018, MarketFactory Inc 2017, Adaptive 2014. All rights reserved.</Copyright>
+    <Copyright>Copyright (C) Bill Segall 2018, MarketFactory Inc 2017, Adaptive 2014-2024. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <ItemGroup>
@@ -15,11 +15,6 @@
   <ItemGroup>
     <ProjectReference Include="..\sbe-dll\sbe-dll.csproj" />
     <ProjectReference Include="..\sbe-generated\sbe-generated.csproj" />
-  </ItemGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
-
   </ItemGroup>
 
 </Project>

--- a/csharp/sbe-tests/sbe-tests.csproj
+++ b/csharp/sbe-tests/sbe-tests.csproj
@@ -1,10 +1,10 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFrameworks>net45;netcoreapp3.1</TargetFrameworks>
+    <TargetFrameworks>net8.0</TargetFrameworks>
     <RootNamespace>Org.SbeTool.Sbe.Tests</RootNamespace>
     <AssemblyName>Org.SbeTool.Sbe.UnitTests</AssemblyName>
     <AllowUnsafeBlocks>True</AllowUnsafeBlocks>
-    <Copyright>Copyright (C) Bill Segall 2018, MarketFactory Inc 2017, Adaptive 2014. All rights reserved.</Copyright>
+    <Copyright>Copyright (C) Bill Segall 2018, MarketFactory Inc 2017, Adaptive 2014-2024. All rights reserved.</Copyright>
   </PropertyGroup>
 
   <ItemGroup>
@@ -18,10 +18,9 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.NETFramework.ReferenceAssemblies" Version="1.0.0-preview.2" PrivateAssets="All" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.2.0" />
-    <PackageReference Include="MSTest.TestAdapter" Version="1.4.0" />
-    <PackageReference Include="MSTest.TestFramework" Version="1.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.9.0" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.2.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.2.2" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
I've updated the .NET SDK to `8.0`, which is the most recent LTS version. Support ends on 10 November 2026.

There are several C# projects in the SBE solution. Only `sbe-dll` is consumed by users of SBE.

Previously, `sbe-dll` had two targets:
- `.NET Standard 2.0` (2017, supported by `.NET Framework >= 4.6.1` and `.NET Core >= 2.0`, which were both superseded by `.NET`)
- `.NET Framework 4.5` (2012)

In this commit, I have removed the _ancient_ `.NET Framework 4.5` target. This makes it easier to build SBE on Linux, as one only needs a recent .NET installation.

I have also changed the other C# projects to target `.NET 8.0` and updated their dependencies.