### PR TITLE
[Rust] Enhance enum supporting fromstr and display and into

### DIFF
--- a/rust/tests/baseline_enum_from_str.rs
+++ b/rust/tests/baseline_enum_from_str.rs
@@ -1,0 +1,21 @@
+use examples_baseline::{
+    boost_type::BoostType,
+};
+
+#[test]
+fn test_boost_type_from_str() -> Result<(), ()> {
+    assert_eq!("TURBO".parse::<BoostType>()?, BoostType::TURBO, "Parse \"TURBO\" as BoostType");
+    assert_eq!("SUPERCHARGER".parse::<BoostType>()?, BoostType::SUPERCHARGER, "Parse \"SUPERCHARGER\" as BoostType");
+    assert_eq!("NITROUS".parse::<BoostType>()?, BoostType::NITROUS, "Parse \"NITROUS\" as BoostType");
+    assert_eq!("KERS".parse::<BoostType>()?, BoostType::KERS, "Parse \"KERS\" as BoostType");
+
+    assert_eq!("Turbo".parse::<BoostType>()?, BoostType::NullVal, "Parse \"Turbo\" as BoostType");
+    assert_eq!("Supercharger".parse::<BoostType>()?, BoostType::NullVal, "Parse \"Supercharger\" as BoostType");
+    assert_eq!("Nitrous".parse::<BoostType>()?, BoostType::NullVal, "Parse \"Nitrous\" as BoostType");
+    assert_eq!("Kers".parse::<BoostType>()?, BoostType::NullVal, "Parse \"Kers\" as BoostType");
+
+    assert_eq!("AA".parse::<BoostType>()?, BoostType::NullVal, "Parse \"AA\" as BoostType");
+    assert_eq!("".parse::<BoostType>().unwrap(), BoostType::NullVal, "Parse \"\" as BoostType");
+
+    Ok(())
+}

--- a/rust/tests/baseline_enum_into.rs
+++ b/rust/tests/baseline_enum_into.rs
@@ -1,0 +1,14 @@
+use examples_baseline::{
+    boost_type::BoostType,
+};
+
+#[test]
+fn test_boost_type_from_str() -> Result<(), ()> {
+    assert_eq!(<BoostType as Into<u8>>::into(BoostType::TURBO), 84_u8, "BoostType::TURBO into value");
+    assert_eq!(<BoostType as Into<u8>>::into(BoostType::SUPERCHARGER), 83_u8, "BoostType::SUPERCHARGER into value");
+    assert_eq!(<BoostType as Into<u8>>::into(BoostType::NITROUS), 78_u8, "BoostType::NITROUS into value");
+    assert_eq!(<BoostType as Into<u8>>::into(BoostType::KERS), 75_u8, "BoostType::KERS into value");
+    assert_eq!(<BoostType as Into<u8>>::into(BoostType::NullVal), 0_u8, "BoostType::NullVal into value");
+
+    Ok(())
+}

--- a/rust/tests/baseline_enum_to_str.rs
+++ b/rust/tests/baseline_enum_to_str.rs
@@ -1,0 +1,14 @@
+use examples_baseline::{
+    boost_type::BoostType,
+};
+
+#[test]
+fn test_boost_type_from_str() -> Result<(), ()> {
+    assert_eq!(format!("{}", BoostType::TURBO), "TURBO", "Display \"TURBO\"");
+    assert_eq!(format!("{}", BoostType::SUPERCHARGER), "SUPERCHARGER", "Display \"SUPERCHARGER\"");
+    assert_eq!(format!("{}", BoostType::NITROUS), "NITROUS", "Display \"NITROUS\"");
+    assert_eq!(format!("{}", BoostType::KERS), "KERS", "Display \"KERS\"");
+    assert_eq!(format!("{}", BoostType::NullVal), "NullVal", "Display \"NullVal\"");
+
+    Ok(())
+}

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -1283,6 +1283,22 @@ public class RustGenerator implements CodeGenerator
         indent(writer, 2, "}\n");
         indent(writer, 1, "}\n");
         indent(writer, 0, "}\n");
