### PR TITLE
[C#] Avoid ToString() affect the message internal state

### DIFF
--- a/csharp/sbe-tests/Issue992Tests.cs
+++ b/csharp/sbe-tests/Issue992Tests.cs
@@ -1,0 +1,65 @@
+﻿using System;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Org.SbeTool.Sbe.Dll;
+using Mktdata;
+
+namespace Org.SbeTool.Sbe.Tests
+{
+  [TestClass]
+  public class Issue992Tests
+  {
+    private const int Offset = 0;
+    private DirectBuffer _buffer;
+    private MessageHeader _messageHeader;
+
+    [TestInitialize]
+    public void SetUp()
+    {
+      var byteArray = new byte[4096];
+      _buffer = new DirectBuffer(byteArray);
+
+      _messageHeader = new MessageHeader();
+
+      _messageHeader.Wrap(_buffer, 0, MessageHeader.SbeSchemaVersion);
+      _messageHeader.BlockLength = MDIncrementalRefreshBook46.BlockLength;
+      _messageHeader.SchemaId = MDIncrementalRefreshBook46.SchemaId;
+      _messageHeader.TemplateId = MDIncrementalRefreshBook46.TemplateId;
+      _messageHeader.Version = MDIncrementalRefreshBook46.SchemaVersion;
+    }
+
+    [TestMethod]
+    public void CheckToStringDontMessWithGroupIteration()
+    {
+      var encoder = new MDIncrementalRefreshBook46()
+        .WrapForEncodeAndApplyHeader(_buffer, Offset, _messageHeader);
+      encoder.TransactTime = (ulong)new DateTime(2000, 1, 1, 0, 0, 0, DateTimeKind.Utc).Ticks;
+      var noMDEntries = encoder.NoMDEntriesCount(2);
+      noMDEntries.Next();
+      noMDEntries.MDEntryPx.Mantissa = 12;
+      noMDEntries.MDEntrySize = 3;
+      noMDEntries.Next();
+      noMDEntries.MDEntryPx.Mantissa = 15;
+      noMDEntries.MDEntrySize = 7;
+      encoder.NoOrderIDEntriesCount(0);
+      encoder.CheckEncodingIsComplete();
+
+      var expectedString = "[MDIncrementalRefreshBook46](sbeTemplateId=46|sbeSchemaId=1|sbeSchemaVersion=9|sbeBlockLength=11):TransactTime=630822816000000000|MatchEventIndicator={0}|NoMDEntries=[(MDEntryPx=(Mantissa=12|)|MDEntrySize=3|SecurityID=0|RptSeq=0|NumberOfOrders=0|MDPriceLevel=0|MDUpdateAction=New|MDEntryType=NULL_VALUE),(MDEntryPx=(Mantissa=15|)|MDEntrySize=7|SecurityID=0|RptSeq=0|NumberOfOrders=0|MDPriceLevel=0|MDUpdateAction=New|MDEntryType=NULL_VALUE)]|NoOrderIDEntries=[]";
+
+      var decoder = new MDIncrementalRefreshBook46()
+        .WrapForDecodeAndApplyHeader(_buffer, Offset, _messageHeader);
+      noMDEntries = decoder.NoMDEntries;
+      Assert.AreEqual(expectedString, decoder.ToString());
+      int counter = 0;
+      while (noMDEntries.HasNext)
+      {
+        Assert.AreEqual(expectedString, decoder.ToString());
+        ++counter;
+        noMDEntries.Next();
+        Assert.AreEqual(expectedString, decoder.ToString());
+      }
+
+      Assert.AreEqual(2, counter);
+      Assert.AreEqual(expectedString, decoder.ToString());
+    }
+  }
+}

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -181,7 +181,7 @@ public class CSharpGenerator implements CodeGenerator
                 out.append(generateVarData(fieldPrecedenceModel, varData, BASE_INDENT + INDENT));
 
                 out.append(generateDisplay(toUpperFirstChar(msgToken.name()),
-                    fields, groups, varData, fieldPrecedenceModel));
+                    className, fields, groups, varData, fieldPrecedenceModel));
 
                 out.append(INDENT + "}\n");
                 out.append("}\n");
@@ -2511,13 +2511,22 @@ public class CSharpGenerator implements CodeGenerator
         return lengthBeforeFieldSeparator;
     }
 
-    private void appendToString(final StringBuilder sb, final String indent)
+    private void appendToString(final StringBuilder sb, final String indent, final String className)
     {
         sb.append('\n');
         append(sb, indent, "public override string ToString()");
         append(sb, indent, "{");
         append(sb, indent, "    var sb = new StringBuilder(100);");
-        append(sb, indent, "    this.BuildString(sb);");
+        if(null != className) 
+        {
+            append(sb, indent, "    var m = new " + className + "();");
+            append(sb, indent, "    m.WrapForDecode(_buffer, _offset, _actingBlockLength, _actingVersion);");
+            append(sb, indent, "    m.BuildString(sb);");
+        } 
+        else 
+        {
+            append(sb, indent, "    this.BuildString(sb);");
+        }
         append(sb, indent, "    return sb.ToString();");
         append(sb, indent, "}");
     }
@@ -2542,6 +2551,7 @@ public class CSharpGenerator implements CodeGenerator
 
     private CharSequence generateDisplay(
         final String name,
+        final String className,
         final List<Token> tokens,
         final List<Token> groups,
         final List<Token> varData,
@@ -2549,7 +2559,7 @@ public class CSharpGenerator implements CodeGenerator
     {
         final StringBuilder sb = new StringBuilder(100);
 
-        appendToString(sb, TWO_INDENT);
+        appendToString(sb, TWO_INDENT, className);
         sb.append('\n');
         append(sb, TWO_INDENT, "internal void BuildString(StringBuilder builder)");
         append(sb, TWO_INDENT, "{");
@@ -2607,7 +2617,7 @@ public class CSharpGenerator implements CodeGenerator
     {
         final StringBuilder sb = new StringBuilder();
 
-        appendToString(sb, TWO_INDENT);
+        appendToString(sb, TWO_INDENT, null);
         sb.append('\n');
         append(sb, TWO_INDENT, "internal void BuildString(StringBuilder builder)");
         append(sb, TWO_INDENT, "{");


### PR DESCRIPTION
Hi,

This PR intends to fix [Issue 992](https://github.com/real-logic/simple-binary-encoding/issues/992).

The current generate ToString() implementation calls to `this.BuildString()` which change `this` state.

```
public override string ToString()
{
    var sb = new StringBuilder(100);
    this.BuildString(sb);
    return sb.ToString();
}
```

To avoid the affect ton `this`, I changed the generated `ToString()` to create a new instance of the message, wrap it and then use it with `BuildString()`. This way `this` is not affected.

```
public override string ToString()
{
    var sb = new StringBuilder(100);
    var m = new GroupAndVarLength();
    m.WrapForDecode(_buffer, _offset, _actingBlockLength, _actingVersion);
    m.BuildString(sb);
    return sb.ToString();
}
```
 
The assumption is that `ToString()` is only called for logging and debugging purposes, so the extra object created doesn't affect performance.

Ami