### PR TITLE
[Rust] generate slice ref setter in Encoder for fixed size array

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -654,6 +654,7 @@ tasks.register('generateRustTestCodecs', JavaExec) {
             'sbe-tool/src/test/resources/issue984.xml',
             'sbe-tool/src/test/resources/issue987.xml',
             'sbe-tool/src/test/resources/issue1028.xml',
+            'sbe-tool/src/test/resources/fixed-sized-primitive-array-types.xml',
             'sbe-tool/src/test/resources/example-bigendian-test-schema.xml',
             'sbe-tool/src/test/resources/nested-composite-name.xml',
     ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,6 +19,7 @@ issue_987 = { path = "../generated/rust/issue987" }
 issue_1028 = { path = "../generated/rust/issue1028" }
 baseline_bigendian = { path = "../generated/rust/baseline-bigendian" }
 nested_composite_name = { path = "../generated/rust/nested-composite-name" }
+fixed_sized_primitive_array = { path = "../generated/rust/fixed_sized_primitive_array" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/rust/tests/fixed_sized_primitive_array.rs
+++ b/rust/tests/fixed_sized_primitive_array.rs
@@ -1,0 +1,511 @@
+use fixed_sized_primitive_array::{
+    demo_codec::{DemoDecoder, DemoEncoder},
+    message_header_codec::{MessageHeaderDecoder, ENCODED_LENGTH},
+    ReadBuf, WriteBuf,
+};
+
+fn create_encoder(buffer: &mut Vec<u8>) -> DemoEncoder {
+    let encoder = DemoEncoder::default().wrap(WriteBuf::new(buffer.as_mut_slice()), ENCODED_LENGTH);
+    let mut header = encoder.header(0);
+    header.parent().unwrap()
+}
+
+#[test]
+fn test_encode_then_decode_u8_slice() {
+    let test_data = [
+        b"" as &[u8],
+        b"0" as &[u8],
+        b"01" as &[u8],
+        b"012" as &[u8],
+        b"0123" as &[u8],
+        b"01234" as &[u8],
+        b"012345" as &[u8],
+        b"0123456" as &[u8],
+        b"01234567" as &[u8],
+        b"012345678" as &[u8],
+        b"0123456789" as &[u8],
+        b"0123456789A" as &[u8],
+        b"0123456789AB" as &[u8],
+        b"0123456789ABC" as &[u8],
+        b"0123456789ABCD" as &[u8],
+        b"0123456789ABCDE" as &[u8],
+        b"0123456789ABCDEF" as &[u8],
+        b"0123456789abcdef" as &[u8],
+        b"0123456789abcdef0" as &[u8],
+        b"0123456789abcdef01" as &[u8],
+        b"0123456789abcdef012" as &[u8],
+        b"0123456789abcdef0123" as &[u8],
+        b"0123456789abcdef01234" as &[u8],
+        b"0123456789abcdef012345" as &[u8],
+        b"0123456789abcdef0123456" as &[u8],
+        b"0123456789abcdef01234567" as &[u8],
+        b"0123456789abcdef012345678" as &[u8],
+        b"0123456789abcdef0123456789" as &[u8],
+        b"0123456789abcdef0123456789A" as &[u8],
+        b"0123456789abcdef0123456789AB" as &[u8],
+        b"0123456789abcdef0123456789ABC" as &[u8],
+        b"0123456789abcdef0123456789ABCD" as &[u8],
+        b"0123456789abcdef0123456789ABCDE" as &[u8],
+        b"0123456789abcdef0123456789ABCDEF" as &[u8],
+    ];
+
+    // <field name="fixed16Char" id="1" type="Fixed16Char"/>
+    // <field name="fixed16AsciiChar" id="2" type="Fixed16AsciiChar"/>
+    // <field name="fixed16Gb18030Char" id="3" type="Fixed16Gb18030Char"/>
+    // <field name="fixed16Utf8Char" id="4" type="Fixed16Utf8Char"/>
+    // <field name="fixed16U8" id="11" type="Fixed16U8"/>
+    // <field name="fixed16AsciiU8" id="12" type="Fixed16AsciiU8"/>
+    // <field name="fixed16Gb18030U8" id="13" type="Fixed16Gb18030U8"/>
+    // <field name="fixed16Utf8U8" id="14" type="Fixed16Utf8U8"/>
+    macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
+        ($encode_func:expr, $decode_func:expr, $i_null:expr) => {
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = vec![1u8; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, each_slice);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx], decoded[each_idx],
+                        "Item mismatched at {}/{}",
+                        each_idx, cur_len
+                    );
+                }
+                let null_value = $i_null;
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx], null_value,
+                        "Item should be NULL at {}/{}",
+                        each_idx, cur_len
+                    );
+                }
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_char_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_char,
+        0
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_ascii_char_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_ascii_char,
+        0
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_gb_18030_char_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_gb_18030_char,
+        0
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_utf_8_char_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_utf_8_char,
+        0
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_u8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_u8,
+        u8::MAX
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_ascii_u8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_ascii_u8,
+        u8::MAX
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_gb_18030_u8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_gb_18030_u8,
+        u8::MAX
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_utf_8_u8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_utf_8_u8,
+        u8::MAX
+    );
+}
+
+#[test]
+fn test_encode_then_decode_non_u8_signed_primitive_slice() {
+    // <field name="fixed16i8" id="21" type="Fixed16i8"/>
+    // <field name="fixed16i16" id="22" type="Fixed16i16"/>
+    // <field name="fixed16i32" id="23" type="Fixed16i32"/>
+    // <field name="fixed16i64" id="24" type="Fixed16i64"/>
+    macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
+        ($encode_func:expr, $decode_func:expr, $i_type:ty, $i_null:expr) => {
+            let test_data = [
+                &[] as &[$i_type],
+                &[1 as $i_type] as &[$i_type],
+                &[0 as $i_type] as &[$i_type],
+                &[-1 as $i_type] as &[$i_type],
+                &[-1, 1 as $i_type] as &[$i_type],
+                &[-1, 0, 1 as $i_type] as &[$i_type],
+                &[-2, -1, 1, 2 as $i_type] as &[$i_type],
+                &[-2, -1, 0, 1, 2 as $i_type] as &[$i_type],
+                &[-3, -2, -1, 1, 2, 3 as $i_type] as &[$i_type],
+                &[-3, -2, -1, 0, 1, 2, 3 as $i_type] as &[$i_type],
+                &[-4, -3, -2, -1, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[-4, -3, -2, -1, 0, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[-5, -4, -3, -2, -1, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[-6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[-7, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 7 as $i_type] as &[$i_type],
+                &[
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -9,
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -9,
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+            ];
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = vec![1u8; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, &each_slice);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx],
+                        decoded[each_idx],
+                        "Item mismatched at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+                let null_value = $i_null;
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx],
+                        null_value,
+                        "Item should be null at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_i8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_i8,
+        i8,
+        i8::MIN
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_i16_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_i16,
+        i16,
+        i16::MIN
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_i32_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_i32,
+        i32,
+        i32::MIN
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_i64_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_i64,
+        i64,
+        i64::MIN
+    );
+}
+
+#[test]
+fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
+    // <field name="fixed16u16" id="32" type="Fixed16u16"/>
+    // <field name="fixed16u32" id="33" type="Fixed16u32"/>
+    macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
+        ($encode_func:expr, $decode_func:expr, $i_type:ty, $i_null:expr) => {
+            let test_data = [
+                &[] as &[$i_type],
+                &[1 as $i_type] as &[$i_type],
+                &[0 as $i_type] as &[$i_type],
+                &[11 as $i_type] as &[$i_type],
+                &[11, 1 as $i_type] as &[$i_type],
+                &[11, 0, 1 as $i_type] as &[$i_type],
+                &[12, 11, 1, 2 as $i_type] as &[$i_type],
+                &[12, 11, 0, 1, 2 as $i_type] as &[$i_type],
+                &[13, 12, 11, 1, 2, 3 as $i_type] as &[$i_type],
+                &[13, 12, 11, 0, 1, 2, 3 as $i_type] as &[$i_type],
+                &[14, 13, 12, 11, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[14, 13, 12, 11, 0, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[15, 14, 13, 12, 11, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[15, 14, 13, 12, 11, 0, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[16, 15, 14, 13, 12, 11, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[16, 15, 14, 13, 12, 11, 0, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[17, 16, 15, 14, 13, 12, 11, 1, 2, 3, 4, 5, 6, 7 as $i_type] as &[$i_type],
+                &[
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7 as $i_type,
+                ] as &[$i_type],
+                &[
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    19,
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+                &[
+                    19,
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+            ];
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = vec![1u8; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, &each_slice);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx],
+                        decoded[each_idx],
+                        "Item mismatched at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+                let null_value = $i_null;
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx],
+                        null_value,
+                        "Item should be null at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_u16_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_u16,
+        u16,
+        u16::MAX
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_u32_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_u32,
+        u32,
+        u32::MAX
+    );
+    // run_encode_then_decode_for_array_of_u8_len_16!(DemoEncoder::fixed_16_u64_at_most_16_items_from_slice, DemoDecoder::fixed_16_i64, i64, u64::MAX);
+}

--- a/rust/tests/fixed_sized_primitive_array.rs
+++ b/rust/tests/fixed_sized_primitive_array.rs
@@ -4,14 +4,16 @@ use fixed_sized_primitive_array::{
     ReadBuf, WriteBuf,
 };
 
-fn create_encoder(buffer: &mut Vec<u8>) -> DemoEncoder {
-    let encoder = DemoEncoder::default().wrap(WriteBuf::new(buffer.as_mut_slice()), ENCODED_LENGTH);
+fn create_encoder(buffer: &mut [u8]) -> DemoEncoder {
+    let encoder = DemoEncoder::default().wrap(WriteBuf::new(buffer), ENCODED_LENGTH);
     let mut header = encoder.header(0);
     header.parent().unwrap()
 }
 
 #[test]
 fn test_encode_then_decode_u8_slice() {
+    let uninit = 1u8;
+
     let test_data = [
         b"" as &[u8],
         b"0" as &[u8],
@@ -58,19 +60,578 @@ fn test_encode_then_decode_u8_slice() {
     // <field name="fixed16Gb18030U8" id="13" type="Fixed16Gb18030U8"/>
     // <field name="fixed16Utf8U8" id="14" type="Fixed16Utf8U8"/>
     macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
-        ($encode_func:expr, $decode_func:expr) => {
+        ($encode_func:expr, $decode_func:expr, $end_encode_func:expr, $end_decode_func:expr) => {
             for each_slice in test_data {
                 let encode_func = $encode_func;
                 let decode_func = $decode_func;
+                let end_encode_func = $end_encode_func;
+                let end_decode_func = $end_decode_func;
 
                 let cur_len = each_slice.len();
                 let effective_len = cur_len.min(16);
 
                 // encode...
-                let mut buffer = vec![0u8; 1024];
+                let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
                 encode_func(&mut encoder, each_slice);
+
+                let end = 1i32;
+                end_encode_func(&mut encoder, end);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx], decoded[each_idx],
+                        "Item mismatched at {}/{}",
+                        each_idx, cur_len
+                    );
+                }
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx], uninit,
+                        "Item should not be padded ZERO at {}/{}",
+                        each_idx, cur_len
+                    );
+                }
+                let decoded_end = end_decode_func(&decoder);
+                assert_eq!(decoded_end, end, "End Item should equal",);
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_char_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_char,
+        DemoEncoder::fixed_16_char_end,
+        DemoDecoder::fixed_16_char_end
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_ascii_char_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_ascii_char,
+        DemoEncoder::fixed_16_ascii_char_end,
+        DemoDecoder::fixed_16_ascii_char_end
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_gb_18030_char_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_gb_18030_char,
+        DemoEncoder::fixed_16_gb_18030_char_end,
+        DemoDecoder::fixed_16_gb_18030_char_end
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_utf_8_char_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_utf_8_char,
+        DemoEncoder::fixed_16_utf_8_char_end,
+        DemoDecoder::fixed_16_utf_8_char_end
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_u8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_u8,
+        DemoEncoder::fixed_16_u8_end,
+        DemoDecoder::fixed_16_u8_end
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_ascii_u8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_ascii_u8,
+        DemoEncoder::fixed_16_ascii_u8_end,
+        DemoDecoder::fixed_16_ascii_u8_end
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_gb_18030_u8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_gb_18030_u8,
+        DemoEncoder::fixed_16_gb_18030_u8_end,
+        DemoDecoder::fixed_16_gb_18030_u8_end
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_utf_8_u8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_utf_8_u8,
+        DemoEncoder::fixed_16_utf_8u_8_end,
+        DemoDecoder::fixed_16_utf_8u_8_end
+    );
+}
+
+#[test]
+fn test_encode_then_decode_non_u8_signed_primitive_slice() {
+    let uninit = 1u8;
+
+    // <field name="fixed16i8" id="21" type="Fixed16i8"/>
+    // <field name="fixed16i16" id="22" type="Fixed16i16"/>
+    // <field name="fixed16i32" id="23" type="Fixed16i32"/>
+    // <field name="fixed16i64" id="24" type="Fixed16i64"/>
+    macro_rules! run_encode_then_decode_for_array_of_signed_len_16 {
+        ($encode_func:expr, $decode_func:expr, $end_encode_func:expr, $end_decode_func:expr, $i_type:ty, $existed:expr) => {
+            let test_data = [
+                &[] as &[$i_type],
+                &[1 as $i_type] as &[$i_type],
+                &[0 as $i_type] as &[$i_type],
+                &[-1 as $i_type] as &[$i_type],
+                &[-1, 1 as $i_type] as &[$i_type],
+                &[-1, 0, 1 as $i_type] as &[$i_type],
+                &[-2, -1, 1, 2 as $i_type] as &[$i_type],
+                &[-2, -1, 0, 1, 2 as $i_type] as &[$i_type],
+                &[-3, -2, -1, 1, 2, 3 as $i_type] as &[$i_type],
+                &[-3, -2, -1, 0, 1, 2, 3 as $i_type] as &[$i_type],
+                &[-4, -3, -2, -1, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[-4, -3, -2, -1, 0, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[-5, -4, -3, -2, -1, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[-6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[-7, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 7 as $i_type] as &[$i_type],
+                &[
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -9,
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -9,
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+            ];
+
+            let existed = $existed;
+
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+                let end_encode_func = $end_encode_func;
+                let end_decode_func = $end_decode_func;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = [uninit; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, &each_slice);
+
+                let end = 1i32;
+                end_encode_func(&mut encoder, end);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx],
+                        decoded[each_idx],
+                        "Item mismatched at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx],
+                        existed,
+                        "Item should not be padded ZERO at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+                let decoded_end = end_decode_func(&decoder);
+                assert_eq!(decoded_end, end, "End Item should equal",);
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_signed_len_16!(
+        DemoEncoder::fixed_16_i8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_i8,
+        DemoEncoder::fixed_16_i8_end,
+        DemoDecoder::fixed_16_i8_end,
+        i8, i8::from_le_bytes([uninit])
+    );
+    run_encode_then_decode_for_array_of_signed_len_16!(
+        DemoEncoder::fixed_16_i16_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_i16,
+        DemoEncoder::fixed_16_i16_end,
+        DemoDecoder::fixed_16_i16_end,
+        i16, i16::from_le_bytes([uninit, uninit])
+    );
+    run_encode_then_decode_for_array_of_signed_len_16!(
+        DemoEncoder::fixed_16_i32_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_i32,
+        DemoEncoder::fixed_16_i32_end,
+        DemoDecoder::fixed_16_i32_end,
+        i32, i32::from_le_bytes([uninit, uninit, uninit, uninit])
+    );
+    run_encode_then_decode_for_array_of_signed_len_16!(
+        DemoEncoder::fixed_16_i64_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_i64,
+        DemoEncoder::fixed_16_i64_end,
+        DemoDecoder::fixed_16_i64_end,
+        i64, i64::from_le_bytes([uninit, uninit, uninit, uninit, uninit, uninit, uninit, uninit])
+    );
+}
+
+#[test]
+fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
+    let uninit = 1u8;
+
+    // <field name="fixed16u16" id="32" type="Fixed16u16"/>
+    // <field name="fixed16u32" id="33" type="Fixed16u32"/>
+    macro_rules! run_encode_then_decode_for_array_of_unsigned_len_16 {
+        ($encode_func:expr, $decode_func:expr, $end_encode_func:expr, $end_decode_func:expr, $i_type:ty, $existed:expr) => {
+            let test_data = [
+                &[] as &[$i_type],
+                &[1 as $i_type] as &[$i_type],
+                &[0 as $i_type] as &[$i_type],
+                &[11 as $i_type] as &[$i_type],
+                &[11, 1 as $i_type] as &[$i_type],
+                &[11, 0, 1 as $i_type] as &[$i_type],
+                &[12, 11, 1, 2 as $i_type] as &[$i_type],
+                &[12, 11, 0, 1, 2 as $i_type] as &[$i_type],
+                &[13, 12, 11, 1, 2, 3 as $i_type] as &[$i_type],
+                &[13, 12, 11, 0, 1, 2, 3 as $i_type] as &[$i_type],
+                &[14, 13, 12, 11, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[14, 13, 12, 11, 0, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[15, 14, 13, 12, 11, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[15, 14, 13, 12, 11, 0, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[16, 15, 14, 13, 12, 11, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[16, 15, 14, 13, 12, 11, 0, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[17, 16, 15, 14, 13, 12, 11, 1, 2, 3, 4, 5, 6, 7 as $i_type] as &[$i_type],
+                &[
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7 as $i_type,
+                ] as &[$i_type],
+                &[
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    19,
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+                &[
+                    19,
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+            ];
+
+            let existed = $existed;
+
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+                let end_encode_func = $end_encode_func;
+                let end_decode_func = $end_decode_func;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = [uninit; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, each_slice);
+
+                let end = 1i32;
+                end_encode_func(&mut encoder, end);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx],
+                        decoded[each_idx],
+                        "Item mismatched at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx],
+                        existed,
+                        "Item should not be padded ZERO at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+                let decoded_end = end_decode_func(&decoder);
+                assert_eq!(decoded_end, end, "End Item should equal",);
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
+        DemoEncoder::fixed_16_u16_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_u16,
+        DemoEncoder::fixed_16_u16_end,
+        DemoDecoder::fixed_16_u16_end,
+        u16,
+        u16::from_le_bytes([uninit, uninit])
+    );
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
+        DemoEncoder::fixed_16_u32_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_u32,
+        DemoEncoder::fixed_16_u32_end,
+        DemoDecoder::fixed_16_u32_end,
+        u32,
+        u32::from_le_bytes([uninit, uninit, uninit, uninit])
+    );
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
+        DemoEncoder::fixed_16_u64_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_u64,
+        DemoEncoder::fixed_16_u64_end,
+        DemoDecoder::fixed_16_u64_end,
+        u64,
+        u64::from_le_bytes([uninit, uninit, uninit, uninit, uninit, uninit, uninit, uninit])
+    );
+}
+
+#[test]
+fn test_encode_then_decode_u8_slice_padded() {
+    let uninit = 1u8;
+
+    let test_data = [
+        b"" as &[u8],
+        b"0" as &[u8],
+        b"01" as &[u8],
+        b"012" as &[u8],
+        b"0123" as &[u8],
+        b"01234" as &[u8],
+        b"012345" as &[u8],
+        b"0123456" as &[u8],
+        b"01234567" as &[u8],
+        b"012345678" as &[u8],
+        b"0123456789" as &[u8],
+        b"0123456789A" as &[u8],
+        b"0123456789AB" as &[u8],
+        b"0123456789ABC" as &[u8],
+        b"0123456789ABCD" as &[u8],
+        b"0123456789ABCDE" as &[u8],
+        b"0123456789ABCDEF" as &[u8],
+        b"0123456789abcdef" as &[u8],
+        b"0123456789abcdef0" as &[u8],
+        b"0123456789abcdef01" as &[u8],
+        b"0123456789abcdef012" as &[u8],
+        b"0123456789abcdef0123" as &[u8],
+        b"0123456789abcdef01234" as &[u8],
+        b"0123456789abcdef012345" as &[u8],
+        b"0123456789abcdef0123456" as &[u8],
+        b"0123456789abcdef01234567" as &[u8],
+        b"0123456789abcdef012345678" as &[u8],
+        b"0123456789abcdef0123456789" as &[u8],
+        b"0123456789abcdef0123456789A" as &[u8],
+        b"0123456789abcdef0123456789AB" as &[u8],
+        b"0123456789abcdef0123456789ABC" as &[u8],
+        b"0123456789abcdef0123456789ABCD" as &[u8],
+        b"0123456789abcdef0123456789ABCDE" as &[u8],
+        b"0123456789abcdef0123456789ABCDEF" as &[u8],
+    ];
+
+    // <field name="fixed16Char" id="1" type="Fixed16Char"/>
+    // <field name="fixed16AsciiChar" id="2" type="Fixed16AsciiChar"/>
+    // <field name="fixed16Gb18030Char" id="3" type="Fixed16Gb18030Char"/>
+    // <field name="fixed16Utf8Char" id="4" type="Fixed16Utf8Char"/>
+    // <field name="fixed16U8" id="11" type="Fixed16U8"/>
+    // <field name="fixed16AsciiU8" id="12" type="Fixed16AsciiU8"/>
+    // <field name="fixed16Gb18030U8" id="13" type="Fixed16Gb18030U8"/>
+    // <field name="fixed16Utf8U8" id="14" type="Fixed16Utf8U8"/>
+    macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
+        ($encode_func:expr, $decode_func:expr, $end_encode_func:expr, $end_decode_func:expr,) => {
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+                let end_encode_func = $end_encode_func;
+                let end_decode_func = $end_decode_func;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = [uninit; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, each_slice);
+
+                let end = 1i32;
+                end_encode_func(&mut encoder, end);
 
                 // decode...
                 let buf = ReadBuf::new(buffer.as_slice());
@@ -88,552 +649,76 @@ fn test_encode_then_decode_u8_slice() {
                 for each_idx in effective_len..16 {
                     assert_eq!(
                         decoded[each_idx], 0,
-                        "Item should be ZERO at {}/{}",
+                        "Item should be padded ZERO at {}/{}",
                         each_idx, cur_len
                     );
                 }
+                let decoded_end = end_decode_func(&decoder);
+                assert_eq!(decoded_end, end, "End Item should equal",);
             }
         };
     }
 
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_char_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_char
-    );
-    run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_ascii_char_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_ascii_char
-    );
-    run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_gb_18030_char_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_gb_18030_char
-    );
-    run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_utf_8_char_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_utf_8_char
-    );
-    run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_u8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_u8
-    );
-    run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_ascii_u8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_ascii_u8
-    );
-    run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_gb_18030_u8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_gb_18030_u8
-    );
-    run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_utf_8_u8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_utf_8_u8
-    );
-}
-
-#[test]
-fn test_encode_then_decode_non_u8_signed_primitive_slice() {
-    // <field name="fixed16i8" id="21" type="Fixed16i8"/>
-    // <field name="fixed16i16" id="22" type="Fixed16i16"/>
-    // <field name="fixed16i32" id="23" type="Fixed16i32"/>
-    // <field name="fixed16i64" id="24" type="Fixed16i64"/>
-    macro_rules! run_encode_then_decode_for_array_of_signed_len_16 {
-        ($encode_func:expr, $decode_func:expr, $i_type:ty) => {
-            let test_data = [
-                &[] as &[$i_type],
-                &[1 as $i_type] as &[$i_type],
-                &[0 as $i_type] as &[$i_type],
-                &[-1 as $i_type] as &[$i_type],
-                &[-1, 1 as $i_type] as &[$i_type],
-                &[-1, 0, 1 as $i_type] as &[$i_type],
-                &[-2, -1, 1, 2 as $i_type] as &[$i_type],
-                &[-2, -1, 0, 1, 2 as $i_type] as &[$i_type],
-                &[-3, -2, -1, 1, 2, 3 as $i_type] as &[$i_type],
-                &[-3, -2, -1, 0, 1, 2, 3 as $i_type] as &[$i_type],
-                &[-4, -3, -2, -1, 1, 2, 3, 4 as $i_type] as &[$i_type],
-                &[-4, -3, -2, -1, 0, 1, 2, 3, 4 as $i_type] as &[$i_type],
-                &[-5, -4, -3, -2, -1, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
-                &[-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
-                &[-6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
-                &[-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
-                &[-7, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 7 as $i_type] as &[$i_type],
-                &[
-                    -7,
-                    -6,
-                    -5,
-                    -4,
-                    -3,
-                    -2,
-                    -1,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7 as $i_type,
-                ] as &[$i_type],
-                &[
-                    -8,
-                    -7,
-                    -6,
-                    -5,
-                    -4,
-                    -3,
-                    -2,
-                    -1,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8 as $i_type,
-                ] as &[$i_type],
-                &[
-                    -8,
-                    -7,
-                    -6,
-                    -5,
-                    -4,
-                    -3,
-                    -2,
-                    -1,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8 as $i_type,
-                ] as &[$i_type],
-                &[
-                    -9,
-                    -8,
-                    -7,
-                    -6,
-                    -5,
-                    -4,
-                    -3,
-                    -2,
-                    -1,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8,
-                    9 as $i_type,
-                ] as &[$i_type],
-                &[
-                    -9,
-                    -8,
-                    -7,
-                    -6,
-                    -5,
-                    -4,
-                    -3,
-                    -2,
-                    -1,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8,
-                    9 as $i_type,
-                ] as &[$i_type],
-            ];
-            for each_slice in test_data {
-                let encode_func = $encode_func;
-                let decode_func = $decode_func;
-
-                let cur_len = each_slice.len();
-                let effective_len = cur_len.min(16);
-
-                // encode...
-                let mut buffer = vec![0u8; 1024];
-                let mut encoder = create_encoder(&mut buffer);
-
-                encode_func(&mut encoder, &each_slice);
-
-                // decode...
-                let buf = ReadBuf::new(buffer.as_slice());
-                let header = MessageHeaderDecoder::default().wrap(buf, 0);
-
-                let decoder = DemoDecoder::default().header(header, 0);
-                let decoded = decode_func(&decoder);
-                for each_idx in 0..effective_len {
-                    assert_eq!(
-                        each_slice[each_idx],
-                        decoded[each_idx],
-                        "Item mismatched at {}/{} for {}",
-                        each_idx,
-                        cur_len,
-                        stringify!($i_type)
-                    );
-                }
-                for each_idx in effective_len..16 {
-                    assert_eq!(
-                        decoded[each_idx],
-                        0,
-                        "Item should be ZERO at {}/{} for {}",
-                        each_idx,
-                        cur_len,
-                        stringify!($i_type)
-                    );
-                }
-            }
-        };
-    }
-
-    run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_i8,
-        i8
-    );
-    run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i16_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_i16,
-        i16
-    );
-    run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i32_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_i32,
-        i32
-    );
-    run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i64_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_i64,
-        i64
-    );
-}
-
-#[test]
-fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
-    // <field name="fixed16u16" id="32" type="Fixed16u16"/>
-    // <field name="fixed16u32" id="33" type="Fixed16u32"/>
-    macro_rules! run_encode_then_decode_for_array_of_unsigned_len_16 {
-        ($encode_func:expr, $decode_func:expr, $i_type:ty) => {
-            let test_data = [
-                &[] as &[$i_type],
-                &[1 as $i_type] as &[$i_type],
-                &[0 as $i_type] as &[$i_type],
-                &[11 as $i_type] as &[$i_type],
-                &[11, 1 as $i_type] as &[$i_type],
-                &[11, 0, 1 as $i_type] as &[$i_type],
-                &[12, 11, 1, 2 as $i_type] as &[$i_type],
-                &[12, 11, 0, 1, 2 as $i_type] as &[$i_type],
-                &[13, 12, 11, 1, 2, 3 as $i_type] as &[$i_type],
-                &[13, 12, 11, 0, 1, 2, 3 as $i_type] as &[$i_type],
-                &[14, 13, 12, 11, 1, 2, 3, 4 as $i_type] as &[$i_type],
-                &[14, 13, 12, 11, 0, 1, 2, 3, 4 as $i_type] as &[$i_type],
-                &[15, 14, 13, 12, 11, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
-                &[15, 14, 13, 12, 11, 0, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
-                &[16, 15, 14, 13, 12, 11, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
-                &[16, 15, 14, 13, 12, 11, 0, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
-                &[17, 16, 15, 14, 13, 12, 11, 1, 2, 3, 4, 5, 6, 7 as $i_type] as &[$i_type],
-                &[
-                    17,
-                    16,
-                    15,
-                    14,
-                    13,
-                    12,
-                    11,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7 as $i_type,
-                ] as &[$i_type],
-                &[
-                    18,
-                    17,
-                    16,
-                    15,
-                    14,
-                    13,
-                    12,
-                    11,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8 as $i_type,
-                ] as &[$i_type],
-                &[
-                    18,
-                    17,
-                    16,
-                    15,
-                    14,
-                    13,
-                    12,
-                    11,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8 as $i_type,
-                ] as &[$i_type],
-                &[
-                    19,
-                    18,
-                    17,
-                    16,
-                    15,
-                    14,
-                    13,
-                    12,
-                    11,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8,
-                    9 as $i_type,
-                ] as &[$i_type],
-                &[
-                    19,
-                    18,
-                    17,
-                    16,
-                    15,
-                    14,
-                    13,
-                    12,
-                    11,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8,
-                    9 as $i_type,
-                ] as &[$i_type],
-            ];
-            for each_slice in test_data {
-                let encode_func = $encode_func;
-                let decode_func = $decode_func;
-
-                let cur_len = each_slice.len();
-                let effective_len = cur_len.min(16);
-
-                // encode...
-                let mut buffer = vec![0u8; 1024];
-                let mut encoder = create_encoder(&mut buffer);
-
-                encode_func(&mut encoder, each_slice);
-
-                // decode...
-                let buf = ReadBuf::new(buffer.as_slice());
-                let header = MessageHeaderDecoder::default().wrap(buf, 0);
-
-                let decoder = DemoDecoder::default().header(header, 0);
-                let decoded = decode_func(&decoder);
-                for each_idx in 0..effective_len {
-                    assert_eq!(
-                        each_slice[each_idx],
-                        decoded[each_idx],
-                        "Item mismatched at {}/{} for {}",
-                        each_idx,
-                        cur_len,
-                        stringify!($i_type)
-                    );
-                }
-                for each_idx in effective_len..16 {
-                    assert_eq!(
-                        decoded[each_idx],
-                        0,
-                        "Item should be ZERO at {}/{} for {}",
-                        each_idx,
-                        cur_len,
-                        stringify!($i_type)
-                    );
-                }
-            }
-        };
-    }
-
-    run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u16_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_u16,
-        u16
-    );
-    run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u32_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_u32,
-        u32
-    );
-    run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u64_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_u64,
-        u64
-    );
-}
-
-#[test]
-fn test_encode_then_decode_u8_slice_padded() {
-    let test_data = [
-        b"" as &[u8],
-        b"0" as &[u8],
-        b"01" as &[u8],
-        b"012" as &[u8],
-        b"0123" as &[u8],
-        b"01234" as &[u8],
-        b"012345" as &[u8],
-        b"0123456" as &[u8],
-        b"01234567" as &[u8],
-        b"012345678" as &[u8],
-        b"0123456789" as &[u8],
-        b"0123456789A" as &[u8],
-        b"0123456789AB" as &[u8],
-        b"0123456789ABC" as &[u8],
-        b"0123456789ABCD" as &[u8],
-        b"0123456789ABCDE" as &[u8],
-        b"0123456789ABCDEF" as &[u8],
-        b"0123456789abcdef" as &[u8],
-        b"0123456789abcdef0" as &[u8],
-        b"0123456789abcdef01" as &[u8],
-        b"0123456789abcdef012" as &[u8],
-        b"0123456789abcdef0123" as &[u8],
-        b"0123456789abcdef01234" as &[u8],
-        b"0123456789abcdef012345" as &[u8],
-        b"0123456789abcdef0123456" as &[u8],
-        b"0123456789abcdef01234567" as &[u8],
-        b"0123456789abcdef012345678" as &[u8],
-        b"0123456789abcdef0123456789" as &[u8],
-        b"0123456789abcdef0123456789A" as &[u8],
-        b"0123456789abcdef0123456789AB" as &[u8],
-        b"0123456789abcdef0123456789ABC" as &[u8],
-        b"0123456789abcdef0123456789ABCD" as &[u8],
-        b"0123456789abcdef0123456789ABCDE" as &[u8],
-        b"0123456789abcdef0123456789ABCDEF" as &[u8],
-    ];
-
-    // <field name="fixed16Char" id="1" type="Fixed16Char"/>
-    // <field name="fixed16AsciiChar" id="2" type="Fixed16AsciiChar"/>
-    // <field name="fixed16Gb18030Char" id="3" type="Fixed16Gb18030Char"/>
-    // <field name="fixed16Utf8Char" id="4" type="Fixed16Utf8Char"/>
-    // <field name="fixed16U8" id="11" type="Fixed16U8"/>
-    // <field name="fixed16AsciiU8" id="12" type="Fixed16AsciiU8"/>
-    // <field name="fixed16Gb18030U8" id="13" type="Fixed16Gb18030U8"/>
-    // <field name="fixed16Utf8U8" id="14" type="Fixed16Utf8U8"/>
-    macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
-        ($encode_func:expr, $decode_func:expr, $i_padded:expr) => {
-            for each_slice in test_data {
-                let encode_func = $encode_func;
-                let decode_func = $decode_func;
-                let padded_value = $i_padded;
-
-                let cur_len = each_slice.len();
-                let effective_len = cur_len.min(16);
-
-                // encode...
-                let mut buffer = vec![0u8; 1024];
-                let mut encoder = create_encoder(&mut buffer);
-
-                encode_func(&mut encoder, each_slice, padded_value);
-
-                // decode...
-                let buf = ReadBuf::new(buffer.as_slice());
-                let header = MessageHeaderDecoder::default().wrap(buf, 0);
-
-                let decoder = DemoDecoder::default().header(header, 0);
-                let decoded = decode_func(&decoder);
-                for each_idx in 0..effective_len {
-                    assert_eq!(
-                        each_slice[each_idx], decoded[each_idx],
-                        "Item mismatched at {}/{}",
-                        each_idx, cur_len
-                    );
-                }
-                for each_idx in effective_len..16 {
-                    assert_eq!(
-                        decoded[each_idx], padded_value,
-                        "Item should be padded at {}/{}",
-                        each_idx, cur_len
-                    );
-                }
-            }
-        };
-    }
-
-    run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_char_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_char_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_char,
-        30
+        DemoEncoder::fixed_16_char_end,
+        DemoDecoder::fixed_16_char_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_ascii_char_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_ascii_char_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_ascii_char,
-        30
+        DemoEncoder::fixed_16_ascii_char_end,
+        DemoDecoder::fixed_16_ascii_char_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_gb_18030_char_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_gb_18030_char_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_gb_18030_char,
-        30
+        DemoEncoder::fixed_16_gb_18030_char_end,
+        DemoDecoder::fixed_16_gb_18030_char_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_utf_8_char_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_utf_8_char_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_utf_8_char,
-        30
+        DemoEncoder::fixed_16_utf_8_char_end,
+        DemoDecoder::fixed_16_utf_8_char_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_u8_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_u8_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_u8,
-        30
+        DemoEncoder::fixed_16_u8_end,
+        DemoDecoder::fixed_16_u8_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_ascii_u8_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_ascii_u8_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_ascii_u8,
-        30
+        DemoEncoder::fixed_16_ascii_u8_end,
+        DemoDecoder::fixed_16_ascii_u8_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_gb_18030_u8_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_gb_18030_u8_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_gb_18030_u8,
-        30
+        DemoEncoder::fixed_16_gb_18030_u8_end,
+        DemoDecoder::fixed_16_gb_18030_u8_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_utf_8_u8_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_utf_8_u8_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_utf_8_u8,
-        30
+        DemoEncoder::fixed_16_utf_8u_8_end,
+        DemoDecoder::fixed_16_utf_8u_8_end,
     );
 }
 
 #[test]
 fn test_encode_then_decode_non_u8_signed_primitive_slice_padded() {
+    let uninit = 1u8;
+
     // <field name="fixed16i8" id="21" type="Fixed16i8"/>
     // <field name="fixed16i16" id="22" type="Fixed16i16"/>
     // <field name="fixed16i32" id="23" type="Fixed16i32"/>
     // <field name="fixed16i64" id="24" type="Fixed16i64"/>
     macro_rules! run_encode_then_decode_for_array_of_signed_len_16 {
-        ($encode_func:expr, $decode_func:expr, $i_type:ty, $i_padded:expr) => {
+        ($encode_func:expr, $decode_func:expr, $end_encode_func:expr, $end_decode_func:expr, $i_type:ty,) => {
             let test_data = [
                 &[] as &[$i_type],
                 &[1 as $i_type] as &[$i_type],
@@ -751,16 +836,20 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice_padded() {
             for each_slice in test_data {
                 let encode_func = $encode_func;
                 let decode_func = $decode_func;
-                let padded_value = $i_padded;
+                let end_encode_func = $end_encode_func;
+                let end_decode_func = $end_decode_func;
 
                 let cur_len = each_slice.len();
                 let effective_len = cur_len.min(16);
 
                 // encode...
-                let mut buffer = vec![0u8; 1024];
+                let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, each_slice, padded_value);
+                encode_func(&mut encoder, each_slice);
+
+                let end = 1i32;
+                end_encode_func(&mut encoder, end);
 
                 // decode...
                 let buf = ReadBuf::new(buffer.as_slice());
@@ -781,50 +870,58 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice_padded() {
                 for each_idx in effective_len..16 {
                     assert_eq!(
                         decoded[each_idx],
-                        padded_value,
-                        "Item should be padded at {}/{} for {}",
+                        0,
+                        "Item should be padded ZERO at {}/{} for {}",
                         each_idx,
                         cur_len,
                         stringify!($i_type)
                     );
                 }
+                let decoded_end = end_decode_func(&decoder);
+                assert_eq!(decoded_end, end, "End Item should equal",);
             }
         };
     }
 
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i8_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_i8_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_i8,
+        DemoEncoder::fixed_16_i8_end,
+        DemoDecoder::fixed_16_i8_end,
         i8,
-        -31
     );
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i16_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_i16_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_i16,
+        DemoEncoder::fixed_16_i16_end,
+        DemoDecoder::fixed_16_i16_end,
         i16,
-        -31
     );
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i32_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_i32_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_i32,
+        DemoEncoder::fixed_16_i32_end,
+        DemoDecoder::fixed_16_i32_end,
         i32,
-        -31
     );
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i64_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_i64_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_i64,
+        DemoEncoder::fixed_16_i64_end,
+        DemoDecoder::fixed_16_i64_end,
         i64,
-        -31
     );
 }
 
 #[test]
 fn test_encode_then_decode_non_u8_unsigned_primitive_slice_padded() {
+    let uninit = 1u8;
+
     // <field name="fixed16u16" id="32" type="Fixed16u16"/>
     // <field name="fixed16u32" id="33" type="Fixed16u32"/>
     // <field name="fixed16u64" id="33" type="Fixed16u64"/>
     macro_rules! run_encode_then_decode_for_array_of_unsigned_len_16 {
-        ($encode_func:expr, $decode_func:expr, $i_type:ty, $i_padded:expr) => {
+        ($encode_func:expr, $decode_func:expr, $end_encode_func:expr, $end_decode_func:expr, $i_type:ty) => {
             let test_data = [
                 &[] as &[$i_type],
                 &[1 as $i_type] as &[$i_type],
@@ -942,16 +1039,20 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice_padded() {
             for each_slice in test_data {
                 let encode_func = $encode_func;
                 let decode_func = $decode_func;
-                let padded_value = $i_padded;
+                let end_encode_func = $end_encode_func;
+                let end_decode_func = $end_decode_func;
 
                 let cur_len = each_slice.len();
                 let effective_len = cur_len.min(16);
 
                 // encode...
-                let mut buffer = vec![0u8; 1024];
+                let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, each_slice, padded_value);
+                encode_func(&mut encoder, each_slice);
+
+                let end = 1i32;
+                end_encode_func(&mut encoder, end);
 
                 // decode...
                 let buf = ReadBuf::new(buffer.as_slice());
@@ -972,33 +1073,38 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice_padded() {
                 for each_idx in effective_len..16 {
                     assert_eq!(
                         decoded[each_idx],
-                        padded_value,
-                        "Item should be padded at {}/{} for {}",
+                        0,
+                        "Item should be padded ZERO at {}/{} for {}",
                         each_idx,
                         cur_len,
                         stringify!($i_type)
                     );
                 }
+                let decoded_end = end_decode_func(&decoder);
+                assert_eq!(decoded_end, end, "End Item should equal",);
             }
         };
     }
 
     run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u16_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_u16_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_u16,
-        u16,
-        1024u16
+        DemoEncoder::fixed_16_u16_end,
+        DemoDecoder::fixed_16_u16_end,
+        u16
     );
     run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u32_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_u32_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_u32,
-        u32,
-        10000000u32
+        DemoEncoder::fixed_16_u32_end,
+        DemoDecoder::fixed_16_u32_end,
+        u32
     );
     run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u64_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_u64_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_u64,
-        u64,
-        20241115173301u64
+        DemoEncoder::fixed_16_u64_end,
+        DemoDecoder::fixed_16_u64_end,
+        u64
     );
 }

--- a/rust/tests/fixed_sized_primitive_array.rs
+++ b/rust/tests/fixed_sized_primitive_array.rs
@@ -58,7 +58,7 @@ fn test_encode_then_decode_u8_slice() {
     // <field name="fixed16Gb18030U8" id="13" type="Fixed16Gb18030U8"/>
     // <field name="fixed16Utf8U8" id="14" type="Fixed16Utf8U8"/>
     macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
-        ($encode_func:expr, $decode_func:expr, $i_null:expr) => {
+        ($encode_func:expr, $decode_func:expr) => {
             for each_slice in test_data {
                 let encode_func = $encode_func;
                 let decode_func = $decode_func;
@@ -67,7 +67,7 @@ fn test_encode_then_decode_u8_slice() {
                 let effective_len = cur_len.min(16);
 
                 // encode...
-                let mut buffer = vec![1u8; 1024];
+                let mut buffer = vec![0u8; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
                 encode_func(&mut encoder, each_slice);
@@ -85,11 +85,10 @@ fn test_encode_then_decode_u8_slice() {
                         each_idx, cur_len
                     );
                 }
-                let null_value = $i_null;
                 for each_idx in effective_len..16 {
                     assert_eq!(
-                        decoded[each_idx], null_value,
-                        "Item should be NULL at {}/{}",
+                        decoded[each_idx], 0,
+                        "Item should be ZERO at {}/{}",
                         each_idx, cur_len
                     );
                 }
@@ -99,43 +98,35 @@ fn test_encode_then_decode_u8_slice() {
 
     run_encode_then_decode_for_array_of_u8_len_16!(
         DemoEncoder::fixed_16_char_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_char,
-        0
+        DemoDecoder::fixed_16_char
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
         DemoEncoder::fixed_16_ascii_char_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_ascii_char,
-        0
+        DemoDecoder::fixed_16_ascii_char
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
         DemoEncoder::fixed_16_gb_18030_char_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_gb_18030_char,
-        0
+        DemoDecoder::fixed_16_gb_18030_char
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
         DemoEncoder::fixed_16_utf_8_char_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_utf_8_char,
-        0
+        DemoDecoder::fixed_16_utf_8_char
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
         DemoEncoder::fixed_16_u8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_u8,
-        u8::MAX
+        DemoDecoder::fixed_16_u8
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
         DemoEncoder::fixed_16_ascii_u8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_ascii_u8,
-        u8::MAX
+        DemoDecoder::fixed_16_ascii_u8
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
         DemoEncoder::fixed_16_gb_18030_u8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_gb_18030_u8,
-        u8::MAX
+        DemoDecoder::fixed_16_gb_18030_u8
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
         DemoEncoder::fixed_16_utf_8_u8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_utf_8_u8,
-        u8::MAX
+        DemoDecoder::fixed_16_utf_8_u8
     );
 }
 
@@ -145,8 +136,8 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice() {
     // <field name="fixed16i16" id="22" type="Fixed16i16"/>
     // <field name="fixed16i32" id="23" type="Fixed16i32"/>
     // <field name="fixed16i64" id="24" type="Fixed16i64"/>
-    macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
-        ($encode_func:expr, $decode_func:expr, $i_type:ty, $i_null:expr) => {
+    macro_rules! run_encode_then_decode_for_array_of_signed_len_16 {
+        ($encode_func:expr, $decode_func:expr, $i_type:ty) => {
             let test_data = [
                 &[] as &[$i_type],
                 &[1 as $i_type] as &[$i_type],
@@ -269,7 +260,7 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice() {
                 let effective_len = cur_len.min(16);
 
                 // encode...
-                let mut buffer = vec![1u8; 1024];
+                let mut buffer = vec![0u8; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
                 encode_func(&mut encoder, &each_slice);
@@ -290,12 +281,11 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice() {
                         stringify!($i_type)
                     );
                 }
-                let null_value = $i_null;
                 for each_idx in effective_len..16 {
                     assert_eq!(
                         decoded[each_idx],
-                        null_value,
-                        "Item should be null at {}/{} for {}",
+                        0,
+                        "Item should be ZERO at {}/{} for {}",
                         each_idx,
                         cur_len,
                         stringify!($i_type)
@@ -305,29 +295,25 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice() {
         };
     }
 
-    run_encode_then_decode_for_array_of_u8_len_16!(
+    run_encode_then_decode_for_array_of_signed_len_16!(
         DemoEncoder::fixed_16_i8_at_most_16_items_from_slice,
         DemoDecoder::fixed_16_i8,
-        i8,
-        i8::MIN
+        i8
     );
-    run_encode_then_decode_for_array_of_u8_len_16!(
+    run_encode_then_decode_for_array_of_signed_len_16!(
         DemoEncoder::fixed_16_i16_at_most_16_items_from_slice,
         DemoDecoder::fixed_16_i16,
-        i16,
-        i16::MIN
+        i16
     );
-    run_encode_then_decode_for_array_of_u8_len_16!(
+    run_encode_then_decode_for_array_of_signed_len_16!(
         DemoEncoder::fixed_16_i32_at_most_16_items_from_slice,
         DemoDecoder::fixed_16_i32,
-        i32,
-        i32::MIN
+        i32
     );
-    run_encode_then_decode_for_array_of_u8_len_16!(
+    run_encode_then_decode_for_array_of_signed_len_16!(
         DemoEncoder::fixed_16_i64_at_most_16_items_from_slice,
         DemoDecoder::fixed_16_i64,
-        i64,
-        i64::MIN
+        i64
     );
 }
 
@@ -335,8 +321,8 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice() {
 fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
     // <field name="fixed16u16" id="32" type="Fixed16u16"/>
     // <field name="fixed16u32" id="33" type="Fixed16u32"/>
-    macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
-        ($encode_func:expr, $decode_func:expr, $i_type:ty, $i_null:expr) => {
+    macro_rules! run_encode_then_decode_for_array_of_unsigned_len_16 {
+        ($encode_func:expr, $decode_func:expr, $i_type:ty) => {
             let test_data = [
                 &[] as &[$i_type],
                 &[1 as $i_type] as &[$i_type],
@@ -459,10 +445,10 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
                 let effective_len = cur_len.min(16);
 
                 // encode...
-                let mut buffer = vec![1u8; 1024];
+                let mut buffer = vec![0u8; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, &each_slice);
+                encode_func(&mut encoder, each_slice);
 
                 // decode...
                 let buf = ReadBuf::new(buffer.as_slice());
@@ -480,12 +466,11 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
                         stringify!($i_type)
                     );
                 }
-                let null_value = $i_null;
                 for each_idx in effective_len..16 {
                     assert_eq!(
                         decoded[each_idx],
-                        null_value,
-                        "Item should be null at {}/{} for {}",
+                        0,
+                        "Item should be ZERO at {}/{} for {}",
                         each_idx,
                         cur_len,
                         stringify!($i_type)
@@ -495,17 +480,525 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
         };
     }
 
-    run_encode_then_decode_for_array_of_u8_len_16!(
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
         DemoEncoder::fixed_16_u16_at_most_16_items_from_slice,
         DemoDecoder::fixed_16_u16,
-        u16,
-        u16::MAX
+        u16
     );
-    run_encode_then_decode_for_array_of_u8_len_16!(
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
         DemoEncoder::fixed_16_u32_at_most_16_items_from_slice,
         DemoDecoder::fixed_16_u32,
-        u32,
-        u32::MAX
+        u32
     );
-    // run_encode_then_decode_for_array_of_u8_len_16!(DemoEncoder::fixed_16_u64_at_most_16_items_from_slice, DemoDecoder::fixed_16_i64, i64, u64::MAX);
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
+        DemoEncoder::fixed_16_u64_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_u64,
+        u64
+    );
+}
+
+#[test]
+fn test_encode_then_decode_u8_slice_padded() {
+    let test_data = [
+        b"" as &[u8],
+        b"0" as &[u8],
+        b"01" as &[u8],
+        b"012" as &[u8],
+        b"0123" as &[u8],
+        b"01234" as &[u8],
+        b"012345" as &[u8],
+        b"0123456" as &[u8],
+        b"01234567" as &[u8],
+        b"012345678" as &[u8],
+        b"0123456789" as &[u8],
+        b"0123456789A" as &[u8],
+        b"0123456789AB" as &[u8],
+        b"0123456789ABC" as &[u8],
+        b"0123456789ABCD" as &[u8],
+        b"0123456789ABCDE" as &[u8],
+        b"0123456789ABCDEF" as &[u8],
+        b"0123456789abcdef" as &[u8],
+        b"0123456789abcdef0" as &[u8],
+        b"0123456789abcdef01" as &[u8],
+        b"0123456789abcdef012" as &[u8],
+        b"0123456789abcdef0123" as &[u8],
+        b"0123456789abcdef01234" as &[u8],
+        b"0123456789abcdef012345" as &[u8],
+        b"0123456789abcdef0123456" as &[u8],
+        b"0123456789abcdef01234567" as &[u8],
+        b"0123456789abcdef012345678" as &[u8],
+        b"0123456789abcdef0123456789" as &[u8],
+        b"0123456789abcdef0123456789A" as &[u8],
+        b"0123456789abcdef0123456789AB" as &[u8],
+        b"0123456789abcdef0123456789ABC" as &[u8],
+        b"0123456789abcdef0123456789ABCD" as &[u8],
+        b"0123456789abcdef0123456789ABCDE" as &[u8],
+        b"0123456789abcdef0123456789ABCDEF" as &[u8],
+    ];
+
+    // <field name="fixed16Char" id="1" type="Fixed16Char"/>
+    // <field name="fixed16AsciiChar" id="2" type="Fixed16AsciiChar"/>
+    // <field name="fixed16Gb18030Char" id="3" type="Fixed16Gb18030Char"/>
+    // <field name="fixed16Utf8Char" id="4" type="Fixed16Utf8Char"/>
+    // <field name="fixed16U8" id="11" type="Fixed16U8"/>
+    // <field name="fixed16AsciiU8" id="12" type="Fixed16AsciiU8"/>
+    // <field name="fixed16Gb18030U8" id="13" type="Fixed16Gb18030U8"/>
+    // <field name="fixed16Utf8U8" id="14" type="Fixed16Utf8U8"/>
+    macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
+        ($encode_func:expr, $decode_func:expr, $i_padded:expr) => {
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+                let padded_value = $i_padded;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = vec![0u8; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, each_slice, padded_value);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx], decoded[each_idx],
+                        "Item mismatched at {}/{}",
+                        each_idx, cur_len
+                    );
+                }
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx], padded_value,
+                        "Item should be padded at {}/{}",
+                        each_idx, cur_len
+                    );
+                }
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_char_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_char,
+        30
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_ascii_char_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_ascii_char,
+        30
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_gb_18030_char_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_gb_18030_char,
+        30
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_utf_8_char_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_utf_8_char,
+        30
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_u8_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_u8,
+        30
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_ascii_u8_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_ascii_u8,
+        30
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_gb_18030_u8_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_gb_18030_u8,
+        30
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_utf_8_u8_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_utf_8_u8,
+        30
+    );
+}
+
+#[test]
+fn test_encode_then_decode_non_u8_signed_primitive_slice_padded() {
+    // <field name="fixed16i8" id="21" type="Fixed16i8"/>
+    // <field name="fixed16i16" id="22" type="Fixed16i16"/>
+    // <field name="fixed16i32" id="23" type="Fixed16i32"/>
+    // <field name="fixed16i64" id="24" type="Fixed16i64"/>
+    macro_rules! run_encode_then_decode_for_array_of_signed_len_16 {
+        ($encode_func:expr, $decode_func:expr, $i_type:ty, $i_padded:expr) => {
+            let test_data = [
+                &[] as &[$i_type],
+                &[1 as $i_type] as &[$i_type],
+                &[0 as $i_type] as &[$i_type],
+                &[-1 as $i_type] as &[$i_type],
+                &[-1, 1 as $i_type] as &[$i_type],
+                &[-1, 0, 1 as $i_type] as &[$i_type],
+                &[-2, -1, 1, 2 as $i_type] as &[$i_type],
+                &[-2, -1, 0, 1, 2 as $i_type] as &[$i_type],
+                &[-3, -2, -1, 1, 2, 3 as $i_type] as &[$i_type],
+                &[-3, -2, -1, 0, 1, 2, 3 as $i_type] as &[$i_type],
+                &[-4, -3, -2, -1, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[-4, -3, -2, -1, 0, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[-5, -4, -3, -2, -1, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[-6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[-7, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 7 as $i_type] as &[$i_type],
+                &[
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -9,
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -9,
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+            ];
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+                let padded_value = $i_padded;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = vec![0u8; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, each_slice, padded_value);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx],
+                        decoded[each_idx],
+                        "Item mismatched at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx],
+                        padded_value,
+                        "Item should be padded at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_signed_len_16!(
+        DemoEncoder::fixed_16_i8_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_i8,
+        i8,
+        -31
+    );
+    run_encode_then_decode_for_array_of_signed_len_16!(
+        DemoEncoder::fixed_16_i16_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_i16,
+        i16,
+        -31
+    );
+    run_encode_then_decode_for_array_of_signed_len_16!(
+        DemoEncoder::fixed_16_i32_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_i32,
+        i32,
+        -31
+    );
+    run_encode_then_decode_for_array_of_signed_len_16!(
+        DemoEncoder::fixed_16_i64_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_i64,
+        i64,
+        -31
+    );
+}
+
+#[test]
+fn test_encode_then_decode_non_u8_unsigned_primitive_slice_padded() {
+    // <field name="fixed16u16" id="32" type="Fixed16u16"/>
+    // <field name="fixed16u32" id="33" type="Fixed16u32"/>
+    // <field name="fixed16u64" id="33" type="Fixed16u64"/>
+    macro_rules! run_encode_then_decode_for_array_of_unsigned_len_16 {
+        ($encode_func:expr, $decode_func:expr, $i_type:ty, $i_padded:expr) => {
+            let test_data = [
+                &[] as &[$i_type],
+                &[1 as $i_type] as &[$i_type],
+                &[0 as $i_type] as &[$i_type],
+                &[11 as $i_type] as &[$i_type],
+                &[11, 1 as $i_type] as &[$i_type],
+                &[11, 0, 1 as $i_type] as &[$i_type],
+                &[12, 11, 1, 2 as $i_type] as &[$i_type],
+                &[12, 11, 0, 1, 2 as $i_type] as &[$i_type],
+                &[13, 12, 11, 1, 2, 3 as $i_type] as &[$i_type],
+                &[13, 12, 11, 0, 1, 2, 3 as $i_type] as &[$i_type],
+                &[14, 13, 12, 11, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[14, 13, 12, 11, 0, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[15, 14, 13, 12, 11, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[15, 14, 13, 12, 11, 0, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[16, 15, 14, 13, 12, 11, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[16, 15, 14, 13, 12, 11, 0, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[17, 16, 15, 14, 13, 12, 11, 1, 2, 3, 4, 5, 6, 7 as $i_type] as &[$i_type],
+                &[
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7 as $i_type,
+                ] as &[$i_type],
+                &[
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    19,
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+                &[
+                    19,
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+            ];
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+                let padded_value = $i_padded;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = vec![0u8; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, each_slice, padded_value);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx],
+                        decoded[each_idx],
+                        "Item mismatched at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx],
+                        padded_value,
+                        "Item should be padded at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
+        DemoEncoder::fixed_16_u16_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_u16,
+        u16,
+        1024u16
+    );
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
+        DemoEncoder::fixed_16_u32_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_u32,
+        u32,
+        10000000u32
+    );
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
+        DemoEncoder::fixed_16_u64_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_u64,
+        u64,
+        20241115173301u64
+    );
 }

--- a/sbe-tool/src/test/resources/fixed-sized-primitive-array-types.xml
+++ b/sbe-tool/src/test/resources/fixed-sized-primitive-array-types.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+               package="fixed.sized.primitive.array"
+               id="1989"
+               version="1"
+               semanticVersion="1.0.0"
+               description="Support for fixed sized primitive array"
+               byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader" description="Message identifiers and length of message root">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+
+        <!-- char array without encoding (default to US-ASCII) -->
+        <type name="Fixed16Char" description="String of char with length=16" length="16" primitiveType="char" semanticType="String"/>
+        <type name="Fixed16AsciiChar" description="ASCII string of char with length=16" length="16" primitiveType="char" characterEncoding="US-ASCII" semanticType="String"/>
+        <type name="Fixed16Gb18030Char" description="GB18030 string of char with length=16" length="16" primitiveType="char" characterEncoding="GB18030" semanticType="String"/>
+        <type name="Fixed16Utf8Char" description="GB18030 string of char with length=16" length="16" primitiveType="char" characterEncoding="UTF-8" semanticType="String"/>
+
+        <type name="Fixed16U8" description="Array of 16 u8" length="16" primitiveType="uint8" semanticType="Data"/>
+        <type name="Fixed16AsciiU8" description="Array of 16 u8" length="16" primitiveType="uint8" characterEncoding="US-ASCII" semanticType="Data"/>
+        <type name="Fixed16Gb18030U8" description="Array of 16 u8" length="16" primitiveType="uint8" characterEncoding="GB18030" semanticType="Data"/>
+        <type name="Fixed16Utf8U8" description="Array of 16 u8" length="16" primitiveType="uint8" characterEncoding="UTF-8" semanticType="Data"/>
+
+        <type name="Fixed16i8" description="Array of 16 i8" length="16" primitiveType="int8" />
+        <type name="Fixed16i16" description="Array of 16 i16" length="16" primitiveType="int16" />
+        <type name="Fixed16i32" description="Array of 16 i32" length="16" primitiveType="int32" />
+        <type name="Fixed16i64" description="Array of 16 i64" length="16" primitiveType="int64" />
+
+        <type name="Fixed16u16" description="Array of 16 u16" length="16" primitiveType="uint16" />
+        <type name="Fixed16u32" description="Array of 16 u32" length="16" primitiveType="uint32" />
+        <!-- <type name="Fixed16u64" description="Array of 16 u64" length="16" primitiveType="uint64" /> -->
+    </types>
+
+    <sbe:message name="demo" id="1">
+        <field name="fixed16Char" id="1" type="Fixed16Char"/>
+        <field name="fixed16AsciiChar" id="2" type="Fixed16AsciiChar"/>
+        <field name="fixed16Gb18030Char" id="3" type="Fixed16Gb18030Char"/>
+        <field name="fixed16Utf8Char" id="4" type="Fixed16Utf8Char"/>
+
+        <field name="fixed16U8" id="11" type="Fixed16U8"/>
+        <field name="fixed16AsciiU8" id="12" type="Fixed16AsciiU8"/>
+        <field name="fixed16Gb18030U8" id="13" type="Fixed16Gb18030U8"/>
+        <field name="fixed16Utf8U8" id="14" type="Fixed16Utf8U8"/>
+
+        <field name="fixed16i8" id="21" type="Fixed16i8"/>
+        <field name="fixed16i16" id="22" type="Fixed16i16"/>
+        <field name="fixed16i32" id="23" type="Fixed16i32"/>
+        <field name="fixed16i64" id="24" type="Fixed16i64"/>
+
+        <field name="fixed16u16" id="32" type="Fixed16u16"/>
+        <field name="fixed16u32" id="33" type="Fixed16u32"/>
+        <!-- <field name="fixed16u64" id="34" type="Fixed16u64"/> -->
+    </sbe:message>
+</sbe:messageSchema>

--- a/sbe-tool/src/test/resources/fixed-sized-primitive-array-types.xml
+++ b/sbe-tool/src/test/resources/fixed-sized-primitive-array-types.xml
@@ -32,7 +32,7 @@
 
         <type name="Fixed16u16" description="Array of 16 u16" length="16" primitiveType="uint16" />
         <type name="Fixed16u32" description="Array of 16 u32" length="16" primitiveType="uint32" />
-        <!-- <type name="Fixed16u64" description="Array of 16 u64" length="16" primitiveType="uint64" /> -->
+        <type name="Fixed16u64" description="Array of 16 u64" length="16" primitiveType="uint64" />
     </types>
 
     <sbe:message name="demo" id="1">
@@ -53,6 +53,6 @@
 
         <field name="fixed16u16" id="32" type="Fixed16u16"/>
         <field name="fixed16u32" id="33" type="Fixed16u32"/>
-        <!-- <field name="fixed16u64" id="34" type="Fixed16u64"/> -->
+        <field name="fixed16u64" id="34" type="Fixed16u64"/>
     </sbe:message>
 </sbe:messageSchema>

--- a/sbe-tool/src/test/resources/fixed-sized-primitive-array-types.xml
+++ b/sbe-tool/src/test/resources/fixed-sized-primitive-array-types.xml
@@ -37,22 +37,37 @@
 
     <sbe:message name="demo" id="1">
         <field name="fixed16Char" id="1" type="Fixed16Char"/>
-        <field name="fixed16AsciiChar" id="2" type="Fixed16AsciiChar"/>
-        <field name="fixed16Gb18030Char" id="3" type="Fixed16Gb18030Char"/>
-        <field name="fixed16Utf8Char" id="4" type="Fixed16Utf8Char"/>
+        <field name="fixed16CharEnd" id="2" type="int32" description="End boundary of fixed16Char"/>
+        <field name="fixed16AsciiChar" id="3" type="Fixed16AsciiChar"/>
+        <field name="fixed16AsciiCharEnd" id="4" type="int32" description="End boundary of fixed16AsciiChar"/>
+        <field name="fixed16Gb18030Char" id="5" type="Fixed16Gb18030Char"/>
+        <field name="fixed16Gb18030CharEnd" id="6" type="int32" description="End boundary of fixed16Gb18030Char"/>
+        <field name="fixed16Utf8Char" id="7" type="Fixed16Utf8Char"/>
+        <field name="fixed16Utf8CharEnd" id="8" type="int32" description="End boundary of fixed16Utf8Char"/>
 
         <field name="fixed16U8" id="11" type="Fixed16U8"/>
-        <field name="fixed16AsciiU8" id="12" type="Fixed16AsciiU8"/>
-        <field name="fixed16Gb18030U8" id="13" type="Fixed16Gb18030U8"/>
-        <field name="fixed16Utf8U8" id="14" type="Fixed16Utf8U8"/>
+        <field name="fixed16U8End" id="12" type="int32" description="End boundary of fixed16U8"/>
+        <field name="fixed16AsciiU8" id="13" type="Fixed16AsciiU8"/>
+        <field name="fixed16AsciiU8End" id="14" type="int32" description="End boundary of fixed16AsciiU8"/>
+        <field name="fixed16Gb18030U8" id="15" type="Fixed16Gb18030U8"/>
+        <field name="fixed16Gb18030U8End" id="16" type="int32" description="End boundary of fixed16Gb18030U8"/>
+        <field name="fixed16Utf8U8" id="17" type="Fixed16Utf8U8"/>
+        <field name="fixed16Utf8U8End" id="18" type="int32" description="End boundary of fixed16Utf8U8"/>
 
         <field name="fixed16i8" id="21" type="Fixed16i8"/>
-        <field name="fixed16i16" id="22" type="Fixed16i16"/>
-        <field name="fixed16i32" id="23" type="Fixed16i32"/>
-        <field name="fixed16i64" id="24" type="Fixed16i64"/>
+        <field name="fixed16i8End" id="22" type="int32" description="End boundary of fixed16i8"/>
+        <field name="fixed16i16" id="23" type="Fixed16i16"/>
+        <field name="fixed16i16End" id="24" type="int32" description="End boundary of fixed16i16"/>
+        <field name="fixed16i32" id="25" type="Fixed16i32"/>
+        <field name="fixed16i32End" id="26" type="int32" description="End boundary of fixed16i32"/>
+        <field name="fixed16i64" id="27" type="Fixed16i64"/>
+        <field name="fixed16i64End" id="28" type="int32" description="End boundary of fixed16i64"/>
 
-        <field name="fixed16u16" id="32" type="Fixed16u16"/>
-        <field name="fixed16u32" id="33" type="Fixed16u32"/>
-        <field name="fixed16u64" id="34" type="Fixed16u64"/>
+        <field name="fixed16u16" id="33" type="Fixed16u16"/>
+        <field name="fixed16u16End" id="34" type="int32" description="End boundary of fixed16u16"/>
+        <field name="fixed16u32" id="35" type="Fixed16u32"/>
+        <field name="fixed16u32End" id="36" type="int32" description="End boundary of fixed16u32"/>
+        <field name="fixed16u64" id="37" type="Fixed16u64"/>
+        <field name="fixed16u64End" id="38" type="int32" description="End boundary of fixed16u64"/>
     </sbe:message>
 </sbe:messageSchema>


### PR DESCRIPTION
Releated to <https://github.com/real-logic/simple-binary-encoding/issues/1021>

For field of primitive array type, generate 2 more setter methods in its Encoder:

1. one named with `_at_most_N_items_from_slice` to enable copy as more as items less than array length to encoding bytes buffer.
2. one named with `_at_most_N_items_from_slice` to enable copy as more as items less than array length to encoding bytes buffer.    If no enough items provided, will continue padding using a given value provided via a third parameter.

Generated methods differs on backing primitive type for `u8` and non `u8`.

If there exists following SBE definition:

```xml
<type name="Fixed4U8" length="4" primitiveType="uint8" semanticType="Data"/>
<type name="Fixed4i32" length="4" primitiveType="int32" />

<field name="fixedU8" id="11" type="Fixed4U8"/>
<field name="fixedi32" id="23" type="Fixed4i32"/>
```

Then following new methods would be generated:

```rust
// primitive array field 'fixedU8'
/// - min value: 0
/// - max value: 254
/// - null value: 255
/// - characterEncoding: null
/// - semanticType: Data
/// - encodedOffset: 0
/// - encodedLength: 4
/// - version: 0
#[inline]
pub fn fixed_u8(&mut self, value: &[u8; 4]) {
    let offset = self.offset;
    let buf = self.get_buf_mut();
    buf.put_bytes_at(offset, value);
}

/// primitive array field 'fixedU8': copy at most 4 items from slice without padding
/// - min value: 0
/// - max value: 254
/// - null value: 255
/// - characterEncoding: null
/// - semanticType: Data
/// - encodedOffset: 0
/// - encodedLength: 4
/// - version: 0
#[inline]
pub fn fixed_u8_at_most_4_items_from_slice(&mut self, value: &[u8]) {
    let offset = self.offset;
    let buf = self.get_buf_mut();
    match value.len() {
        0 => {
            // Copy all 0 items from 'value' into 'fixedU8' of [u8; 4]

            // Leave 4 left items unchanged
        }
        1 => {
            // Copy all 1 items from 'value' into 'fixedU8' of [u8; 4]
            buf.put_slice_at(offset, value);

            // Leave 3 left items unchanged
        }
        2 => {
            // Copy all 2 items from 'value' into 'fixedU8' of [u8; 4]
            buf.put_slice_at(offset, value);

            // Leave 2 left items unchanged
        }
        3 => {
            // Copy all 3 items from 'value' into 'fixedU8' of [u8; 4]
            buf.put_slice_at(offset, value);

            // Leave 1 left items unchanged
        }
        _ => {
            // Copy all 4 items from 'value' into 'fixedU8' of [u8; 4]
            buf.put_slice_at(offset, value);

            // Leave 0 left items unchanged
        }
    }
}

/// primitive array field 'fixedU8': copy at most 4 items from slice with padding
/// - min value: 0
/// - max value: 254
/// - null value: 255
/// - characterEncoding: null
/// - semanticType: Data
/// - encodedOffset: 0
/// - encodedLength: 4
/// - version: 0
#[inline]
pub fn fixed_u8_at_most_4_items_from_slice_padded(&mut self, value: &[u8], padded: u8) {
    let offset = self.offset;
    let buf = self.get_buf_mut();
    match value.len() {
        0 => {
            // Copy all 0 items from 'value' into 'fixedU8' of [u8; 4]

            // Pad 4 left items of 'fixedU8' with parameter "padded"
            buf.put_bytes_at(offset, &[padded; 4]);
        }
        1 => {
            // Copy all 1 items from 'value' into 'fixedU8' of [u8; 4]
            buf.put_slice_at(offset, value);

            // Pad 3 left items of 'fixedU8' with parameter "padded"
            buf.put_bytes_at(offset + 1, &[padded; 3]);
        }
        2 => {
            // Copy all 2 items from 'value' into 'fixedU8' of [u8; 4]
            buf.put_slice_at(offset, value);

            // Pad 2 left items of 'fixedU8' with parameter "padded"
            buf.put_bytes_at(offset + 2, &[padded; 2]);
        }
        3 => {
            // Copy all 3 items from 'value' into 'fixedU8' of [u8; 4]
            buf.put_slice_at(offset, value);

            // Pad 1 left items of 'fixedU8' with parameter "padded"
            buf.put_bytes_at(offset + 3, &[padded; 1]);
        }
        _ => {
            // Copy all 4 items from 'value' into 'fixedU8' of [u8; 4]
            buf.put_slice_at(offset, value);

            // Pad 0 left items of 'fixedU8' with parameter "padded"
        }
    }
}

/// primitive array field 'fixedi32'
/// - min value: -2147483647
/// - max value: 2147483647
/// - null value: -2147483648
/// - characterEncoding: null
/// - semanticType: null
/// - encodedOffset: 4
/// - encodedLength: 16
/// - version: 0
#[inline]
pub fn fixedi_32(&mut self, value: &[i32; 4]) {
    let offset = self.offset + 4;
    let buf = self.get_buf_mut();
    buf.put_i32_at(offset, value[0]);
    buf.put_i32_at(offset + 4, value[1]);
    buf.put_i32_at(offset + 8, value[2]);
    buf.put_i32_at(offset + 12, value[3]);
}

/// primitive array field 'fixedi32': copy at most 4 items from slice without padding
/// - min value: -2147483647
/// - max value: 2147483647
/// - null value: -2147483648
/// - characterEncoding: null
/// - semanticType: null
/// - encodedOffset: 4
/// - encodedLength: 16
/// - version: 0
#[inline]
pub fn fixedi_32_at_most_4_items_from_slice(&mut self, value: &[i32]) {
    let offset = self.offset + 4;
    let buf = self.get_buf_mut();
    match value.len() {
        0 => {
            // Copy all 0 items from 'value' into 'fixedi32' of [i32; 4]

            // Leave 4 left items unchanged
        }
        1 => {
            // Copy all 1 items from 'value' into 'fixedi32' of [i32; 4]
            buf.put_i32_at(offset, value[0]);

            // Leave 3 left items unchanged
        }
        2 => {
            // Copy all 2 items from 'value' into 'fixedi32' of [i32; 4]
            buf.put_i32_at(offset, value[0]);
            buf.put_i32_at(offset + 4, value[1]);

            // Leave 2 left items unchanged
        }
        3 => {
            // Copy all 3 items from 'value' into 'fixedi32' of [i32; 4]
            buf.put_i32_at(offset, value[0]);
            buf.put_i32_at(offset + 4, value[1]);
            buf.put_i32_at(offset + 8, value[2]);

            // Leave 1 left items unchanged
        }
        _ => {
            // Copy all 4 items from 'value' into 'fixedi32' of [i32; 4]
            buf.put_i32_at(offset, value[0]);
            buf.put_i32_at(offset + 4, value[1]);
            buf.put_i32_at(offset + 8, value[2]);
            buf.put_i32_at(offset + 12, value[3]);

            // Leave 0 left items unchanged
        }
    }
}

/// primitive array field 'fixedi32': copy at most 4 items from slice with padding
/// - min value: -2147483647
/// - max value: 2147483647
/// - null value: -2147483648
/// - characterEncoding: null
/// - semanticType: null
/// - encodedOffset: 4
/// - encodedLength: 16
/// - version: 0
#[inline]
pub fn fixedi_32_at_most_4_items_from_slice_padded(&mut self, value: &[i32], padded: i32) {
    let offset = self.offset + 4;
    let buf = self.get_buf_mut();
    match value.len() {
        0 => {
            // Copy all 0 items from 'value' into 'fixedi32' of [i32; 4]

            // Pad 4 left items of 'fixedi32' with parameter "padded"
            buf.put_i32_at(offset, padded);
            buf.put_i32_at(offset + 4, padded);
            buf.put_i32_at(offset + 8, padded);
            buf.put_i32_at(offset + 12, padded);
        }
        1 => {
            // Copy all 1 items from 'value' into 'fixedi32' of [i32; 4]
            buf.put_i32_at(offset, value[0]);

            // Pad 3 left items of 'fixedi32' with parameter "padded"
            buf.put_i32_at(offset + 4, padded);
            buf.put_i32_at(offset + 8, padded);
            buf.put_i32_at(offset + 12, padded);
        }
        2 => {
            // Copy all 2 items from 'value' into 'fixedi32' of [i32; 4]
            buf.put_i32_at(offset, value[0]);
            buf.put_i32_at(offset + 4, value[1]);

            // Pad 2 left items of 'fixedi32' with parameter "padded"
            buf.put_i32_at(offset + 8, padded);
            buf.put_i32_at(offset + 12, padded);
        }
        3 => {
            // Copy all 3 items from 'value' into 'fixedi32' of [i32; 4]
            buf.put_i32_at(offset, value[0]);
            buf.put_i32_at(offset + 4, value[1]);
            buf.put_i32_at(offset + 8, value[2]);

            // Pad 1 left items of 'fixedi32' with parameter "padded"
            buf.put_i32_at(offset + 12, padded);
        }
        _ => {
            // Copy all 4 items from 'value' into 'fixedi32' of [i32; 4]
            buf.put_i32_at(offset, value[0]);
            buf.put_i32_at(offset + 4, value[1]);
            buf.put_i32_at(offset + 8, value[2]);
            buf.put_i32_at(offset + 12, value[3]);

            // Pad 0 left items of 'fixedi32' with parameter "padded"
        }
    }
}
```