### PR TITLE
[C++] small test fix

### DIFF
--- a/sbe-tool/src/test/cpp/FieldAccessOrderCheckTest.cpp
+++ b/sbe-tool/src/test/cpp/FieldAccessOrderCheckTest.cpp
@@ -3624,7 +3624,7 @@ TEST_F(FieldAccessOrderCheckTest, allowsEncodingAndDecodingAsciiInsideGroupInSch
         AsciiInsideGroup::sbeSchemaVersion(),
         BUFFER_LEN
     );
-    char aOut[6];
+    char aOut[7] = {'\0'};
     decoder.getA(aOut, 6);
     EXPECT_STREQ(aOut, "GBPUSD");
     AsciiInsideGroup::B &b = decoder.b();


### PR DESCRIPTION
Small fix to one C++ test.
EXPECT_STREQ macro expects a c-string (i.e. null-terminated), which aOut was not (explicitly).
Extended buffer to accomodate zero byte and explicitly zeroed.
Test was failing on my aging CentOS environment but passes now.