### PR TITLE
[Go] Fix to not allocate to the heap when iterating over repeating groups …

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/golang/GolangGenerator.java
@@ -1276,8 +1276,8 @@ public class GolangGenerator implements CodeGenerator
 
         // Write the group itself
         encode.append(String.format(
-            "\tfor _, prop := range %1$s.%2$s {\n" +
-            "\t\tif err := prop.Encode(_m, _w); err != nil {\n" +
+            "\tfor i := range %1$s.%2$s {\n" +
+            "\t\tif err := %1$s.%2$s[i].Encode(_m, _w); err != nil {\n" +
             "\t\t\treturn err\n" +
             "\t\t}\n",
             varName,
@@ -1329,8 +1329,8 @@ public class GolangGenerator implements CodeGenerator
 
         // Range check the group itself
         rc.append(String.format(
-            "\tfor _, prop := range %1$s.%2$s {\n" +
-            "\t\tif err := prop.RangeCheck(actingVersion, schemaVersion); err != nil {\n" +
+            "\tfor i := range %1$s.%2$s {\n" +
+            "\t\tif err := %1$s.%2$s[i].RangeCheck(actingVersion, schemaVersion); err != nil {\n" +
             "\t\t\treturn err\n" +
             "\t\t}\n" +
             "\t}\n",


### PR DESCRIPTION
…in golang 1.22

Verify by running
```
go build -gcflags=all=-d=loopvar=2
```


When compiling in Golang 1.22, [the loop behavior has changed ](https://tip.golang.org/wiki/LoopvarExperiment#will-the-change-make-programs-slower-by-causing-more-allocations) and the code generated by SBE in Go can suddenly allocate to the heap.  

You can verify this by running 
```
go build -gcflags=all=-d=loopvar=2
```

Before the generated could would look like

```golang
	for _, prop := range m.Entries {
		if err := prop.Encode(_m, _w); err != nil {
			return err
		}
	}
```

This reference to prop could potentially allocate if prop.Encode could not be inlined.  

The new code that is generated uses the index to get the reference, which will not allocate.

```golang
	for i := range m.Entries {
		if err := m.Entries[i].Encode(_m, _w); err != nil {
			return err
		}
	}
```	