### PR TITLE
[Java, C#, C++] Fix precedence checks to account for non-contiguous versions.

### DIFF
--- a/csharp/sbe-tests/FieldAccessOrderCheckTests.cs
+++ b/csharp/sbe-tests/FieldAccessOrderCheckTests.cs
@@ -3159,6 +3159,25 @@ namespace Org.SbeTool.Sbe.Tests
             var exception = Assert.ThrowsException<InvalidOperationException>(encoder.CheckEncodingIsComplete);
             StringAssert.Contains(exception.Message, $"Not fully encoded, current state: {expectedState}");
         }
+        
+        [TestMethod]
+        public void AllowsSkippingFutureGroupWhenDecodingFromVersionWithNoChangesInMessage()
+        {
+            var encoder = new AddGroupBeforeVarDataV0()
+                .WrapForEncodeAndApplyHeader(_buffer, Offset, _messageHeader);
+
+            _messageHeader.TemplateId = SkipVersionAddGroupBeforeVarDataV2.TemplateId;
+            _messageHeader.Version = 1;
+
+            encoder.A = 42;
+            encoder.SetB("abc");
+
+            var decoder = new SkipVersionAddGroupBeforeVarDataV2()
+                .WrapForDecodeAndApplyHeader(_buffer, Offset, _messageHeader);
+
+            Assert.AreEqual(42, decoder.A);
+            Assert.AreEqual(decoder.GetB(), "abc");
+        }
 
         private void ModifyHeaderToLookLikeVersion0()
         {

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/common/FieldPrecedenceModel.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/common/FieldPrecedenceModel.java
@@ -46,7 +46,7 @@ public final class FieldPrecedenceModel
         new CodecInteraction.CodecInteractionFactory(groupPathsByField, topLevelBlockFields);
     private final Map<CodecInteraction, List<TransitionGroup>> transitionsByInteraction = new LinkedHashMap<>();
     private final Map<State, List<TransitionGroup>> transitionsByState = new HashMap<>();
-    private final Int2ObjectHashMap<State> versionWrappedStates = new Int2ObjectHashMap<>();
+    private final TreeMap<Integer, State> versionWrappedStates = new TreeMap<>();
     private final State notWrappedState = allocateState("NOT_WRAPPED");
     private final String generatedRepresentationClassName;
     private State encoderWrappedState;
@@ -103,13 +103,11 @@ public final class FieldPrecedenceModel
      * Iterates over the states after a codec is wrapped over a particular version of data.
      * @param consumer the consumer of the states.
      */
-    public void forEachWrappedStateByVersion(final IntObjConsumer<State> consumer)
+    public void forEachWrappedStateByVersionDesc(final IntObjConsumer<State> consumer)
     {
-        final Int2ObjectHashMap<State>.EntryIterator iterator = versionWrappedStates.entrySet().iterator();
-        while (iterator.hasNext())
+        for (final Map.Entry<Integer, State> entry : versionWrappedStates.descendingMap().entrySet())
         {
-            iterator.next();
-            consumer.accept(iterator.getIntKey(), iterator.getValue());
+            consumer.accept(entry.getKey(), entry.getValue());
         }
     }
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -1912,22 +1912,20 @@ public class CSharpGenerator implements CodeGenerator
         }
 
         final StringBuilder sb = new StringBuilder();
+
         sb.append(indent).append("private void OnWrapForDecode(int actingVersion)\n")
-            .append(indent).append("{\n")
-            .append(indent).append(INDENT).append("switch(actingVersion)\n")
-            .append(indent).append(INDENT).append("{\n");
+            .append(indent).append("{\n");
 
-        fieldPrecedenceModel.forEachWrappedStateByVersion((version, state) ->
-            sb.append(indent).append(TWO_INDENT).append("case ").append(version).append(":\n")
-            .append(indent).append(THREE_INDENT).append("codecState(")
+        fieldPrecedenceModel.forEachWrappedStateByVersionDesc((version, state) ->
+            sb.append(indent).append("    if (actingVersion >= ").append(version).append(")\n")
+            .append(indent).append("    {\n")
+            .append(indent).append("        codecState(")
             .append(qualifiedStateCase(state)).append(");\n")
-            .append(indent).append(THREE_INDENT).append("break;\n"));
+            .append(indent).append("        return;\n")
+            .append(indent).append("    }\n\n"));
 
-        sb.append(indent).append(TWO_INDENT).append("default:\n")
-            .append(indent).append(THREE_INDENT).append("codecState(")
-            .append(qualifiedStateCase(fieldPrecedenceModel.latestVersionWrappedState())).append(");\n")
-            .append(indent).append(THREE_INDENT).append("break;\n")
-            .append(indent).append(INDENT).append("}\n")
+        sb.append(indent)
+            .append("    throw new InvalidOperationException(\"Unsupported acting version: \" + actingVersion);\n")
             .append(indent).append("}\n\n");
 
         return sb;

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/java/JavaGenerator.java
@@ -762,21 +762,18 @@ public class JavaGenerator implements CodeGenerator
 
         final StringBuilder sb = new StringBuilder();
         sb.append(indent).append("private void onWrap(final int actingVersion)\n")
-            .append(indent).append("{\n")
-            .append(indent).append("    switch(actingVersion)\n")
-            .append(indent).append("    {\n");
+            .append(indent).append("{\n");
 