+
+        // FromStr impl
+        indent(writer, 0, "impl core::str::FromStr for %s {\n", enumRustName);
+        indent(writer, 1, "type Err = ();\n\n");
+        indent(writer, 1, "#[inline]\n");
+        indent(writer, 1, "fn from_str(v: &str) -> core::result::Result<Self, Self::Err> {\n", primitiveType);
+        indent(writer, 2, "match v {\n");
+        for (final Token token : messageBody)
+        {
+            indent(writer, 3, "\"%1$s\" => core::result::Result::Ok(Self::%1$s), \n", token.name());
+        }
+        // default => NullVal
+        indent(writer, 3, "_ => core::result::Result::Ok(Self::NullVal),\n");
+        indent(writer, 2, "}\n");
+        indent(writer, 1, "}\n");
+        indent(writer, 0, "}\n");
     }
 
     private static void generateComposites(

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -1266,6 +1266,20 @@ public class RustGenerator implements CodeGenerator
         indent(writer, 0, "}\n");
 
         // From impl
+        generateFromImplForEnum(enumRustName, primitiveType, messageBody, writer);
+
+        // Into impl
+        generateIntoImplForEnum(enumRustName, primitiveType, messageBody, writer);
+
+        // FromStr impl
+        generateFromStrImplForEnum(enumRustName, primitiveType, messageBody, writer);
+
+        // Display impl
+        generateDisplayImplForEnum(enumRustName, primitiveType, messageBody, writer);
+    }
+
+    private static void generateFromImplForEnum(
+            final String enumRustName, final String primitiveType,final List<Token> messageBody, final Appendable writer) throws IOException {
         indent(writer, 0, "impl From<%s> for %s {\n", primitiveType, enumRustName);
         indent(writer, 1, "#[inline]\n");
         indent(writer, 1, "fn from(v: %s) -> Self {\n", primitiveType);
@@ -1283,8 +1297,10 @@ public class RustGenerator implements CodeGenerator
         indent(writer, 2, "}\n");
         indent(writer, 1, "}\n");
         indent(writer, 0, "}\n");
+    }
 
-        // Into impl
+    private static void generateIntoImplForEnum(
+            final String enumRustName, final String primitiveType,final List<Token> messageBody, final Appendable writer) throws IOException {
         indent(writer, 0, "impl Into<%s> for %s {\n", primitiveType, enumRustName);
         indent(writer, 1, "#[inline]\n");
         indent(writer, 1, "fn into(self) -> %s {\n", primitiveType);
@@ -1298,14 +1314,16 @@ public class RustGenerator implements CodeGenerator
         {
             final Encoding encoding = messageBody.get(0).encoding();
             final CharSequence nullVal = generateRustLiteral(encoding.primitiveType(),
-                encoding.applicableNullValue().toString());
+                    encoding.applicableNullValue().toString());
             indent(writer, 3, "Self::NullVal => %s,\n", nullVal);
         }
         indent(writer, 2, "}\n");
         indent(writer, 1, "}\n");
         indent(writer, 0, "}\n");
+    }
 
-        // FromStr impl
+    private static void generateFromStrImplForEnum(
+            final String enumRustName, final String primitiveType,final List<Token> messageBody, final Appendable writer) throws IOException{
         indent(writer, 0, "impl core::str::FromStr for %s {\n", enumRustName);
         indent(writer, 1, "type Err = ();\n\n");
         indent(writer, 1, "#[inline]\n");
@@ -1320,8 +1338,10 @@ public class RustGenerator implements CodeGenerator
         indent(writer, 2, "}\n");
         indent(writer, 1, "}\n");
         indent(writer, 0, "}\n");
+    }
 
