### PR TITLE
[C#] Avoid ToString() change the state of its groups

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -2367,7 +2367,8 @@ public class CSharpGenerator implements CodeGenerator
 
             append(
                 sb, indent, "builder.Append(\"" + groupName + Separators.KEY_VALUE + Separators.BEGIN_GROUP + "\");");
-            append(sb, indent, "var " + varName + " = this." + groupName + ";");
+            append(sb, indent, "var " + varName + " = new " + groupName + "Group();");
+            append(sb, indent, varName + ".WrapForDecode(_parentMessage, _buffer, _actingVersion);");
             append(sb, indent, "if (" + varName + ".Count > 0)");
             append(sb, indent, "{");
             append(sb, indent, "    var first = true;");


### PR DESCRIPTION
Hi,

I am debugging a code that uses the sbe library with VS 2022 and I find it very annoying that the debugger interfers with the program's state via the `ToString()` calls. 
The debugger calls it implicitly every now and then display data, so I don't have control over it. 

Moreover, quoting from the `ToString` documents "Notes to Inheritors": https://learn.microsoft.com/en-us/dotnet/api/system.object.tostring
* Your `ToString()` override should have no observable side effects to avoid complications in debugging. For example, a call to the `ToString()` method should not change the value of instance fields.

This PR intends to fix this.

The issue occurs when a message has a group in it.
When calling to the message's `ToString()`, the internal group is iterated and changes `_index `to `_count`.

Assuming we have a scheme containing this message:
```
<ns2:message name="Symbols" id="1" blockLength="11" semanticType="S" sinceVersion="0">
	<group name="NoSymbols" id="2" blockLength="40" dimensionType="groupSize">
		<field name="Symbol" id="3" type="Symbol" offset="0" semanticType="String"/>
	</group>
</ns2:message>
```

The decoding looks something like this:
```
Symbols symbols = new Symbols();
symbols.WrapForDecode(buffer, ...);

var noSymbols = symbols.NoSymbols;  // Get the internal group instance and reset it
symbols.ToString();                 // Debugger calls implicitly to show data
while (noSymbols.HasNext)           // Is always false since the ToString() changed the group state
{
  noSymbols.Next();
  Console.WriteLine(noSymbols.GetSymbol());
}
```
The code above is not printing anything!
Note that the `ToString()` is called on the message and not on the group.

Looking at the generated code of `BuildString`, it calls to `this.NoSymbols.Next()` which affects the state of the internal group, eventually setting `_index `to `_count`.

```
  builder.Append("NoSymbols=[");
  var noSymbols = this.NoSymbols;
  if (noSymbols.Count > 0)
  {
      var first = true;
      while (noSymbols.HasNext)
      {
          if (!first)
          {
              builder.Append(',');
          }
          first = false;
          noSymbols.Next().BuildString(builder);
      }
  }
  builder.Append("]");
```

This PR I changes the generated code so instead of using the internal group instance, it creates another one, just for the sake of `BuildString`. The updated generated code looks like this:

```
  builder.Append("NoSymbols=[");
  var noSymbols = new NoSymbolsGroup();
  noSymbols.WrapForDecode(_parentMessage, _buffer, _actingVersion);
  if (noSymbols.Count > 0)
  {
      var first = true;
      while (noSymbols.HasNext)
      {
          if (!first)
          {
              builder.Append(',');
          }
          first = false;
          noSymbols.Next().BuildString(builder);
      }
  }
  builder.Append("]");
```

The assumption is that `ToString()` is only called for logging and debugging purposes, so the extra object created shouldn't affect performance.
I tried to make smallest change possible to solve the issue at hand.

Ami