-        fieldPrecedenceModel.forEachWrappedStateByVersion((version, state) ->
-            sb.append(indent).append("        case ").append(version).append(":\n")
-            .append(indent).append("            codecState(")
+        fieldPrecedenceModel.forEachWrappedStateByVersionDesc((version, state) ->
+            sb.append(indent).append("    if (actingVersion >= ").append(version).append(")\n")
+            .append(indent).append("    {\n")
+            .append(indent).append("        codecState(")
             .append(qualifiedStateCase(state)).append(");\n")
-            .append(indent).append("            break;\n"));
+            .append(indent).append("        return;\n")
+            .append(indent).append("    }\n\n"));
 
-        sb.append(indent).append("        default:\n")
-            .append(indent).append("            codecState(")
-            .append(qualifiedStateCase(fieldPrecedenceModel.latestVersionWrappedState())).append(");\n")
-            .append(indent).append("            break;\n")
-            .append(indent).append("    }\n")
+        sb.append(indent)
+            .append("    throw new IllegalStateException(\"Unsupported acting version: \" + actingVersion);\n")
             .append(indent).append("}\n\n");
 
         return sb;

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/FrameCodecDecoder.java
@@ -139,15 +139,13 @@ public final class FrameCodecDecoder
 
     private void onWrap(final int actingVersion)
     {
-        switch(actingVersion)
+        if (actingVersion >= 0)
         {
-            case 0:
-                codecState(CodecStates.V0_BLOCK);
-                break;
-            default:
-                codecState(CodecStates.V0_BLOCK);
-                break;
+            codecState(CodecStates.V0_BLOCK);
+            return;
         }
+
+        throw new IllegalStateException("Unsupported acting version: " + actingVersion);
     }
 
     public FrameCodecDecoder wrap(

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecDecoder.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/ir/generated/TokenCodecDecoder.java
@@ -186,15 +186,13 @@ public final class TokenCodecDecoder
 
     private void onWrap(final int actingVersion)
     {
-        switch(actingVersion)
+        if (actingVersion >= 0)
         {
-            case 0:
-                codecState(CodecStates.V0_BLOCK);
-                break;
-            default:
-                codecState(CodecStates.V0_BLOCK);
-                break;
+            codecState(CodecStates.V0_BLOCK);
+            return;
         }
+
+        throw new IllegalStateException("Unsupported acting version: " + actingVersion);
     }
 
     public TokenCodecDecoder wrap(

--- a/sbe-tool/src/test/resources/field-order-check-schema.xml
+++ b/sbe-tool/src/test/resources/field-order-check-schema.xml
@@ -4,7 +4,7 @@
                    id="1"
                    description="Unit Test"
                    byteOrder="littleEndian"
-                   version="1">
+                   version="3">
     <types>
         <composite name="messageHeader" description="Message identifiers and length of message root">
             <type name="blockLength" primitiveType="uint16"/>
@@ -141,6 +141,7 @@
 
     <sbe:message name="AddGroupBeforeVarDataV1" id="1010">
         <field name="a" id="1" type="int32"/>
+        <!-- Not technically allowed by the v1 spec -->
         <group name="c" id="3" sinceVersion="1">
             <field name="d" id="4" type="int32"/>
         </group>
@@ -288,5 +289,44 @@
                 <data name="f" id="6" type="varDataEncoding"/>
             </group>
         </group>
+    </sbe:message>
+
+    <sbe:message name="SkipVersionAddPrimitiveV1" id="25">
+        <data name="b" id="3" type="varDataEncoding"/>
+    </sbe:message>
+
+    <sbe:message name="SkipVersionAddPrimitiveV2" id="1025">
+        <field name="a" id="1" type="int32" sinceVersion="2"/>
+        <data name="b" id="3" type="varDataEncoding"/>
+    </sbe:message>
+
+    <sbe:message name="SkipVersionAddGroupV1" id="26">
+        <field name="a" id="1" type="int32"/>
+        <data name="d" id="2" type="varDataEncoding"/>
+    </sbe:message>
+
+    <sbe:message name="SkipVersionAddGroupV2" id="1026">
+        <field name="a" id="1" type="int32"/>
+        <group name="b" id="3" sinceVersion="2">
+            <field name="c" id="4" type="int32" sinceVersion="2"/>
+        </group>
+    </sbe:message>
+
+    <sbe:message name="SkipVersionAddVarDataV1" id="27">
+        <field name="a" id="1" type="int32"/>
+    </sbe:message>
+
+    <sbe:message name="SkipVersionAddVarDataV2" id="1027">
+        <field name="a" id="1" type="int32"/>
+        <data name="b" id="2" sinceVersion="2" type="varDataEncoding"/>
+    </sbe:message>
+
+    <sbe:message name="SkipVersionAddGroupBeforeVarDataV2" id="1028">
+        <field name="a" id="1" type="int32"/>
+        <!-- Not technically allowed by the v1 spec -->
+        <group name="c" id="3" sinceVersion="2">
+            <field name="d" id="4" type="int32"/>
+        </group>
+        <data name="b" id="2" type="varDataEncoding"/>
     </sbe:message>
 </sbe:messageSchema>


### PR DESCRIPTION
Relates to issue #988.

An SBE message might not change in every version of a schema. For example, another message might change.

Previously, the field precedence checking model would expect an exact match for `actingVersion` in `wrap` to enter one of its initial states. However, it is only aware of the versions in which a message schema has changed. Therefore, it was possible for `actingVersion` not to match any of these versions, in which case the initial state that represented a codec wrapped around the latest known version of the format was picked.

Now, we do _not_ expect an exact match in `wrap`. Instead, we select the "best" match. For example, if a codec was changed in v1 and v3, and the acting version is v2, we will decode using v1. However, if the acting version is v4, we would decode as v3.