-        // Display impl
+    private static void generateDisplayImplForEnum(
+            final String enumRustName, final String primitiveType,final List<Token> messageBody, final Appendable writer) throws IOException{
         indent(writer, 0, "impl core::fmt::Display for %s {\n", enumRustName);
         indent(writer, 1, "#[inline]\n");
         indent(writer, 1, "fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {\n", primitiveType);

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -1299,6 +1299,21 @@ public class RustGenerator implements CodeGenerator
         indent(writer, 2, "}\n");
         indent(writer, 1, "}\n");
         indent(writer, 0, "}\n");
+
+        // Display impl
+        indent(writer, 0, "impl core::fmt::Display for %s {\n", enumRustName);
+        indent(writer, 1, "#[inline]\n");
+        indent(writer, 1, "fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {\n", primitiveType);
+        indent(writer, 2, "match self {\n");
+        for (final Token token : messageBody)
+        {
+            indent(writer, 3, "Self::%1$s => write!(f, \"%1$s\"), \n", token.name());
+        }
+        // default => Err
+        indent(writer, 3, "Self::NullVal => write!(f, \"NullVal\"),\n");
+        indent(writer, 2, "}\n");
+        indent(writer, 1, "}\n");
+        indent(writer, 0, "}\n");
     }
 
     private static void generateComposites(

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -1284,6 +1284,27 @@ public class RustGenerator implements CodeGenerator
         indent(writer, 1, "}\n");
         indent(writer, 0, "}\n");
 
+        // Into impl
+        indent(writer, 0, "impl Into<%s> for %s {\n", primitiveType, enumRustName);
+        indent(writer, 1, "#[inline]\n");
+        indent(writer, 1, "fn into(self) -> %s {\n", primitiveType);
+        indent(writer, 2, "match self {\n");
+        for (final Token token : messageBody)
+        {
+            final Encoding encoding = token.encoding();
+            final String literal = generateRustLiteral(encoding.primitiveType(), encoding.constValue().toString());
+            indent(writer, 3, "Self::%s => %s, \n", token.name(), literal);
+        }
+        {
+            final Encoding encoding = messageBody.get(0).encoding();
+            final CharSequence nullVal = generateRustLiteral(encoding.primitiveType(),
+                    encoding.applicableNullValue().toString());
+            indent(writer, 3, "Self::NullVal => %s,\n", nullVal);
+        }
+        indent(writer, 2, "}\n");
+        indent(writer, 1, "}\n");
+        indent(writer, 0, "}\n");
+
         // FromStr impl
         indent(writer, 0, "impl core::str::FromStr for %s {\n", enumRustName);
         indent(writer, 1, "type Err = ();\n\n");

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -1360,7 +1360,7 @@ public class RustGenerator implements CodeGenerator
     {
         indent(writer, 0, "impl core::fmt::Display for %s {\n", enumRustName);
         indent(writer, 1, "#[inline]\n");
-        indent(writer, 1, "fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {\n", primitiveType);
+        indent(writer, 1, "fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {\n");
         indent(writer, 2, "match self {\n");
         for (final Token token : messageBody)
         {

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -1298,7 +1298,7 @@ public class RustGenerator implements CodeGenerator
         {
             final Encoding encoding = messageBody.get(0).encoding();
             final CharSequence nullVal = generateRustLiteral(encoding.primitiveType(),
-                    encoding.applicableNullValue().toString());
+                encoding.applicableNullValue().toString());
             indent(writer, 3, "Self::NullVal => %s,\n", nullVal);
         }
         indent(writer, 2, "}\n");

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -1279,7 +1279,11 @@ public class RustGenerator implements CodeGenerator
     }
 
     private static void generateFromImplForEnum(
-            final String enumRustName, final String primitiveType,final List<Token> messageBody, final Appendable writer) throws IOException {
+        final String enumRustName,
+        final String primitiveType,
+        final List<Token> messageBody,
+        final Appendable writer) throws IOException
+    {
         indent(writer, 0, "impl From<%s> for %s {\n", primitiveType, enumRustName);
         indent(writer, 1, "#[inline]\n");
         indent(writer, 1, "fn from(v: %s) -> Self {\n", primitiveType);
@@ -1300,7 +1304,11 @@ public class RustGenerator implements CodeGenerator
     }
 
     private static void generateIntoImplForEnum(
-            final String enumRustName, final String primitiveType,final List<Token> messageBody, final Appendable writer) throws IOException {
+        final String enumRustName,
+        final String primitiveType,
+        final List<Token> messageBody,
+        final Appendable writer) throws IOException
+    {
         indent(writer, 0, "impl Into<%s> for %s {\n", primitiveType, enumRustName);
         indent(writer, 1, "#[inline]\n");
         indent(writer, 1, "fn into(self) -> %s {\n", primitiveType);
@@ -1314,7 +1322,7 @@ public class RustGenerator implements CodeGenerator
         {
             final Encoding encoding = messageBody.get(0).encoding();
             final CharSequence nullVal = generateRustLiteral(encoding.primitiveType(),
-                    encoding.applicableNullValue().toString());
+                encoding.applicableNullValue().toString());
             indent(writer, 3, "Self::NullVal => %s,\n", nullVal);
         }
         indent(writer, 2, "}\n");
@@ -1323,7 +1331,11 @@ public class RustGenerator implements CodeGenerator
     }
 
     private static void generateFromStrImplForEnum(
-            final String enumRustName, final String primitiveType,final List<Token> messageBody, final Appendable writer) throws IOException{
+        final String enumRustName,
+        final String primitiveType,
+        final List<Token> messageBody,
+        final Appendable writer) throws IOException
+    {
         indent(writer, 0, "impl core::str::FromStr for %s {\n", enumRustName);
         indent(writer, 1, "type Err = ();\n\n");
         indent(writer, 1, "#[inline]\n");
@@ -1341,7 +1353,11 @@ public class RustGenerator implements CodeGenerator
     }
 
     private static void generateDisplayImplForEnum(
-            final String enumRustName, final String primitiveType,final List<Token> messageBody, final Appendable writer) throws IOException{
+        final String enumRustName,
+        final String primitiveType,
+        final List<Token> messageBody,
+        final Appendable writer) throws IOException
+    {
         indent(writer, 0, "impl core::fmt::Display for %s {\n", enumRustName);
         indent(writer, 1, "#[inline]\n");
         indent(writer, 1, "fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {\n", primitiveType);

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -1339,7 +1339,7 @@ public class RustGenerator implements CodeGenerator
         indent(writer, 0, "impl core::str::FromStr for %s {\n", enumRustName);
         indent(writer, 1, "type Err = ();\n\n");
         indent(writer, 1, "#[inline]\n");
-        indent(writer, 1, "fn from_str(v: &str) -> core::result::Result<Self, Self::Err> {\n", primitiveType);
+        indent(writer, 1, "fn from_str(v: &str) -> core::result::Result<Self, Self::Err> {\n");
         indent(writer, 2, "match v {\n");
         for (final Token token : messageBody)
         {


### PR DESCRIPTION
This pr intended to make generated enum items impl FromStr and Display and Into trait.

Usually an enum (in or not in trading) may have two different usecases: either for integer-compitible values (like Side/OrderType) or for string values (like Market).  It's very kind to generate conversion helper for generated Rust enum types.  Currently only `From` was impl for enum types.

1. FromStr trait

    Consider a Market enum:

    ```rust
    enum Market {
    XSHE, XSHG, 
    }
    ```

    A `str` to `Market` conversion was usually needed when dealing with external system.

3. Display trait

    See above `Market` enum, a `Display` trait impl was helpful when converting to meaningful string representation for display or presentation purpose.

4. Into trait
    
    As a reverse op of `From`, it is also helpful to get sensible storing data into DB or something similar.