### PR TITLE
[Rust] encoding primitive arrays now supports slice instead of array (issue #1021)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -654,6 +654,7 @@ tasks.register('generateRustTestCodecs', JavaExec) {
             'sbe-tool/src/test/resources/issue984.xml',
             'sbe-tool/src/test/resources/issue987.xml',
             'sbe-tool/src/test/resources/issue1028.xml',
+            'sbe-tool/src/test/resources/fixed-sized-primitive-array-types.xml',
             'sbe-tool/src/test/resources/example-bigendian-test-schema.xml',
             'sbe-tool/src/test/resources/nested-composite-name.xml',
     ]

--- a/rust/Cargo.toml
+++ b/rust/Cargo.toml
@@ -19,6 +19,7 @@ issue_987 = { path = "../generated/rust/issue987" }
 issue_1028 = { path = "../generated/rust/issue1028" }
 baseline_bigendian = { path = "../generated/rust/baseline-bigendian" }
 nested_composite_name = { path = "../generated/rust/nested-composite-name" }
+fixed_sized_primitive_array = { path = "../generated/rust/fixed_sized_primitive_array" }
 
 [dev-dependencies]
 criterion = "0.5"

--- a/rust/tests/baseline_enum_from_str.rs
+++ b/rust/tests/baseline_enum_from_str.rs
@@ -1,21 +1,22 @@
+use BoostType::{NullVal, KERS, NITROUS, SUPERCHARGER, TURBO};
 use examples_baseline::{
     boost_type::BoostType,
 };
 
 #[test]
 fn test_boost_type_from_str() -> Result<(), ()> {
-    assert_eq!("TURBO".parse::<BoostType>()?, BoostType::TURBO, "Parse \"TURBO\" as BoostType");
-    assert_eq!("SUPERCHARGER".parse::<BoostType>()?, BoostType::SUPERCHARGER, "Parse \"SUPERCHARGER\" as BoostType");
-    assert_eq!("NITROUS".parse::<BoostType>()?, BoostType::NITROUS, "Parse \"NITROUS\" as BoostType");
-    assert_eq!("KERS".parse::<BoostType>()?, BoostType::KERS, "Parse \"KERS\" as BoostType");
+    assert_eq!("TURBO".parse::<BoostType>()?, TURBO, "Parse \"TURBO\" as BoostType");
+    assert_eq!("SUPERCHARGER".parse::<BoostType>()?, SUPERCHARGER, "Parse \"SUPERCHARGER\" as BoostType");
+    assert_eq!("NITROUS".parse::<BoostType>()?, NITROUS, "Parse \"NITROUS\" as BoostType");
+    assert_eq!("KERS".parse::<BoostType>()?, KERS, "Parse \"KERS\" as BoostType");
 
-    assert_eq!("Turbo".parse::<BoostType>()?, BoostType::NullVal, "Parse \"Turbo\" as BoostType");
-    assert_eq!("Supercharger".parse::<BoostType>()?, BoostType::NullVal, "Parse \"Supercharger\" as BoostType");
-    assert_eq!("Nitrous".parse::<BoostType>()?, BoostType::NullVal, "Parse \"Nitrous\" as BoostType");
-    assert_eq!("Kers".parse::<BoostType>()?, BoostType::NullVal, "Parse \"Kers\" as BoostType");
+    assert_eq!("Turbo".parse::<BoostType>()?, NullVal, "Parse \"Turbo\" as BoostType");
+    assert_eq!("Supercharger".parse::<BoostType>()?, NullVal, "Parse \"Supercharger\" as BoostType");
+    assert_eq!("Nitrous".parse::<BoostType>()?, NullVal, "Parse \"Nitrous\" as BoostType");
+    assert_eq!("Kers".parse::<BoostType>()?, NullVal, "Parse \"Kers\" as BoostType");
 
-    assert_eq!("AA".parse::<BoostType>()?, BoostType::NullVal, "Parse \"AA\" as BoostType");
-    assert_eq!("".parse::<BoostType>().unwrap(), BoostType::NullVal, "Parse \"\" as BoostType");
+    assert_eq!("AA".parse::<BoostType>()?, NullVal, "Parse \"AA\" as BoostType");
+    assert_eq!("".parse::<BoostType>().unwrap(), NullVal, "Parse \"\" as BoostType");
 
     Ok(())
 }

--- a/rust/tests/extension_test.rs
+++ b/rust/tests/extension_test.rs
@@ -187,7 +187,7 @@ fn encode_car_from_scratch() -> SbeResult<(usize, Vec<u8>)> {
     car.available(BooleanType::T);
     car.code(Model::A);
     car.some_numbers(&[0, 1, 2, 3]);
-    car.vehicle_code(&[97, 98, 99, 100, 101, 102]); // abcdef
+    car.vehicle_code(b"abcdef_extra_is_ignored"); // abcdef
 
     extras.set_cruise_control(true);
     extras.set_sports_pack(true);
@@ -197,7 +197,7 @@ fn encode_car_from_scratch() -> SbeResult<(usize, Vec<u8>)> {
     let mut engine = car.engine_encoder();
     engine.capacity(2000);
     engine.num_cylinders(4);
-    engine.manufacturer_code(&[49, 50, 51]); // 123
+    engine.manufacturer_code(b"123");
     engine.efficiency(35);
     engine.booster_enabled(BooleanType::T);
     let mut booster = engine.booster_encoder();

--- a/rust/tests/extension_test.rs
+++ b/rust/tests/extension_test.rs
@@ -187,7 +187,7 @@ fn encode_car_from_scratch() -> SbeResult<(usize, Vec<u8>)> {
     car.available(BooleanType::T);
     car.code(Model::A);
     car.some_numbers(&[0, 1, 2, 3]);
-    car.vehicle_code(b"abcdef_extra_is_ignored"); // abcdef
+    car.vehicle_code_from_iter(b"abcdef_extra_is_ignored".iter().map(|x| *x)); // abcdef
 
     extras.set_cruise_control(true);
     extras.set_sports_pack(true);

--- a/rust/tests/extension_test.rs
+++ b/rust/tests/extension_test.rs
@@ -187,7 +187,7 @@ fn encode_car_from_scratch() -> SbeResult<(usize, Vec<u8>)> {
     car.available(BooleanType::T);
     car.code(Model::A);
     car.some_numbers(&[0, 1, 2, 3]);
-    car.vehicle_code_from_iter(b"abcdef_extra_is_ignored".iter().map(|x| *x)); // abcdef
+    car.vehicle_code_from_iter(b"abcdef_extra_is_ignored".into_iter().copied()); // abcdef
 
     extras.set_cruise_control(true);
     extras.set_sports_pack(true);

--- a/rust/tests/fixed_sized_primitive_array.rs
+++ b/rust/tests/fixed_sized_primitive_array.rs
@@ -1,0 +1,511 @@
+use fixed_sized_primitive_array::{
+    demo_codec::{DemoDecoder, DemoEncoder},
+    message_header_codec::{MessageHeaderDecoder, ENCODED_LENGTH},
+    ReadBuf, WriteBuf,
+};
+
+fn create_encoder(buffer: &mut Vec<u8>) -> DemoEncoder {
+    let encoder = DemoEncoder::default().wrap(WriteBuf::new(buffer.as_mut_slice()), ENCODED_LENGTH);
+    let mut header = encoder.header(0);
+    header.parent().unwrap()
+}
+
+#[test]
+fn test_encode_then_decode_u8_slice() {
+    let test_data = [
+        b"" as &[u8],
+        b"0" as &[u8],
+        b"01" as &[u8],
+        b"012" as &[u8],
+        b"0123" as &[u8],
+        b"01234" as &[u8],
+        b"012345" as &[u8],
+        b"0123456" as &[u8],
+        b"01234567" as &[u8],
+        b"012345678" as &[u8],
+        b"0123456789" as &[u8],
+        b"0123456789A" as &[u8],
+        b"0123456789AB" as &[u8],
+        b"0123456789ABC" as &[u8],
+        b"0123456789ABCD" as &[u8],
+        b"0123456789ABCDE" as &[u8],
+        b"0123456789ABCDEF" as &[u8],
+        b"0123456789abcdef" as &[u8],
+        b"0123456789abcdef0" as &[u8],
+        b"0123456789abcdef01" as &[u8],
+        b"0123456789abcdef012" as &[u8],
+        b"0123456789abcdef0123" as &[u8],
+        b"0123456789abcdef01234" as &[u8],
+        b"0123456789abcdef012345" as &[u8],
+        b"0123456789abcdef0123456" as &[u8],
+        b"0123456789abcdef01234567" as &[u8],
+        b"0123456789abcdef012345678" as &[u8],
+        b"0123456789abcdef0123456789" as &[u8],
+        b"0123456789abcdef0123456789A" as &[u8],
+        b"0123456789abcdef0123456789AB" as &[u8],
+        b"0123456789abcdef0123456789ABC" as &[u8],
+        b"0123456789abcdef0123456789ABCD" as &[u8],
+        b"0123456789abcdef0123456789ABCDE" as &[u8],
+        b"0123456789abcdef0123456789ABCDEF" as &[u8],
+    ];
+
+    // <field name="fixed16Char" id="1" type="Fixed16Char"/>
+    // <field name="fixed16AsciiChar" id="2" type="Fixed16AsciiChar"/>
+    // <field name="fixed16Gb18030Char" id="3" type="Fixed16Gb18030Char"/>
+    // <field name="fixed16Utf8Char" id="4" type="Fixed16Utf8Char"/>
+    // <field name="fixed16U8" id="11" type="Fixed16U8"/>
+    // <field name="fixed16AsciiU8" id="12" type="Fixed16AsciiU8"/>
+    // <field name="fixed16Gb18030U8" id="13" type="Fixed16Gb18030U8"/>
+    // <field name="fixed16Utf8U8" id="14" type="Fixed16Utf8U8"/>
+    macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
+        ($encode_func:expr, $decode_func:expr, $i_null:expr) => {
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = vec![1u8; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, each_slice);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx], decoded[each_idx],
+                        "Item mismatched at {}/{}",
+                        each_idx, cur_len
+                    );
+                }
+                let null_value = $i_null;
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx], null_value,
+                        "Item should be NULL at {}/{}",
+                        each_idx, cur_len
+                    );
+                }
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_char_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_char,
+        0
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_ascii_char_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_ascii_char,
+        0
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_gb_18030_char_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_gb_18030_char,
+        0
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_utf_8_char_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_utf_8_char,
+        0
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_u8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_u8,
+        u8::MAX
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_ascii_u8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_ascii_u8,
+        u8::MAX
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_gb_18030_u8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_gb_18030_u8,
+        u8::MAX
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_utf_8_u8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_utf_8_u8,
+        u8::MAX
+    );
+}
+
+#[test]
+fn test_encode_then_decode_non_u8_signed_primitive_slice() {
+    // <field name="fixed16i8" id="21" type="Fixed16i8"/>
+    // <field name="fixed16i16" id="22" type="Fixed16i16"/>
+    // <field name="fixed16i32" id="23" type="Fixed16i32"/>
+    // <field name="fixed16i64" id="24" type="Fixed16i64"/>
+    macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
+        ($encode_func:expr, $decode_func:expr, $i_type:ty, $i_null:expr) => {
+            let test_data = [
+                &[] as &[$i_type],
+                &[1 as $i_type] as &[$i_type],
+                &[0 as $i_type] as &[$i_type],
+                &[-1 as $i_type] as &[$i_type],
+                &[-1, 1 as $i_type] as &[$i_type],
+                &[-1, 0, 1 as $i_type] as &[$i_type],
+                &[-2, -1, 1, 2 as $i_type] as &[$i_type],
+                &[-2, -1, 0, 1, 2 as $i_type] as &[$i_type],
+                &[-3, -2, -1, 1, 2, 3 as $i_type] as &[$i_type],
+                &[-3, -2, -1, 0, 1, 2, 3 as $i_type] as &[$i_type],
+                &[-4, -3, -2, -1, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[-4, -3, -2, -1, 0, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[-5, -4, -3, -2, -1, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[-6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[-7, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 7 as $i_type] as &[$i_type],
+                &[
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -9,
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -9,
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+            ];
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = vec![1u8; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, &each_slice);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx],
+                        decoded[each_idx],
+                        "Item mismatched at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+                let null_value = $i_null;
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx],
+                        null_value,
+                        "Item should be null at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_i8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_i8,
+        i8,
+        i8::MIN
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_i16_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_i16,
+        i16,
+        i16::MIN
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_i32_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_i32,
+        i32,
+        i32::MIN
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_i64_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_i64,
+        i64,
+        i64::MIN
+    );
+}
+
+#[test]
+fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
+    // <field name="fixed16u16" id="32" type="Fixed16u16"/>
+    // <field name="fixed16u32" id="33" type="Fixed16u32"/>
+    macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
+        ($encode_func:expr, $decode_func:expr, $i_type:ty, $i_null:expr) => {
+            let test_data = [
+                &[] as &[$i_type],
+                &[1 as $i_type] as &[$i_type],
+                &[0 as $i_type] as &[$i_type],
+                &[11 as $i_type] as &[$i_type],
+                &[11, 1 as $i_type] as &[$i_type],
+                &[11, 0, 1 as $i_type] as &[$i_type],
+                &[12, 11, 1, 2 as $i_type] as &[$i_type],
+                &[12, 11, 0, 1, 2 as $i_type] as &[$i_type],
+                &[13, 12, 11, 1, 2, 3 as $i_type] as &[$i_type],
+                &[13, 12, 11, 0, 1, 2, 3 as $i_type] as &[$i_type],
+                &[14, 13, 12, 11, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[14, 13, 12, 11, 0, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[15, 14, 13, 12, 11, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[15, 14, 13, 12, 11, 0, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[16, 15, 14, 13, 12, 11, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[16, 15, 14, 13, 12, 11, 0, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[17, 16, 15, 14, 13, 12, 11, 1, 2, 3, 4, 5, 6, 7 as $i_type] as &[$i_type],
+                &[
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7 as $i_type,
+                ] as &[$i_type],
+                &[
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    19,
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+                &[
+                    19,
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+            ];
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = vec![1u8; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, &each_slice);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx],
+                        decoded[each_idx],
+                        "Item mismatched at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+                let null_value = $i_null;
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx],
+                        null_value,
+                        "Item should be null at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_u16_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_u16,
+        u16,
+        u16::MAX
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_u32_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_u32,
+        u32,
+        u32::MAX
+    );
+    // run_encode_then_decode_for_array_of_u8_len_16!(DemoEncoder::fixed_16_u64_at_most_16_items_from_slice, DemoDecoder::fixed_16_i64, i64, u64::MAX);
+}

--- a/rust/tests/fixed_sized_primitive_array.rs
+++ b/rust/tests/fixed_sized_primitive_array.rs
@@ -74,7 +74,7 @@ fn test_encode_then_decode_u8_slice() {
                 let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, each_slice);
+                encode_func(&mut encoder, each_slice.iter().map(|x| *x));
 
                 let end = 1i32;
                 end_encode_func(&mut encoder, end);
@@ -106,49 +106,49 @@ fn test_encode_then_decode_u8_slice() {
     }
 
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_char_at_most_16_items_from_slice,
+        DemoEncoder::fixed_16_char_from_iter,
         DemoDecoder::fixed_16_char,
         DemoEncoder::fixed_16_char_end,
         DemoDecoder::fixed_16_char_end
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_ascii_char_at_most_16_items_from_slice,
+        DemoEncoder::fixed_16_ascii_char_from_iter,
         DemoDecoder::fixed_16_ascii_char,
         DemoEncoder::fixed_16_ascii_char_end,
         DemoDecoder::fixed_16_ascii_char_end
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_gb_18030_char_at_most_16_items_from_slice,
+        DemoEncoder::fixed_16_gb_18030_char_from_iter,
         DemoDecoder::fixed_16_gb_18030_char,
         DemoEncoder::fixed_16_gb_18030_char_end,
         DemoDecoder::fixed_16_gb_18030_char_end
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_utf_8_char_at_most_16_items_from_slice,
+        DemoEncoder::fixed_16_utf_8_char_from_iter,
         DemoDecoder::fixed_16_utf_8_char,
         DemoEncoder::fixed_16_utf_8_char_end,
         DemoDecoder::fixed_16_utf_8_char_end
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_u8_at_most_16_items_from_slice,
+        DemoEncoder::fixed_16_u8_from_iter,
         DemoDecoder::fixed_16_u8,
         DemoEncoder::fixed_16_u8_end,
         DemoDecoder::fixed_16_u8_end
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_ascii_u8_at_most_16_items_from_slice,
+        DemoEncoder::fixed_16_ascii_u8_from_iter,
         DemoDecoder::fixed_16_ascii_u8,
         DemoEncoder::fixed_16_ascii_u8_end,
         DemoDecoder::fixed_16_ascii_u8_end
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_gb_18030_u8_at_most_16_items_from_slice,
+        DemoEncoder::fixed_16_gb_18030_u8_from_iter,
         DemoDecoder::fixed_16_gb_18030_u8,
         DemoEncoder::fixed_16_gb_18030_u8_end,
         DemoDecoder::fixed_16_gb_18030_u8_end
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_utf_8_u8_at_most_16_items_from_slice,
+        DemoEncoder::fixed_16_utf_8_u8_from_iter,
         DemoDecoder::fixed_16_utf_8_u8,
         DemoEncoder::fixed_16_utf_8u_8_end,
         DemoDecoder::fixed_16_utf_8u_8_end
@@ -295,7 +295,7 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice() {
                 let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, &each_slice);
+                encode_func(&mut encoder, each_slice.iter().map(|x| *x));
 
                 let end = 1i32;
                 end_encode_func(&mut encoder, end);
@@ -333,28 +333,28 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice() {
     }
 
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i8_at_most_16_items_from_slice,
+        DemoEncoder::fixed_16_i8_from_iter,
         DemoDecoder::fixed_16_i8,
         DemoEncoder::fixed_16_i8_end,
         DemoDecoder::fixed_16_i8_end,
         i8, i8::from_le_bytes([uninit])
     );
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i16_at_most_16_items_from_slice,
+        DemoEncoder::fixed_16_i16_from_iter,
         DemoDecoder::fixed_16_i16,
         DemoEncoder::fixed_16_i16_end,
         DemoDecoder::fixed_16_i16_end,
         i16, i16::from_le_bytes([uninit, uninit])
     );
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i32_at_most_16_items_from_slice,
+        DemoEncoder::fixed_16_i32_from_iter,
         DemoDecoder::fixed_16_i32,
         DemoEncoder::fixed_16_i32_end,
         DemoDecoder::fixed_16_i32_end,
         i32, i32::from_le_bytes([uninit, uninit, uninit, uninit])
     );
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i64_at_most_16_items_from_slice,
+        DemoEncoder::fixed_16_i64_from_iter,
         DemoDecoder::fixed_16_i64,
         DemoEncoder::fixed_16_i64_end,
         DemoDecoder::fixed_16_i64_end,
@@ -500,7 +500,7 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
                 let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, each_slice);
+                encode_func(&mut encoder, each_slice.iter().map(|x| *x));
 
                 let end = 1i32;
                 end_encode_func(&mut encoder, end);
@@ -539,7 +539,7 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
     }
 
     run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u16_at_most_16_items_from_slice,
+        DemoEncoder::fixed_16_u16_from_iter,
         DemoDecoder::fixed_16_u16,
         DemoEncoder::fixed_16_u16_end,
         DemoDecoder::fixed_16_u16_end,
@@ -547,7 +547,7 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
         u16::from_le_bytes([uninit, uninit])
     );
     run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u32_at_most_16_items_from_slice,
+        DemoEncoder::fixed_16_u32_from_iter,
         DemoDecoder::fixed_16_u32,
         DemoEncoder::fixed_16_u32_end,
         DemoDecoder::fixed_16_u32_end,
@@ -555,7 +555,7 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
         u32::from_le_bytes([uninit, uninit, uninit, uninit])
     );
     run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u64_at_most_16_items_from_slice,
+        DemoEncoder::fixed_16_u64_from_iter,
         DemoDecoder::fixed_16_u64,
         DemoEncoder::fixed_16_u64_end,
         DemoDecoder::fixed_16_u64_end,
@@ -628,7 +628,7 @@ fn test_encode_then_decode_u8_slice_padded() {
                 let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, each_slice);
+                encode_func(&mut encoder, each_slice.iter().map(|x| *x));
 
                 let end = 1i32;
                 end_encode_func(&mut encoder, end);
@@ -660,49 +660,49 @@ fn test_encode_then_decode_u8_slice_padded() {
     }
 
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_char_at_most_16_items_from_slice_padded_with_zero,
+        DemoEncoder::fixed_16_char_from_iter,
         DemoDecoder::fixed_16_char,
         DemoEncoder::fixed_16_char_end,
         DemoDecoder::fixed_16_char_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_ascii_char_at_most_16_items_from_slice_padded_with_zero,
+        DemoEncoder::fixed_16_ascii_char_from_iter,
         DemoDecoder::fixed_16_ascii_char,
         DemoEncoder::fixed_16_ascii_char_end,
         DemoDecoder::fixed_16_ascii_char_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_gb_18030_char_at_most_16_items_from_slice_padded_with_zero,
+        DemoEncoder::fixed_16_gb_18030_char_from_iter,
         DemoDecoder::fixed_16_gb_18030_char,
         DemoEncoder::fixed_16_gb_18030_char_end,
         DemoDecoder::fixed_16_gb_18030_char_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_utf_8_char_at_most_16_items_from_slice_padded_with_zero,
+        DemoEncoder::fixed_16_utf_8_char_from_iter,
         DemoDecoder::fixed_16_utf_8_char,
         DemoEncoder::fixed_16_utf_8_char_end,
         DemoDecoder::fixed_16_utf_8_char_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_u8_at_most_16_items_from_slice_padded_with_zero,
+        DemoEncoder::fixed_16_u8_from_iter,
         DemoDecoder::fixed_16_u8,
         DemoEncoder::fixed_16_u8_end,
         DemoDecoder::fixed_16_u8_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_ascii_u8_at_most_16_items_from_slice_padded_with_zero,
+        DemoEncoder::fixed_16_ascii_u8_from_iter,
         DemoDecoder::fixed_16_ascii_u8,
         DemoEncoder::fixed_16_ascii_u8_end,
         DemoDecoder::fixed_16_ascii_u8_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_gb_18030_u8_at_most_16_items_from_slice_padded_with_zero,
+        DemoEncoder::fixed_16_gb_18030_u8_from_iter,
         DemoDecoder::fixed_16_gb_18030_u8,
         DemoEncoder::fixed_16_gb_18030_u8_end,
         DemoDecoder::fixed_16_gb_18030_u8_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_utf_8_u8_at_most_16_items_from_slice_padded_with_zero,
+        DemoEncoder::fixed_16_utf_8_u8_from_iter,
         DemoDecoder::fixed_16_utf_8_u8,
         DemoEncoder::fixed_16_utf_8u_8_end,
         DemoDecoder::fixed_16_utf_8u_8_end,
@@ -846,7 +846,7 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice_padded() {
                 let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, each_slice);
+                encode_func(&mut encoder, each_slice.iter().map(|x| *x));
 
                 let end = 1i32;
                 end_encode_func(&mut encoder, end);
@@ -884,28 +884,28 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice_padded() {
     }
 
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i8_at_most_16_items_from_slice_padded_with_zero,
+        DemoEncoder::fixed_16_i8_from_iter,
         DemoDecoder::fixed_16_i8,
         DemoEncoder::fixed_16_i8_end,
         DemoDecoder::fixed_16_i8_end,
         i8,
     );
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i16_at_most_16_items_from_slice_padded_with_zero,
+        DemoEncoder::fixed_16_i16_from_iter,
         DemoDecoder::fixed_16_i16,
         DemoEncoder::fixed_16_i16_end,
         DemoDecoder::fixed_16_i16_end,
         i16,
     );
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i32_at_most_16_items_from_slice_padded_with_zero,
+        DemoEncoder::fixed_16_i32_from_iter,
         DemoDecoder::fixed_16_i32,
         DemoEncoder::fixed_16_i32_end,
         DemoDecoder::fixed_16_i32_end,
         i32,
     );
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i64_at_most_16_items_from_slice_padded_with_zero,
+        DemoEncoder::fixed_16_i64_from_iter,
         DemoDecoder::fixed_16_i64,
         DemoEncoder::fixed_16_i64_end,
         DemoDecoder::fixed_16_i64_end,
@@ -1049,7 +1049,7 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice_padded() {
                 let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, each_slice);
+                encode_func(&mut encoder, each_slice.iter().map(|x| *x));
 
                 let end = 1i32;
                 end_encode_func(&mut encoder, end);
@@ -1087,21 +1087,21 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice_padded() {
     }
 
     run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u16_at_most_16_items_from_slice_padded_with_zero,
+        DemoEncoder::fixed_16_u16_from_iter,
         DemoDecoder::fixed_16_u16,
         DemoEncoder::fixed_16_u16_end,
         DemoDecoder::fixed_16_u16_end,
         u16
     );
     run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u32_at_most_16_items_from_slice_padded_with_zero,
+        DemoEncoder::fixed_16_u32_from_iter,
         DemoDecoder::fixed_16_u32,
         DemoEncoder::fixed_16_u32_end,
         DemoDecoder::fixed_16_u32_end,
         u32
     );
     run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u64_at_most_16_items_from_slice_padded_with_zero,
+        DemoEncoder::fixed_16_u64_from_iter,
         DemoDecoder::fixed_16_u64,
         DemoEncoder::fixed_16_u64_end,
         DemoDecoder::fixed_16_u64_end,

--- a/rust/tests/fixed_sized_primitive_array.rs
+++ b/rust/tests/fixed_sized_primitive_array.rs
@@ -4,14 +4,16 @@ use fixed_sized_primitive_array::{
     ReadBuf, WriteBuf,
 };
 
-fn create_encoder(buffer: &mut Vec<u8>) -> DemoEncoder {
-    let encoder = DemoEncoder::default().wrap(WriteBuf::new(buffer.as_mut_slice()), ENCODED_LENGTH);
+fn create_encoder(buffer: &mut [u8]) -> DemoEncoder {
+    let encoder = DemoEncoder::default().wrap(WriteBuf::new(buffer), ENCODED_LENGTH);
     let mut header = encoder.header(0);
     header.parent().unwrap()
 }
 
 #[test]
 fn test_encode_then_decode_u8_slice() {
+    let uninit = 1u8;
+
     let test_data = [
         b"" as &[u8],
         b"0" as &[u8],
@@ -58,19 +60,578 @@ fn test_encode_then_decode_u8_slice() {
     // <field name="fixed16Gb18030U8" id="13" type="Fixed16Gb18030U8"/>
     // <field name="fixed16Utf8U8" id="14" type="Fixed16Utf8U8"/>
     macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
-        ($encode_func:expr, $decode_func:expr) => {
+        ($encode_func:expr, $decode_func:expr, $end_encode_func:expr, $end_decode_func:expr) => {
             for each_slice in test_data {
                 let encode_func = $encode_func;
                 let decode_func = $decode_func;
+                let end_encode_func = $end_encode_func;
+                let end_decode_func = $end_decode_func;
 
                 let cur_len = each_slice.len();
                 let effective_len = cur_len.min(16);
 
                 // encode...
-                let mut buffer = vec![0u8; 1024];
+                let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
                 encode_func(&mut encoder, each_slice);
+
+                let end = 1i32;
+                end_encode_func(&mut encoder, end);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx], decoded[each_idx],
+                        "Item mismatched at {}/{}",
+                        each_idx, cur_len
+                    );
+                }
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx], uninit,
+                        "Item should not be padded ZERO at {}/{}",
+                        each_idx, cur_len
+                    );
+                }
+                let decoded_end = end_decode_func(&decoder);
+                assert_eq!(decoded_end, end, "End Item should equal",);
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_char_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_char,
+        DemoEncoder::fixed_16_char_end,
+        DemoDecoder::fixed_16_char_end
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_ascii_char_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_ascii_char,
+        DemoEncoder::fixed_16_ascii_char_end,
+        DemoDecoder::fixed_16_ascii_char_end
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_gb_18030_char_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_gb_18030_char,
+        DemoEncoder::fixed_16_gb_18030_char_end,
+        DemoDecoder::fixed_16_gb_18030_char_end
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_utf_8_char_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_utf_8_char,
+        DemoEncoder::fixed_16_utf_8_char_end,
+        DemoDecoder::fixed_16_utf_8_char_end
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_u8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_u8,
+        DemoEncoder::fixed_16_u8_end,
+        DemoDecoder::fixed_16_u8_end
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_ascii_u8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_ascii_u8,
+        DemoEncoder::fixed_16_ascii_u8_end,
+        DemoDecoder::fixed_16_ascii_u8_end
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_gb_18030_u8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_gb_18030_u8,
+        DemoEncoder::fixed_16_gb_18030_u8_end,
+        DemoDecoder::fixed_16_gb_18030_u8_end
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_utf_8_u8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_utf_8_u8,
+        DemoEncoder::fixed_16_utf_8u_8_end,
+        DemoDecoder::fixed_16_utf_8u_8_end
+    );
+}
+
+#[test]
+fn test_encode_then_decode_non_u8_signed_primitive_slice() {
+    let uninit = 1u8;
+
+    // <field name="fixed16i8" id="21" type="Fixed16i8"/>
+    // <field name="fixed16i16" id="22" type="Fixed16i16"/>
+    // <field name="fixed16i32" id="23" type="Fixed16i32"/>
+    // <field name="fixed16i64" id="24" type="Fixed16i64"/>
+    macro_rules! run_encode_then_decode_for_array_of_signed_len_16 {
+        ($encode_func:expr, $decode_func:expr, $end_encode_func:expr, $end_decode_func:expr, $i_type:ty, $existed:expr) => {
+            let test_data = [
+                &[] as &[$i_type],
+                &[1 as $i_type] as &[$i_type],
+                &[0 as $i_type] as &[$i_type],
+                &[-1 as $i_type] as &[$i_type],
+                &[-1, 1 as $i_type] as &[$i_type],
+                &[-1, 0, 1 as $i_type] as &[$i_type],
+                &[-2, -1, 1, 2 as $i_type] as &[$i_type],
+                &[-2, -1, 0, 1, 2 as $i_type] as &[$i_type],
+                &[-3, -2, -1, 1, 2, 3 as $i_type] as &[$i_type],
+                &[-3, -2, -1, 0, 1, 2, 3 as $i_type] as &[$i_type],
+                &[-4, -3, -2, -1, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[-4, -3, -2, -1, 0, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[-5, -4, -3, -2, -1, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[-6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[-7, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 7 as $i_type] as &[$i_type],
+                &[
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -9,
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -9,
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+            ];
+
+            let existed = $existed;
+
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+                let end_encode_func = $end_encode_func;
+                let end_decode_func = $end_decode_func;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = [uninit; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, &each_slice);
+
+                let end = 1i32;
+                end_encode_func(&mut encoder, end);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx],
+                        decoded[each_idx],
+                        "Item mismatched at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx],
+                        existed,
+                        "Item should not be padded ZERO at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+                let decoded_end = end_decode_func(&decoder);
+                assert_eq!(decoded_end, end, "End Item should equal",);
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_signed_len_16!(
+        DemoEncoder::fixed_16_i8_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_i8,
+        DemoEncoder::fixed_16_i8_end,
+        DemoDecoder::fixed_16_i8_end,
+        i8, i8::from_le_bytes([uninit])
+    );
+    run_encode_then_decode_for_array_of_signed_len_16!(
+        DemoEncoder::fixed_16_i16_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_i16,
+        DemoEncoder::fixed_16_i16_end,
+        DemoDecoder::fixed_16_i16_end,
+        i16, i16::from_le_bytes([uninit, uninit])
+    );
+    run_encode_then_decode_for_array_of_signed_len_16!(
+        DemoEncoder::fixed_16_i32_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_i32,
+        DemoEncoder::fixed_16_i32_end,
+        DemoDecoder::fixed_16_i32_end,
+        i32, i32::from_le_bytes([uninit, uninit, uninit, uninit])
+    );
+    run_encode_then_decode_for_array_of_signed_len_16!(
+        DemoEncoder::fixed_16_i64_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_i64,
+        DemoEncoder::fixed_16_i64_end,
+        DemoDecoder::fixed_16_i64_end,
+        i64, i64::from_le_bytes([uninit, uninit, uninit, uninit, uninit, uninit, uninit, uninit])
+    );
+}
+
+#[test]
+fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
+    let uninit = 1u8;
+
+    // <field name="fixed16u16" id="32" type="Fixed16u16"/>
+    // <field name="fixed16u32" id="33" type="Fixed16u32"/>
+    macro_rules! run_encode_then_decode_for_array_of_unsigned_len_16 {
+        ($encode_func:expr, $decode_func:expr, $end_encode_func:expr, $end_decode_func:expr, $i_type:ty, $existed:expr) => {
+            let test_data = [
+                &[] as &[$i_type],
+                &[1 as $i_type] as &[$i_type],
+                &[0 as $i_type] as &[$i_type],
+                &[11 as $i_type] as &[$i_type],
+                &[11, 1 as $i_type] as &[$i_type],
+                &[11, 0, 1 as $i_type] as &[$i_type],
+                &[12, 11, 1, 2 as $i_type] as &[$i_type],
+                &[12, 11, 0, 1, 2 as $i_type] as &[$i_type],
+                &[13, 12, 11, 1, 2, 3 as $i_type] as &[$i_type],
+                &[13, 12, 11, 0, 1, 2, 3 as $i_type] as &[$i_type],
+                &[14, 13, 12, 11, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[14, 13, 12, 11, 0, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[15, 14, 13, 12, 11, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[15, 14, 13, 12, 11, 0, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[16, 15, 14, 13, 12, 11, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[16, 15, 14, 13, 12, 11, 0, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[17, 16, 15, 14, 13, 12, 11, 1, 2, 3, 4, 5, 6, 7 as $i_type] as &[$i_type],
+                &[
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7 as $i_type,
+                ] as &[$i_type],
+                &[
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    19,
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+                &[
+                    19,
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+            ];
+
+            let existed = $existed;
+
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+                let end_encode_func = $end_encode_func;
+                let end_decode_func = $end_decode_func;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = [uninit; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, each_slice);
+
+                let end = 1i32;
+                end_encode_func(&mut encoder, end);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx],
+                        decoded[each_idx],
+                        "Item mismatched at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx],
+                        existed,
+                        "Item should not be padded ZERO at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+                let decoded_end = end_decode_func(&decoder);
+                assert_eq!(decoded_end, end, "End Item should equal",);
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
+        DemoEncoder::fixed_16_u16_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_u16,
+        DemoEncoder::fixed_16_u16_end,
+        DemoDecoder::fixed_16_u16_end,
+        u16,
+        u16::from_le_bytes([uninit, uninit])
+    );
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
+        DemoEncoder::fixed_16_u32_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_u32,
+        DemoEncoder::fixed_16_u32_end,
+        DemoDecoder::fixed_16_u32_end,
+        u32,
+        u32::from_le_bytes([uninit, uninit, uninit, uninit])
+    );
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
+        DemoEncoder::fixed_16_u64_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_u64,
+        DemoEncoder::fixed_16_u64_end,
+        DemoDecoder::fixed_16_u64_end,
+        u64,
+        u64::from_le_bytes([uninit, uninit, uninit, uninit, uninit, uninit, uninit, uninit])
+    );
+}
+
+#[test]
+fn test_encode_then_decode_u8_slice_padded() {
+    let uninit = 1u8;
+
+    let test_data = [
+        b"" as &[u8],
+        b"0" as &[u8],
+        b"01" as &[u8],
+        b"012" as &[u8],
+        b"0123" as &[u8],
+        b"01234" as &[u8],
+        b"012345" as &[u8],
+        b"0123456" as &[u8],
+        b"01234567" as &[u8],
+        b"012345678" as &[u8],
+        b"0123456789" as &[u8],
+        b"0123456789A" as &[u8],
+        b"0123456789AB" as &[u8],
+        b"0123456789ABC" as &[u8],
+        b"0123456789ABCD" as &[u8],
+        b"0123456789ABCDE" as &[u8],
+        b"0123456789ABCDEF" as &[u8],
+        b"0123456789abcdef" as &[u8],
+        b"0123456789abcdef0" as &[u8],
+        b"0123456789abcdef01" as &[u8],
+        b"0123456789abcdef012" as &[u8],
+        b"0123456789abcdef0123" as &[u8],
+        b"0123456789abcdef01234" as &[u8],
+        b"0123456789abcdef012345" as &[u8],
+        b"0123456789abcdef0123456" as &[u8],
+        b"0123456789abcdef01234567" as &[u8],
+        b"0123456789abcdef012345678" as &[u8],
+        b"0123456789abcdef0123456789" as &[u8],
+        b"0123456789abcdef0123456789A" as &[u8],
+        b"0123456789abcdef0123456789AB" as &[u8],
+        b"0123456789abcdef0123456789ABC" as &[u8],
+        b"0123456789abcdef0123456789ABCD" as &[u8],
+        b"0123456789abcdef0123456789ABCDE" as &[u8],
+        b"0123456789abcdef0123456789ABCDEF" as &[u8],
+    ];
+
+    // <field name="fixed16Char" id="1" type="Fixed16Char"/>
+    // <field name="fixed16AsciiChar" id="2" type="Fixed16AsciiChar"/>
+    // <field name="fixed16Gb18030Char" id="3" type="Fixed16Gb18030Char"/>
+    // <field name="fixed16Utf8Char" id="4" type="Fixed16Utf8Char"/>
+    // <field name="fixed16U8" id="11" type="Fixed16U8"/>
+    // <field name="fixed16AsciiU8" id="12" type="Fixed16AsciiU8"/>
+    // <field name="fixed16Gb18030U8" id="13" type="Fixed16Gb18030U8"/>
+    // <field name="fixed16Utf8U8" id="14" type="Fixed16Utf8U8"/>
+    macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
+        ($encode_func:expr, $decode_func:expr, $end_encode_func:expr, $end_decode_func:expr,) => {
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+                let end_encode_func = $end_encode_func;
+                let end_decode_func = $end_decode_func;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = [uninit; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, each_slice);
+
+                let end = 1i32;
+                end_encode_func(&mut encoder, end);
 
                 // decode...
                 let buf = ReadBuf::new(buffer.as_slice());
@@ -88,552 +649,76 @@ fn test_encode_then_decode_u8_slice() {
                 for each_idx in effective_len..16 {
                     assert_eq!(
                         decoded[each_idx], 0,
-                        "Item should be ZERO at {}/{}",
+                        "Item should be padded ZERO at {}/{}",
                         each_idx, cur_len
                     );
                 }
+                let decoded_end = end_decode_func(&decoder);
+                assert_eq!(decoded_end, end, "End Item should equal",);
             }
         };
     }
 
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_char_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_char
-    );
-    run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_ascii_char_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_ascii_char
-    );
-    run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_gb_18030_char_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_gb_18030_char
-    );
-    run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_utf_8_char_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_utf_8_char
-    );
-    run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_u8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_u8
-    );
-    run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_ascii_u8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_ascii_u8
-    );
-    run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_gb_18030_u8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_gb_18030_u8
-    );
-    run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_utf_8_u8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_utf_8_u8
-    );
-}
-
-#[test]
-fn test_encode_then_decode_non_u8_signed_primitive_slice() {
-    // <field name="fixed16i8" id="21" type="Fixed16i8"/>
-    // <field name="fixed16i16" id="22" type="Fixed16i16"/>
-    // <field name="fixed16i32" id="23" type="Fixed16i32"/>
-    // <field name="fixed16i64" id="24" type="Fixed16i64"/>
-    macro_rules! run_encode_then_decode_for_array_of_signed_len_16 {
-        ($encode_func:expr, $decode_func:expr, $i_type:ty) => {
-            let test_data = [
-                &[] as &[$i_type],
-                &[1 as $i_type] as &[$i_type],
-                &[0 as $i_type] as &[$i_type],
-                &[-1 as $i_type] as &[$i_type],
-                &[-1, 1 as $i_type] as &[$i_type],
-                &[-1, 0, 1 as $i_type] as &[$i_type],
-                &[-2, -1, 1, 2 as $i_type] as &[$i_type],
-                &[-2, -1, 0, 1, 2 as $i_type] as &[$i_type],
-                &[-3, -2, -1, 1, 2, 3 as $i_type] as &[$i_type],
-                &[-3, -2, -1, 0, 1, 2, 3 as $i_type] as &[$i_type],
-                &[-4, -3, -2, -1, 1, 2, 3, 4 as $i_type] as &[$i_type],
-                &[-4, -3, -2, -1, 0, 1, 2, 3, 4 as $i_type] as &[$i_type],
-                &[-5, -4, -3, -2, -1, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
-                &[-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
-                &[-6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
-                &[-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
-                &[-7, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 7 as $i_type] as &[$i_type],
-                &[
-                    -7,
-                    -6,
-                    -5,
-                    -4,
-                    -3,
-                    -2,
-                    -1,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7 as $i_type,
-                ] as &[$i_type],
-                &[
-                    -8,
-                    -7,
-                    -6,
-                    -5,
-                    -4,
-                    -3,
-                    -2,
-                    -1,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8 as $i_type,
-                ] as &[$i_type],
-                &[
-                    -8,
-                    -7,
-                    -6,
-                    -5,
-                    -4,
-                    -3,
-                    -2,
-                    -1,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8 as $i_type,
-                ] as &[$i_type],
-                &[
-                    -9,
-                    -8,
-                    -7,
-                    -6,
-                    -5,
-                    -4,
-                    -3,
-                    -2,
-                    -1,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8,
-                    9 as $i_type,
-                ] as &[$i_type],
-                &[
-                    -9,
-                    -8,
-                    -7,
-                    -6,
-                    -5,
-                    -4,
-                    -3,
-                    -2,
-                    -1,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8,
-                    9 as $i_type,
-                ] as &[$i_type],
-            ];
-            for each_slice in test_data {
-                let encode_func = $encode_func;
-                let decode_func = $decode_func;
-
-                let cur_len = each_slice.len();
-                let effective_len = cur_len.min(16);
-
-                // encode...
-                let mut buffer = vec![0u8; 1024];
-                let mut encoder = create_encoder(&mut buffer);
-
-                encode_func(&mut encoder, &each_slice);
-
-                // decode...
-                let buf = ReadBuf::new(buffer.as_slice());
-                let header = MessageHeaderDecoder::default().wrap(buf, 0);
-
-                let decoder = DemoDecoder::default().header(header, 0);
-                let decoded = decode_func(&decoder);
-                for each_idx in 0..effective_len {
-                    assert_eq!(
-                        each_slice[each_idx],
-                        decoded[each_idx],
-                        "Item mismatched at {}/{} for {}",
-                        each_idx,
-                        cur_len,
-                        stringify!($i_type)
-                    );
-                }
-                for each_idx in effective_len..16 {
-                    assert_eq!(
-                        decoded[each_idx],
-                        0,
-                        "Item should be ZERO at {}/{} for {}",
-                        each_idx,
-                        cur_len,
-                        stringify!($i_type)
-                    );
-                }
-            }
-        };
-    }
-
-    run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_i8,
-        i8
-    );
-    run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i16_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_i16,
-        i16
-    );
-    run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i32_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_i32,
-        i32
-    );
-    run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i64_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_i64,
-        i64
-    );
-}
-
-#[test]
-fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
-    // <field name="fixed16u16" id="32" type="Fixed16u16"/>
-    // <field name="fixed16u32" id="33" type="Fixed16u32"/>
-    macro_rules! run_encode_then_decode_for_array_of_unsigned_len_16 {
-        ($encode_func:expr, $decode_func:expr, $i_type:ty) => {
-            let test_data = [
-                &[] as &[$i_type],
-                &[1 as $i_type] as &[$i_type],
-                &[0 as $i_type] as &[$i_type],
-                &[11 as $i_type] as &[$i_type],
-                &[11, 1 as $i_type] as &[$i_type],
-                &[11, 0, 1 as $i_type] as &[$i_type],
-                &[12, 11, 1, 2 as $i_type] as &[$i_type],
-                &[12, 11, 0, 1, 2 as $i_type] as &[$i_type],
-                &[13, 12, 11, 1, 2, 3 as $i_type] as &[$i_type],
-                &[13, 12, 11, 0, 1, 2, 3 as $i_type] as &[$i_type],
-                &[14, 13, 12, 11, 1, 2, 3, 4 as $i_type] as &[$i_type],
-                &[14, 13, 12, 11, 0, 1, 2, 3, 4 as $i_type] as &[$i_type],
-                &[15, 14, 13, 12, 11, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
-                &[15, 14, 13, 12, 11, 0, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
-                &[16, 15, 14, 13, 12, 11, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
-                &[16, 15, 14, 13, 12, 11, 0, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
-                &[17, 16, 15, 14, 13, 12, 11, 1, 2, 3, 4, 5, 6, 7 as $i_type] as &[$i_type],
-                &[
-                    17,
-                    16,
-                    15,
-                    14,
-                    13,
-                    12,
-                    11,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7 as $i_type,
-                ] as &[$i_type],
-                &[
-                    18,
-                    17,
-                    16,
-                    15,
-                    14,
-                    13,
-                    12,
-                    11,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8 as $i_type,
-                ] as &[$i_type],
-                &[
-                    18,
-                    17,
-                    16,
-                    15,
-                    14,
-                    13,
-                    12,
-                    11,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8 as $i_type,
-                ] as &[$i_type],
-                &[
-                    19,
-                    18,
-                    17,
-                    16,
-                    15,
-                    14,
-                    13,
-                    12,
-                    11,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8,
-                    9 as $i_type,
-                ] as &[$i_type],
-                &[
-                    19,
-                    18,
-                    17,
-                    16,
-                    15,
-                    14,
-                    13,
-                    12,
-                    11,
-                    0,
-                    1,
-                    2,
-                    3,
-                    4,
-                    5,
-                    6,
-                    7,
-                    8,
-                    9 as $i_type,
-                ] as &[$i_type],
-            ];
-            for each_slice in test_data {
-                let encode_func = $encode_func;
-                let decode_func = $decode_func;
-
-                let cur_len = each_slice.len();
-                let effective_len = cur_len.min(16);
-
-                // encode...
-                let mut buffer = vec![0u8; 1024];
-                let mut encoder = create_encoder(&mut buffer);
-
-                encode_func(&mut encoder, each_slice);
-
-                // decode...
-                let buf = ReadBuf::new(buffer.as_slice());
-                let header = MessageHeaderDecoder::default().wrap(buf, 0);
-
-                let decoder = DemoDecoder::default().header(header, 0);
-                let decoded = decode_func(&decoder);
-                for each_idx in 0..effective_len {
-                    assert_eq!(
-                        each_slice[each_idx],
-                        decoded[each_idx],
-                        "Item mismatched at {}/{} for {}",
-                        each_idx,
-                        cur_len,
-                        stringify!($i_type)
-                    );
-                }
-                for each_idx in effective_len..16 {
-                    assert_eq!(
-                        decoded[each_idx],
-                        0,
-                        "Item should be ZERO at {}/{} for {}",
-                        each_idx,
-                        cur_len,
-                        stringify!($i_type)
-                    );
-                }
-            }
-        };
-    }
-
-    run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u16_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_u16,
-        u16
-    );
-    run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u32_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_u32,
-        u32
-    );
-    run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u64_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_u64,
-        u64
-    );
-}
-
-#[test]
-fn test_encode_then_decode_u8_slice_padded() {
-    let test_data = [
-        b"" as &[u8],
-        b"0" as &[u8],
-        b"01" as &[u8],
-        b"012" as &[u8],
-        b"0123" as &[u8],
-        b"01234" as &[u8],
-        b"012345" as &[u8],
-        b"0123456" as &[u8],
-        b"01234567" as &[u8],
-        b"012345678" as &[u8],
-        b"0123456789" as &[u8],
-        b"0123456789A" as &[u8],
-        b"0123456789AB" as &[u8],
-        b"0123456789ABC" as &[u8],
-        b"0123456789ABCD" as &[u8],
-        b"0123456789ABCDE" as &[u8],
-        b"0123456789ABCDEF" as &[u8],
-        b"0123456789abcdef" as &[u8],
-        b"0123456789abcdef0" as &[u8],
-        b"0123456789abcdef01" as &[u8],
-        b"0123456789abcdef012" as &[u8],
-        b"0123456789abcdef0123" as &[u8],
-        b"0123456789abcdef01234" as &[u8],
-        b"0123456789abcdef012345" as &[u8],
-        b"0123456789abcdef0123456" as &[u8],
-        b"0123456789abcdef01234567" as &[u8],
-        b"0123456789abcdef012345678" as &[u8],
-        b"0123456789abcdef0123456789" as &[u8],
-        b"0123456789abcdef0123456789A" as &[u8],
-        b"0123456789abcdef0123456789AB" as &[u8],
-        b"0123456789abcdef0123456789ABC" as &[u8],
-        b"0123456789abcdef0123456789ABCD" as &[u8],
-        b"0123456789abcdef0123456789ABCDE" as &[u8],
-        b"0123456789abcdef0123456789ABCDEF" as &[u8],
-    ];
-
-    // <field name="fixed16Char" id="1" type="Fixed16Char"/>
-    // <field name="fixed16AsciiChar" id="2" type="Fixed16AsciiChar"/>
-    // <field name="fixed16Gb18030Char" id="3" type="Fixed16Gb18030Char"/>
-    // <field name="fixed16Utf8Char" id="4" type="Fixed16Utf8Char"/>
-    // <field name="fixed16U8" id="11" type="Fixed16U8"/>
-    // <field name="fixed16AsciiU8" id="12" type="Fixed16AsciiU8"/>
-    // <field name="fixed16Gb18030U8" id="13" type="Fixed16Gb18030U8"/>
-    // <field name="fixed16Utf8U8" id="14" type="Fixed16Utf8U8"/>
-    macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
-        ($encode_func:expr, $decode_func:expr, $i_padded:expr) => {
-            for each_slice in test_data {
-                let encode_func = $encode_func;
-                let decode_func = $decode_func;
-                let padded_value = $i_padded;
-
-                let cur_len = each_slice.len();
-                let effective_len = cur_len.min(16);
-
-                // encode...
-                let mut buffer = vec![0u8; 1024];
-                let mut encoder = create_encoder(&mut buffer);
-
-                encode_func(&mut encoder, each_slice, padded_value);
-
-                // decode...
-                let buf = ReadBuf::new(buffer.as_slice());
-                let header = MessageHeaderDecoder::default().wrap(buf, 0);
-
-                let decoder = DemoDecoder::default().header(header, 0);
-                let decoded = decode_func(&decoder);
-                for each_idx in 0..effective_len {
-                    assert_eq!(
-                        each_slice[each_idx], decoded[each_idx],
-                        "Item mismatched at {}/{}",
-                        each_idx, cur_len
-                    );
-                }
-                for each_idx in effective_len..16 {
-                    assert_eq!(
-                        decoded[each_idx], padded_value,
-                        "Item should be padded at {}/{}",
-                        each_idx, cur_len
-                    );
-                }
-            }
-        };
-    }
-
-    run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_char_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_char_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_char,
-        30
+        DemoEncoder::fixed_16_char_end,
+        DemoDecoder::fixed_16_char_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_ascii_char_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_ascii_char_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_ascii_char,
-        30
+        DemoEncoder::fixed_16_ascii_char_end,
+        DemoDecoder::fixed_16_ascii_char_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_gb_18030_char_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_gb_18030_char_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_gb_18030_char,
-        30
+        DemoEncoder::fixed_16_gb_18030_char_end,
+        DemoDecoder::fixed_16_gb_18030_char_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_utf_8_char_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_utf_8_char_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_utf_8_char,
-        30
+        DemoEncoder::fixed_16_utf_8_char_end,
+        DemoDecoder::fixed_16_utf_8_char_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_u8_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_u8_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_u8,
-        30
+        DemoEncoder::fixed_16_u8_end,
+        DemoDecoder::fixed_16_u8_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_ascii_u8_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_ascii_u8_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_ascii_u8,
-        30
+        DemoEncoder::fixed_16_ascii_u8_end,
+        DemoDecoder::fixed_16_ascii_u8_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_gb_18030_u8_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_gb_18030_u8_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_gb_18030_u8,
-        30
+        DemoEncoder::fixed_16_gb_18030_u8_end,
+        DemoDecoder::fixed_16_gb_18030_u8_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_utf_8_u8_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_utf_8_u8_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_utf_8_u8,
-        30
+        DemoEncoder::fixed_16_utf_8u_8_end,
+        DemoDecoder::fixed_16_utf_8u_8_end,
     );
 }
 
 #[test]
 fn test_encode_then_decode_non_u8_signed_primitive_slice_padded() {
+    let uninit = 1u8;
+
     // <field name="fixed16i8" id="21" type="Fixed16i8"/>
     // <field name="fixed16i16" id="22" type="Fixed16i16"/>
     // <field name="fixed16i32" id="23" type="Fixed16i32"/>
     // <field name="fixed16i64" id="24" type="Fixed16i64"/>
     macro_rules! run_encode_then_decode_for_array_of_signed_len_16 {
-        ($encode_func:expr, $decode_func:expr, $i_type:ty, $i_padded:expr) => {
+        ($encode_func:expr, $decode_func:expr, $end_encode_func:expr, $end_decode_func:expr, $i_type:ty,) => {
             let test_data = [
                 &[] as &[$i_type],
                 &[1 as $i_type] as &[$i_type],
@@ -751,16 +836,20 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice_padded() {
             for each_slice in test_data {
                 let encode_func = $encode_func;
                 let decode_func = $decode_func;
-                let padded_value = $i_padded;
+                let end_encode_func = $end_encode_func;
+                let end_decode_func = $end_decode_func;
 
                 let cur_len = each_slice.len();
                 let effective_len = cur_len.min(16);
 
                 // encode...
-                let mut buffer = vec![0u8; 1024];
+                let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, each_slice, padded_value);
+                encode_func(&mut encoder, each_slice);
+
+                let end = 1i32;
+                end_encode_func(&mut encoder, end);
 
                 // decode...
                 let buf = ReadBuf::new(buffer.as_slice());
@@ -781,50 +870,58 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice_padded() {
                 for each_idx in effective_len..16 {
                     assert_eq!(
                         decoded[each_idx],
-                        padded_value,
-                        "Item should be padded at {}/{} for {}",
+                        0,
+                        "Item should be padded ZERO at {}/{} for {}",
                         each_idx,
                         cur_len,
                         stringify!($i_type)
                     );
                 }
+                let decoded_end = end_decode_func(&decoder);
+                assert_eq!(decoded_end, end, "End Item should equal",);
             }
         };
     }
 
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i8_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_i8_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_i8,
+        DemoEncoder::fixed_16_i8_end,
+        DemoDecoder::fixed_16_i8_end,
         i8,
-        -31
     );
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i16_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_i16_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_i16,
+        DemoEncoder::fixed_16_i16_end,
+        DemoDecoder::fixed_16_i16_end,
         i16,
-        -31
     );
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i32_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_i32_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_i32,
+        DemoEncoder::fixed_16_i32_end,
+        DemoDecoder::fixed_16_i32_end,
         i32,
-        -31
     );
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i64_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_i64_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_i64,
+        DemoEncoder::fixed_16_i64_end,
+        DemoDecoder::fixed_16_i64_end,
         i64,
-        -31
     );
 }
 
 #[test]
 fn test_encode_then_decode_non_u8_unsigned_primitive_slice_padded() {
+    let uninit = 1u8;
+
     // <field name="fixed16u16" id="32" type="Fixed16u16"/>
     // <field name="fixed16u32" id="33" type="Fixed16u32"/>
     // <field name="fixed16u64" id="33" type="Fixed16u64"/>
     macro_rules! run_encode_then_decode_for_array_of_unsigned_len_16 {
-        ($encode_func:expr, $decode_func:expr, $i_type:ty, $i_padded:expr) => {
+        ($encode_func:expr, $decode_func:expr, $end_encode_func:expr, $end_decode_func:expr, $i_type:ty) => {
             let test_data = [
                 &[] as &[$i_type],
                 &[1 as $i_type] as &[$i_type],
@@ -942,16 +1039,20 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice_padded() {
             for each_slice in test_data {
                 let encode_func = $encode_func;
                 let decode_func = $decode_func;
-                let padded_value = $i_padded;
+                let end_encode_func = $end_encode_func;
+                let end_decode_func = $end_decode_func;
 
                 let cur_len = each_slice.len();
                 let effective_len = cur_len.min(16);
 
                 // encode...
-                let mut buffer = vec![0u8; 1024];
+                let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, each_slice, padded_value);
+                encode_func(&mut encoder, each_slice);
+
+                let end = 1i32;
+                end_encode_func(&mut encoder, end);
 
                 // decode...
                 let buf = ReadBuf::new(buffer.as_slice());
@@ -972,33 +1073,38 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice_padded() {
                 for each_idx in effective_len..16 {
                     assert_eq!(
                         decoded[each_idx],
-                        padded_value,
-                        "Item should be padded at {}/{} for {}",
+                        0,
+                        "Item should be padded ZERO at {}/{} for {}",
                         each_idx,
                         cur_len,
                         stringify!($i_type)
                     );
                 }
+                let decoded_end = end_decode_func(&decoder);
+                assert_eq!(decoded_end, end, "End Item should equal",);
             }
         };
     }
 
     run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u16_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_u16_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_u16,
-        u16,
-        1024u16
+        DemoEncoder::fixed_16_u16_end,
+        DemoDecoder::fixed_16_u16_end,
+        u16
     );
     run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u32_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_u32_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_u32,
-        u32,
-        10000000u32
+        DemoEncoder::fixed_16_u32_end,
+        DemoDecoder::fixed_16_u32_end,
+        u32
     );
     run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u64_at_most_16_items_from_slice_padded,
+        DemoEncoder::fixed_16_u64_at_most_16_items_from_slice_padded_with_zero,
         DemoDecoder::fixed_16_u64,
-        u64,
-        20241115173301u64
+        DemoEncoder::fixed_16_u64_end,
+        DemoDecoder::fixed_16_u64_end,
+        u64
     );
 }

--- a/rust/tests/fixed_sized_primitive_array.rs
+++ b/rust/tests/fixed_sized_primitive_array.rs
@@ -58,7 +58,7 @@ fn test_encode_then_decode_u8_slice() {
     // <field name="fixed16Gb18030U8" id="13" type="Fixed16Gb18030U8"/>
     // <field name="fixed16Utf8U8" id="14" type="Fixed16Utf8U8"/>
     macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
-        ($encode_func:expr, $decode_func:expr, $i_null:expr) => {
+        ($encode_func:expr, $decode_func:expr) => {
             for each_slice in test_data {
                 let encode_func = $encode_func;
                 let decode_func = $decode_func;
@@ -67,7 +67,7 @@ fn test_encode_then_decode_u8_slice() {
                 let effective_len = cur_len.min(16);
 
                 // encode...
-                let mut buffer = vec![1u8; 1024];
+                let mut buffer = vec![0u8; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
                 encode_func(&mut encoder, each_slice);
@@ -85,11 +85,10 @@ fn test_encode_then_decode_u8_slice() {
                         each_idx, cur_len
                     );
                 }
-                let null_value = $i_null;
                 for each_idx in effective_len..16 {
                     assert_eq!(
-                        decoded[each_idx], null_value,
-                        "Item should be NULL at {}/{}",
+                        decoded[each_idx], 0,
+                        "Item should be ZERO at {}/{}",
                         each_idx, cur_len
                     );
                 }
@@ -99,43 +98,35 @@ fn test_encode_then_decode_u8_slice() {
 
     run_encode_then_decode_for_array_of_u8_len_16!(
         DemoEncoder::fixed_16_char_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_char,
-        0
+        DemoDecoder::fixed_16_char
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
         DemoEncoder::fixed_16_ascii_char_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_ascii_char,
-        0
+        DemoDecoder::fixed_16_ascii_char
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
         DemoEncoder::fixed_16_gb_18030_char_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_gb_18030_char,
-        0
+        DemoDecoder::fixed_16_gb_18030_char
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
         DemoEncoder::fixed_16_utf_8_char_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_utf_8_char,
-        0
+        DemoDecoder::fixed_16_utf_8_char
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
         DemoEncoder::fixed_16_u8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_u8,
-        u8::MAX
+        DemoDecoder::fixed_16_u8
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
         DemoEncoder::fixed_16_ascii_u8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_ascii_u8,
-        u8::MAX
+        DemoDecoder::fixed_16_ascii_u8
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
         DemoEncoder::fixed_16_gb_18030_u8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_gb_18030_u8,
-        u8::MAX
+        DemoDecoder::fixed_16_gb_18030_u8
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
         DemoEncoder::fixed_16_utf_8_u8_at_most_16_items_from_slice,
-        DemoDecoder::fixed_16_utf_8_u8,
-        u8::MAX
+        DemoDecoder::fixed_16_utf_8_u8
     );
 }
 
@@ -145,8 +136,8 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice() {
     // <field name="fixed16i16" id="22" type="Fixed16i16"/>
     // <field name="fixed16i32" id="23" type="Fixed16i32"/>
     // <field name="fixed16i64" id="24" type="Fixed16i64"/>
-    macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
-        ($encode_func:expr, $decode_func:expr, $i_type:ty, $i_null:expr) => {
+    macro_rules! run_encode_then_decode_for_array_of_signed_len_16 {
+        ($encode_func:expr, $decode_func:expr, $i_type:ty) => {
             let test_data = [
                 &[] as &[$i_type],
                 &[1 as $i_type] as &[$i_type],
@@ -269,7 +260,7 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice() {
                 let effective_len = cur_len.min(16);
 
                 // encode...
-                let mut buffer = vec![1u8; 1024];
+                let mut buffer = vec![0u8; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
                 encode_func(&mut encoder, &each_slice);
@@ -290,12 +281,11 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice() {
                         stringify!($i_type)
                     );
                 }
-                let null_value = $i_null;
                 for each_idx in effective_len..16 {
                     assert_eq!(
                         decoded[each_idx],
-                        null_value,
-                        "Item should be null at {}/{} for {}",
+                        0,
+                        "Item should be ZERO at {}/{} for {}",
                         each_idx,
                         cur_len,
                         stringify!($i_type)
@@ -305,29 +295,25 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice() {
         };
     }
 
-    run_encode_then_decode_for_array_of_u8_len_16!(
+    run_encode_then_decode_for_array_of_signed_len_16!(
         DemoEncoder::fixed_16_i8_at_most_16_items_from_slice,
         DemoDecoder::fixed_16_i8,
-        i8,
-        i8::MIN
+        i8
     );
-    run_encode_then_decode_for_array_of_u8_len_16!(
+    run_encode_then_decode_for_array_of_signed_len_16!(
         DemoEncoder::fixed_16_i16_at_most_16_items_from_slice,
         DemoDecoder::fixed_16_i16,
-        i16,
-        i16::MIN
+        i16
     );
-    run_encode_then_decode_for_array_of_u8_len_16!(
+    run_encode_then_decode_for_array_of_signed_len_16!(
         DemoEncoder::fixed_16_i32_at_most_16_items_from_slice,
         DemoDecoder::fixed_16_i32,
-        i32,
-        i32::MIN
+        i32
     );
-    run_encode_then_decode_for_array_of_u8_len_16!(
+    run_encode_then_decode_for_array_of_signed_len_16!(
         DemoEncoder::fixed_16_i64_at_most_16_items_from_slice,
         DemoDecoder::fixed_16_i64,
-        i64,
-        i64::MIN
+        i64
     );
 }
 
@@ -335,8 +321,8 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice() {
 fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
     // <field name="fixed16u16" id="32" type="Fixed16u16"/>
     // <field name="fixed16u32" id="33" type="Fixed16u32"/>
-    macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
-        ($encode_func:expr, $decode_func:expr, $i_type:ty, $i_null:expr) => {
+    macro_rules! run_encode_then_decode_for_array_of_unsigned_len_16 {
+        ($encode_func:expr, $decode_func:expr, $i_type:ty) => {
             let test_data = [
                 &[] as &[$i_type],
                 &[1 as $i_type] as &[$i_type],
@@ -459,10 +445,10 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
                 let effective_len = cur_len.min(16);
 
                 // encode...
-                let mut buffer = vec![1u8; 1024];
+                let mut buffer = vec![0u8; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, &each_slice);
+                encode_func(&mut encoder, each_slice);
 
                 // decode...
                 let buf = ReadBuf::new(buffer.as_slice());
@@ -480,12 +466,11 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
                         stringify!($i_type)
                     );
                 }
-                let null_value = $i_null;
                 for each_idx in effective_len..16 {
                     assert_eq!(
                         decoded[each_idx],
-                        null_value,
-                        "Item should be null at {}/{} for {}",
+                        0,
+                        "Item should be ZERO at {}/{} for {}",
                         each_idx,
                         cur_len,
                         stringify!($i_type)
@@ -495,17 +480,525 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
         };
     }
 
-    run_encode_then_decode_for_array_of_u8_len_16!(
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
         DemoEncoder::fixed_16_u16_at_most_16_items_from_slice,
         DemoDecoder::fixed_16_u16,
-        u16,
-        u16::MAX
+        u16
     );
-    run_encode_then_decode_for_array_of_u8_len_16!(
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
         DemoEncoder::fixed_16_u32_at_most_16_items_from_slice,
         DemoDecoder::fixed_16_u32,
-        u32,
-        u32::MAX
+        u32
     );
-    // run_encode_then_decode_for_array_of_u8_len_16!(DemoEncoder::fixed_16_u64_at_most_16_items_from_slice, DemoDecoder::fixed_16_i64, i64, u64::MAX);
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
+        DemoEncoder::fixed_16_u64_at_most_16_items_from_slice,
+        DemoDecoder::fixed_16_u64,
+        u64
+    );
+}
+
+#[test]
+fn test_encode_then_decode_u8_slice_padded() {
+    let test_data = [
+        b"" as &[u8],
+        b"0" as &[u8],
+        b"01" as &[u8],
+        b"012" as &[u8],
+        b"0123" as &[u8],
+        b"01234" as &[u8],
+        b"012345" as &[u8],
+        b"0123456" as &[u8],
+        b"01234567" as &[u8],
+        b"012345678" as &[u8],
+        b"0123456789" as &[u8],
+        b"0123456789A" as &[u8],
+        b"0123456789AB" as &[u8],
+        b"0123456789ABC" as &[u8],
+        b"0123456789ABCD" as &[u8],
+        b"0123456789ABCDE" as &[u8],
+        b"0123456789ABCDEF" as &[u8],
+        b"0123456789abcdef" as &[u8],
+        b"0123456789abcdef0" as &[u8],
+        b"0123456789abcdef01" as &[u8],
+        b"0123456789abcdef012" as &[u8],
+        b"0123456789abcdef0123" as &[u8],
+        b"0123456789abcdef01234" as &[u8],
+        b"0123456789abcdef012345" as &[u8],
+        b"0123456789abcdef0123456" as &[u8],
+        b"0123456789abcdef01234567" as &[u8],
+        b"0123456789abcdef012345678" as &[u8],
+        b"0123456789abcdef0123456789" as &[u8],
+        b"0123456789abcdef0123456789A" as &[u8],
+        b"0123456789abcdef0123456789AB" as &[u8],
+        b"0123456789abcdef0123456789ABC" as &[u8],
+        b"0123456789abcdef0123456789ABCD" as &[u8],
+        b"0123456789abcdef0123456789ABCDE" as &[u8],
+        b"0123456789abcdef0123456789ABCDEF" as &[u8],
+    ];
+
+    // <field name="fixed16Char" id="1" type="Fixed16Char"/>
+    // <field name="fixed16AsciiChar" id="2" type="Fixed16AsciiChar"/>
+    // <field name="fixed16Gb18030Char" id="3" type="Fixed16Gb18030Char"/>
+    // <field name="fixed16Utf8Char" id="4" type="Fixed16Utf8Char"/>
+    // <field name="fixed16U8" id="11" type="Fixed16U8"/>
+    // <field name="fixed16AsciiU8" id="12" type="Fixed16AsciiU8"/>
+    // <field name="fixed16Gb18030U8" id="13" type="Fixed16Gb18030U8"/>
+    // <field name="fixed16Utf8U8" id="14" type="Fixed16Utf8U8"/>
+    macro_rules! run_encode_then_decode_for_array_of_u8_len_16 {
+        ($encode_func:expr, $decode_func:expr, $i_padded:expr) => {
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+                let padded_value = $i_padded;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = vec![0u8; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, each_slice, padded_value);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx], decoded[each_idx],
+                        "Item mismatched at {}/{}",
+                        each_idx, cur_len
+                    );
+                }
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx], padded_value,
+                        "Item should be padded at {}/{}",
+                        each_idx, cur_len
+                    );
+                }
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_char_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_char,
+        30
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_ascii_char_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_ascii_char,
+        30
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_gb_18030_char_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_gb_18030_char,
+        30
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_utf_8_char_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_utf_8_char,
+        30
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_u8_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_u8,
+        30
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_ascii_u8_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_ascii_u8,
+        30
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_gb_18030_u8_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_gb_18030_u8,
+        30
+    );
+    run_encode_then_decode_for_array_of_u8_len_16!(
+        DemoEncoder::fixed_16_utf_8_u8_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_utf_8_u8,
+        30
+    );
+}
+
+#[test]
+fn test_encode_then_decode_non_u8_signed_primitive_slice_padded() {
+    // <field name="fixed16i8" id="21" type="Fixed16i8"/>
+    // <field name="fixed16i16" id="22" type="Fixed16i16"/>
+    // <field name="fixed16i32" id="23" type="Fixed16i32"/>
+    // <field name="fixed16i64" id="24" type="Fixed16i64"/>
+    macro_rules! run_encode_then_decode_for_array_of_signed_len_16 {
+        ($encode_func:expr, $decode_func:expr, $i_type:ty, $i_padded:expr) => {
+            let test_data = [
+                &[] as &[$i_type],
+                &[1 as $i_type] as &[$i_type],
+                &[0 as $i_type] as &[$i_type],
+                &[-1 as $i_type] as &[$i_type],
+                &[-1, 1 as $i_type] as &[$i_type],
+                &[-1, 0, 1 as $i_type] as &[$i_type],
+                &[-2, -1, 1, 2 as $i_type] as &[$i_type],
+                &[-2, -1, 0, 1, 2 as $i_type] as &[$i_type],
+                &[-3, -2, -1, 1, 2, 3 as $i_type] as &[$i_type],
+                &[-3, -2, -1, 0, 1, 2, 3 as $i_type] as &[$i_type],
+                &[-4, -3, -2, -1, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[-4, -3, -2, -1, 0, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[-5, -4, -3, -2, -1, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[-5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[-6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[-6, -5, -4, -3, -2, -1, 0, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[-7, -6, -5, -4, -3, -2, -1, 1, 2, 3, 4, 5, 6, 7 as $i_type] as &[$i_type],
+                &[
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -9,
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+                &[
+                    -9,
+                    -8,
+                    -7,
+                    -6,
+                    -5,
+                    -4,
+                    -3,
+                    -2,
+                    -1,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+            ];
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+                let padded_value = $i_padded;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = vec![0u8; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, each_slice, padded_value);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx],
+                        decoded[each_idx],
+                        "Item mismatched at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx],
+                        padded_value,
+                        "Item should be padded at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_signed_len_16!(
+        DemoEncoder::fixed_16_i8_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_i8,
+        i8,
+        -31
+    );
+    run_encode_then_decode_for_array_of_signed_len_16!(
+        DemoEncoder::fixed_16_i16_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_i16,
+        i16,
+        -31
+    );
+    run_encode_then_decode_for_array_of_signed_len_16!(
+        DemoEncoder::fixed_16_i32_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_i32,
+        i32,
+        -31
+    );
+    run_encode_then_decode_for_array_of_signed_len_16!(
+        DemoEncoder::fixed_16_i64_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_i64,
+        i64,
+        -31
+    );
+}
+
+#[test]
+fn test_encode_then_decode_non_u8_unsigned_primitive_slice_padded() {
+    // <field name="fixed16u16" id="32" type="Fixed16u16"/>
+    // <field name="fixed16u32" id="33" type="Fixed16u32"/>
+    // <field name="fixed16u64" id="33" type="Fixed16u64"/>
+    macro_rules! run_encode_then_decode_for_array_of_unsigned_len_16 {
+        ($encode_func:expr, $decode_func:expr, $i_type:ty, $i_padded:expr) => {
+            let test_data = [
+                &[] as &[$i_type],
+                &[1 as $i_type] as &[$i_type],
+                &[0 as $i_type] as &[$i_type],
+                &[11 as $i_type] as &[$i_type],
+                &[11, 1 as $i_type] as &[$i_type],
+                &[11, 0, 1 as $i_type] as &[$i_type],
+                &[12, 11, 1, 2 as $i_type] as &[$i_type],
+                &[12, 11, 0, 1, 2 as $i_type] as &[$i_type],
+                &[13, 12, 11, 1, 2, 3 as $i_type] as &[$i_type],
+                &[13, 12, 11, 0, 1, 2, 3 as $i_type] as &[$i_type],
+                &[14, 13, 12, 11, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[14, 13, 12, 11, 0, 1, 2, 3, 4 as $i_type] as &[$i_type],
+                &[15, 14, 13, 12, 11, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[15, 14, 13, 12, 11, 0, 1, 2, 3, 4, 5 as $i_type] as &[$i_type],
+                &[16, 15, 14, 13, 12, 11, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[16, 15, 14, 13, 12, 11, 0, 1, 2, 3, 4, 5, 6 as $i_type] as &[$i_type],
+                &[17, 16, 15, 14, 13, 12, 11, 1, 2, 3, 4, 5, 6, 7 as $i_type] as &[$i_type],
+                &[
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7 as $i_type,
+                ] as &[$i_type],
+                &[
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8 as $i_type,
+                ] as &[$i_type],
+                &[
+                    19,
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+                &[
+                    19,
+                    18,
+                    17,
+                    16,
+                    15,
+                    14,
+                    13,
+                    12,
+                    11,
+                    0,
+                    1,
+                    2,
+                    3,
+                    4,
+                    5,
+                    6,
+                    7,
+                    8,
+                    9 as $i_type,
+                ] as &[$i_type],
+            ];
+            for each_slice in test_data {
+                let encode_func = $encode_func;
+                let decode_func = $decode_func;
+                let padded_value = $i_padded;
+
+                let cur_len = each_slice.len();
+                let effective_len = cur_len.min(16);
+
+                // encode...
+                let mut buffer = vec![0u8; 1024];
+                let mut encoder = create_encoder(&mut buffer);
+
+                encode_func(&mut encoder, each_slice, padded_value);
+
+                // decode...
+                let buf = ReadBuf::new(buffer.as_slice());
+                let header = MessageHeaderDecoder::default().wrap(buf, 0);
+
+                let decoder = DemoDecoder::default().header(header, 0);
+                let decoded = decode_func(&decoder);
+                for each_idx in 0..effective_len {
+                    assert_eq!(
+                        each_slice[each_idx],
+                        decoded[each_idx],
+                        "Item mismatched at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+                for each_idx in effective_len..16 {
+                    assert_eq!(
+                        decoded[each_idx],
+                        padded_value,
+                        "Item should be padded at {}/{} for {}",
+                        each_idx,
+                        cur_len,
+                        stringify!($i_type)
+                    );
+                }
+            }
+        };
+    }
+
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
+        DemoEncoder::fixed_16_u16_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_u16,
+        u16,
+        1024u16
+    );
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
+        DemoEncoder::fixed_16_u32_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_u32,
+        u32,
+        10000000u32
+    );
+    run_encode_then_decode_for_array_of_unsigned_len_16!(
+        DemoEncoder::fixed_16_u64_at_most_16_items_from_slice_padded,
+        DemoDecoder::fixed_16_u64,
+        u64,
+        20241115173301u64
+    );
 }

--- a/rust/tests/fixed_sized_primitive_array.rs
+++ b/rust/tests/fixed_sized_primitive_array.rs
@@ -74,7 +74,7 @@ fn test_encode_then_decode_u8_slice() {
                 let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, each_slice.iter().map(|x| *x));
+                encode_func(&mut encoder, each_slice.into_iter().copied());
 
                 let end = 1i32;
                 end_encode_func(&mut encoder, end);
@@ -295,7 +295,7 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice() {
                 let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, each_slice.iter().map(|x| *x));
+                encode_func(&mut encoder, each_slice.into_iter().copied());
 
                 let end = 1i32;
                 end_encode_func(&mut encoder, end);
@@ -500,7 +500,7 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice() {
                 let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, each_slice.iter().map(|x| *x));
+                encode_func(&mut encoder, each_slice.into_iter().copied());
 
                 let end = 1i32;
                 end_encode_func(&mut encoder, end);
@@ -628,7 +628,7 @@ fn test_encode_then_decode_u8_slice_padded() {
                 let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, each_slice.iter().map(|x| *x));
+                encode_func(&mut encoder, each_slice);
 
                 let end = 1i32;
                 end_encode_func(&mut encoder, end);
@@ -660,49 +660,49 @@ fn test_encode_then_decode_u8_slice_padded() {
     }
 
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_char_from_iter,
+        DemoEncoder::fixed_16_char_zero_padded,
         DemoDecoder::fixed_16_char,
         DemoEncoder::fixed_16_char_end,
         DemoDecoder::fixed_16_char_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_ascii_char_from_iter,
+        DemoEncoder::fixed_16_ascii_char_zero_padded,
         DemoDecoder::fixed_16_ascii_char,
         DemoEncoder::fixed_16_ascii_char_end,
         DemoDecoder::fixed_16_ascii_char_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_gb_18030_char_from_iter,
+        DemoEncoder::fixed_16_gb_18030_char_zero_padded,
         DemoDecoder::fixed_16_gb_18030_char,
         DemoEncoder::fixed_16_gb_18030_char_end,
         DemoDecoder::fixed_16_gb_18030_char_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_utf_8_char_from_iter,
+        DemoEncoder::fixed_16_utf_8_char_zero_padded,
         DemoDecoder::fixed_16_utf_8_char,
         DemoEncoder::fixed_16_utf_8_char_end,
         DemoDecoder::fixed_16_utf_8_char_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_u8_from_iter,
+        DemoEncoder::fixed_16_u8_zero_padded,
         DemoDecoder::fixed_16_u8,
         DemoEncoder::fixed_16_u8_end,
         DemoDecoder::fixed_16_u8_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_ascii_u8_from_iter,
+        DemoEncoder::fixed_16_ascii_u8_zero_padded,
         DemoDecoder::fixed_16_ascii_u8,
         DemoEncoder::fixed_16_ascii_u8_end,
         DemoDecoder::fixed_16_ascii_u8_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_gb_18030_u8_from_iter,
+        DemoEncoder::fixed_16_gb_18030_u8_zero_padded,
         DemoDecoder::fixed_16_gb_18030_u8,
         DemoEncoder::fixed_16_gb_18030_u8_end,
         DemoDecoder::fixed_16_gb_18030_u8_end,
     );
     run_encode_then_decode_for_array_of_u8_len_16!(
-        DemoEncoder::fixed_16_utf_8_u8_from_iter,
+        DemoEncoder::fixed_16_utf_8_u8_zero_padded,
         DemoDecoder::fixed_16_utf_8_u8,
         DemoEncoder::fixed_16_utf_8u_8_end,
         DemoDecoder::fixed_16_utf_8u_8_end,
@@ -846,7 +846,7 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice_padded() {
                 let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, each_slice.iter().map(|x| *x));
+                encode_func(&mut encoder, each_slice);
 
                 let end = 1i32;
                 end_encode_func(&mut encoder, end);
@@ -884,28 +884,28 @@ fn test_encode_then_decode_non_u8_signed_primitive_slice_padded() {
     }
 
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i8_from_iter,
+        DemoEncoder::fixed_16_i8_zero_padded,
         DemoDecoder::fixed_16_i8,
         DemoEncoder::fixed_16_i8_end,
         DemoDecoder::fixed_16_i8_end,
         i8,
     );
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i16_from_iter,
+        DemoEncoder::fixed_16_i16_zero_padded,
         DemoDecoder::fixed_16_i16,
         DemoEncoder::fixed_16_i16_end,
         DemoDecoder::fixed_16_i16_end,
         i16,
     );
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i32_from_iter,
+        DemoEncoder::fixed_16_i32_zero_padded,
         DemoDecoder::fixed_16_i32,
         DemoEncoder::fixed_16_i32_end,
         DemoDecoder::fixed_16_i32_end,
         i32,
     );
     run_encode_then_decode_for_array_of_signed_len_16!(
-        DemoEncoder::fixed_16_i64_from_iter,
+        DemoEncoder::fixed_16_i64_zero_padded,
         DemoDecoder::fixed_16_i64,
         DemoEncoder::fixed_16_i64_end,
         DemoDecoder::fixed_16_i64_end,
@@ -1049,7 +1049,7 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice_padded() {
                 let mut buffer = [uninit; 1024];
                 let mut encoder = create_encoder(&mut buffer);
 
-                encode_func(&mut encoder, each_slice.iter().map(|x| *x));
+                encode_func(&mut encoder, each_slice);
 
                 let end = 1i32;
                 end_encode_func(&mut encoder, end);
@@ -1087,21 +1087,21 @@ fn test_encode_then_decode_non_u8_unsigned_primitive_slice_padded() {
     }
 
     run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u16_from_iter,
+        DemoEncoder::fixed_16_u16_zero_padded,
         DemoDecoder::fixed_16_u16,
         DemoEncoder::fixed_16_u16_end,
         DemoDecoder::fixed_16_u16_end,
         u16
     );
     run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u32_from_iter,
+        DemoEncoder::fixed_16_u32_zero_padded,
         DemoDecoder::fixed_16_u32,
         DemoEncoder::fixed_16_u32_end,
         DemoDecoder::fixed_16_u32_end,
         u32
     );
     run_encode_then_decode_for_array_of_unsigned_len_16!(
-        DemoEncoder::fixed_16_u64_from_iter,
+        DemoEncoder::fixed_16_u64_zero_padded,
         DemoDecoder::fixed_16_u64,
         DemoEncoder::fixed_16_u64_end,
         DemoDecoder::fixed_16_u64_end,

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
@@ -277,6 +277,13 @@ class LibRsDef
         indent(writer, 2, "len\n");
         indent(writer, 1, "}\n");
 
+        indent(writer, 0, "}\n");
+
+        indent(writer, 0, "impl<%s> From<&%1$s mut %2$s<%1$s>> for &%1$s mut [u8] {\n", BUF_LIFETIME, WRITE_BUF_TYPE);
+        indent(writer, 1, "#[inline]\n");
+        indent(writer, 1, "fn from(buf: &%s mut %2$s<%1$s>) -> &%1$s mut [u8] {\n", BUF_LIFETIME, WRITE_BUF_TYPE);
+        indent(writer, 2, "buf.data\n");
+        indent(writer, 1, "}\n");
         indent(writer, 0, "}\n\n");
     }
 }

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/LibRsDef.java
@@ -276,9 +276,9 @@ class LibRsDef
         indent(writer, 2, "dest.clone_from_slice(src);\n");
         indent(writer, 2, "len\n");
         indent(writer, 1, "}\n");
-
         indent(writer, 0, "}\n");
 
+        // impl From<WriteBuf> for &[u8]
         indent(writer, 0, "impl<%s> From<&%1$s mut %2$s<%1$s>> for &%1$s mut [u8] {\n", BUF_LIFETIME, WRITE_BUF_TYPE);
         indent(writer, 1, "#[inline]\n");
         indent(writer, 1, "fn from(buf: &%s mut %2$s<%1$s>) -> &%1$s mut [u8] {\n", BUF_LIFETIME, WRITE_BUF_TYPE);

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -384,10 +384,10 @@ public class RustGenerator implements CodeGenerator
     }
 
     private static void generatePrimitiveArrayFromIterEncoder(
-            final StringBuilder sb,
-            final int level,
-            final Token typeToken,
-            final String name) throws IOException
+        final StringBuilder sb,
+        final int level,
+        final Token typeToken,
+        final String name) throws IOException
     {
         final Encoding encoding = typeToken.encoding();
         final PrimitiveType primitiveType = encoding.primitiveType();
@@ -397,7 +397,7 @@ public class RustGenerator implements CodeGenerator
         generateRustDoc(sb, level, typeToken, encoding);
         indent(sb, level, "#[inline]\n");
         indent(sb, level, "pub fn %s_from_iter(&mut self, iter: impl Iterator<Item = %s>) {\n",
-                formatFunctionName(name), rustPrimitiveType);
+            formatFunctionName(name), rustPrimitiveType);
 
         indent(sb, level + 1, "let offset = self.%s;\n", getBufOffset(typeToken));
         indent(sb, level + 1, "let buf = self.get_buf_mut();\n");
@@ -417,10 +417,10 @@ public class RustGenerator implements CodeGenerator
     }
 
     private static void generatePrimitiveArrayZeroPaddedEncoder(
-            final StringBuilder sb,
-            final int level,
-            final Token typeToken,
-            final String name) throws IOException
+        final StringBuilder sb,
+        final int level,
+        final Token typeToken,
+        final String name) throws IOException
     {
         final Encoding encoding = typeToken.encoding();
         final PrimitiveType primitiveType = encoding.primitiveType();

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -436,7 +436,7 @@ public class RustGenerator implements CodeGenerator
         indent(sb, level + 1, "let iter = value.iter().copied().chain(std::iter::repeat(0_%s)).take(%d);\n",
             rustPrimitiveType, arrayLength);
 
-        indent(sb, level + 1, "self.%s_from_iter(iter);", formatFunctionName(name));
+        indent(sb, level + 1, "self.%s_from_iter(iter);\n", formatFunctionName(name));
         indent(sb, level, "}\n\n");
     }
 

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java
@@ -459,8 +459,7 @@ public class RustGenerator implements CodeGenerator
 
         if (primitiveType.size() == 1)
         {
-            indent(sb, level + 1, "buf.put_%s_at(offset + index, value);\n",
-                rustPrimitiveType, primitiveType.size());
+            indent(sb, level + 1, "buf.put_%s_at(offset + index, value);\n", rustPrimitiveType);
         }
         else
         {

--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustUtil.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustUtil.java
@@ -17,6 +17,7 @@ package uk.co.real_logic.sbe.generation.rust;
 
 import org.agrona.Verify;
 import uk.co.real_logic.sbe.PrimitiveType;
+import uk.co.real_logic.sbe.PrimitiveValue;
 import uk.co.real_logic.sbe.generation.Generators;
 import uk.co.real_logic.sbe.generation.rust.RustGenerator.CodecType;
 import uk.co.real_logic.sbe.ir.Encoding;
@@ -63,6 +64,11 @@ public class RustUtil
     static String rustTypeName(final PrimitiveType primitiveType)
     {
         return TYPE_NAME_BY_PRIMITIVE_TYPE_MAP.get(primitiveType);
+    }
+
+    static String generateRustLiteral(final PrimitiveType type, final PrimitiveValue value)
+    {
+        return generateRustLiteral(type, value.toString());
     }
 
     static String generateRustLiteral(final PrimitiveType type, final String value)

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustUtilTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustUtilTest.java
@@ -88,6 +88,7 @@ class RustUtilTest
         assertEquals("0xff_u8", generateRustLiteral(UINT8, UINT8.nullValue().toString()));
         assertEquals("0xffff_u16", generateRustLiteral(UINT16, UINT16.nullValue().toString()));
         assertEquals("0xffffffff_u32", generateRustLiteral(UINT32, UINT32.nullValue().toString()));
+        assertEquals("0xffffffffffffffff_u64", generateRustLiteral(UINT64, UINT64.nullValue()));
         assertEquals("0xffffffffffffffff_u64", generateRustLiteral(UINT64, UINT64.nullValue().toString()));
     }
 
@@ -100,7 +101,7 @@ class RustUtilTest
     @Test
     void generateRustLiteralNullValueParam()
     {
-        assertThrows(NullPointerException.class, () -> generateRustLiteral(INT8, null));
+        assertThrows(NullPointerException.class, () -> generateRustLiteral(INT8, (String) null));
     }
 
     @Test

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustUtilTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/rust/RustUtilTest.java
@@ -101,7 +101,7 @@ class RustUtilTest
     @Test
     void generateRustLiteralNullValueParam()
     {
-        assertThrows(NullPointerException.class, () -> generateRustLiteral(INT8, (String) null));
+        assertThrows(NullPointerException.class, () -> generateRustLiteral(INT8, (String)null));
     }
 
     @Test

--- a/sbe-tool/src/test/resources/fixed-sized-primitive-array-types.xml
+++ b/sbe-tool/src/test/resources/fixed-sized-primitive-array-types.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+               package="fixed.sized.primitive.array"
+               id="1989"
+               version="1"
+               semanticVersion="1.0.0"
+               description="Support for fixed sized primitive array"
+               byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader" description="Message identifiers and length of message root">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+
+        <!-- char array without encoding (default to US-ASCII) -->
+        <type name="Fixed16Char" description="String of char with length=16" length="16" primitiveType="char" semanticType="String"/>
+        <type name="Fixed16AsciiChar" description="ASCII string of char with length=16" length="16" primitiveType="char" characterEncoding="US-ASCII" semanticType="String"/>
+        <type name="Fixed16Gb18030Char" description="GB18030 string of char with length=16" length="16" primitiveType="char" characterEncoding="GB18030" semanticType="String"/>
+        <type name="Fixed16Utf8Char" description="GB18030 string of char with length=16" length="16" primitiveType="char" characterEncoding="UTF-8" semanticType="String"/>
+
+        <type name="Fixed16U8" description="Array of 16 u8" length="16" primitiveType="uint8" semanticType="Data"/>
+        <type name="Fixed16AsciiU8" description="Array of 16 u8" length="16" primitiveType="uint8" characterEncoding="US-ASCII" semanticType="Data"/>
+        <type name="Fixed16Gb18030U8" description="Array of 16 u8" length="16" primitiveType="uint8" characterEncoding="GB18030" semanticType="Data"/>
+        <type name="Fixed16Utf8U8" description="Array of 16 u8" length="16" primitiveType="uint8" characterEncoding="UTF-8" semanticType="Data"/>
+
+        <type name="Fixed16i8" description="Array of 16 i8" length="16" primitiveType="int8" />
+        <type name="Fixed16i16" description="Array of 16 i16" length="16" primitiveType="int16" />
+        <type name="Fixed16i32" description="Array of 16 i32" length="16" primitiveType="int32" />
+        <type name="Fixed16i64" description="Array of 16 i64" length="16" primitiveType="int64" />
+
+        <type name="Fixed16u16" description="Array of 16 u16" length="16" primitiveType="uint16" />
+        <type name="Fixed16u32" description="Array of 16 u32" length="16" primitiveType="uint32" />
+        <!-- <type name="Fixed16u64" description="Array of 16 u64" length="16" primitiveType="uint64" /> -->
+    </types>
+
+    <sbe:message name="demo" id="1">
+        <field name="fixed16Char" id="1" type="Fixed16Char"/>
+        <field name="fixed16AsciiChar" id="2" type="Fixed16AsciiChar"/>
+        <field name="fixed16Gb18030Char" id="3" type="Fixed16Gb18030Char"/>
+        <field name="fixed16Utf8Char" id="4" type="Fixed16Utf8Char"/>
+
+        <field name="fixed16U8" id="11" type="Fixed16U8"/>
+        <field name="fixed16AsciiU8" id="12" type="Fixed16AsciiU8"/>
+        <field name="fixed16Gb18030U8" id="13" type="Fixed16Gb18030U8"/>
+        <field name="fixed16Utf8U8" id="14" type="Fixed16Utf8U8"/>
+
+        <field name="fixed16i8" id="21" type="Fixed16i8"/>
+        <field name="fixed16i16" id="22" type="Fixed16i16"/>
+        <field name="fixed16i32" id="23" type="Fixed16i32"/>
+        <field name="fixed16i64" id="24" type="Fixed16i64"/>
+
+        <field name="fixed16u16" id="32" type="Fixed16u16"/>
+        <field name="fixed16u32" id="33" type="Fixed16u32"/>
+        <!-- <field name="fixed16u64" id="34" type="Fixed16u64"/> -->
+    </sbe:message>
+</sbe:messageSchema>

--- a/sbe-tool/src/test/resources/fixed-sized-primitive-array-types.xml
+++ b/sbe-tool/src/test/resources/fixed-sized-primitive-array-types.xml
@@ -32,7 +32,7 @@
 
         <type name="Fixed16u16" description="Array of 16 u16" length="16" primitiveType="uint16" />
         <type name="Fixed16u32" description="Array of 16 u32" length="16" primitiveType="uint32" />
-        <!-- <type name="Fixed16u64" description="Array of 16 u64" length="16" primitiveType="uint64" /> -->
+        <type name="Fixed16u64" description="Array of 16 u64" length="16" primitiveType="uint64" />
     </types>
 
     <sbe:message name="demo" id="1">
@@ -53,6 +53,6 @@
 
         <field name="fixed16u16" id="32" type="Fixed16u16"/>
         <field name="fixed16u32" id="33" type="Fixed16u32"/>
-        <!-- <field name="fixed16u64" id="34" type="Fixed16u64"/> -->
+        <field name="fixed16u64" id="34" type="Fixed16u64"/>
     </sbe:message>
 </sbe:messageSchema>

--- a/sbe-tool/src/test/resources/fixed-sized-primitive-array-types.xml
+++ b/sbe-tool/src/test/resources/fixed-sized-primitive-array-types.xml
@@ -37,22 +37,37 @@
 
     <sbe:message name="demo" id="1">
         <field name="fixed16Char" id="1" type="Fixed16Char"/>
-        <field name="fixed16AsciiChar" id="2" type="Fixed16AsciiChar"/>
-        <field name="fixed16Gb18030Char" id="3" type="Fixed16Gb18030Char"/>
-        <field name="fixed16Utf8Char" id="4" type="Fixed16Utf8Char"/>
+        <field name="fixed16CharEnd" id="2" type="int32" description="End boundary of fixed16Char"/>
+        <field name="fixed16AsciiChar" id="3" type="Fixed16AsciiChar"/>
+        <field name="fixed16AsciiCharEnd" id="4" type="int32" description="End boundary of fixed16AsciiChar"/>
+        <field name="fixed16Gb18030Char" id="5" type="Fixed16Gb18030Char"/>
+        <field name="fixed16Gb18030CharEnd" id="6" type="int32" description="End boundary of fixed16Gb18030Char"/>
+        <field name="fixed16Utf8Char" id="7" type="Fixed16Utf8Char"/>
+        <field name="fixed16Utf8CharEnd" id="8" type="int32" description="End boundary of fixed16Utf8Char"/>
 
         <field name="fixed16U8" id="11" type="Fixed16U8"/>
-        <field name="fixed16AsciiU8" id="12" type="Fixed16AsciiU8"/>
-        <field name="fixed16Gb18030U8" id="13" type="Fixed16Gb18030U8"/>
-        <field name="fixed16Utf8U8" id="14" type="Fixed16Utf8U8"/>
+        <field name="fixed16U8End" id="12" type="int32" description="End boundary of fixed16U8"/>
+        <field name="fixed16AsciiU8" id="13" type="Fixed16AsciiU8"/>
+        <field name="fixed16AsciiU8End" id="14" type="int32" description="End boundary of fixed16AsciiU8"/>
+        <field name="fixed16Gb18030U8" id="15" type="Fixed16Gb18030U8"/>
+        <field name="fixed16Gb18030U8End" id="16" type="int32" description="End boundary of fixed16Gb18030U8"/>
+        <field name="fixed16Utf8U8" id="17" type="Fixed16Utf8U8"/>
+        <field name="fixed16Utf8U8End" id="18" type="int32" description="End boundary of fixed16Utf8U8"/>
 
         <field name="fixed16i8" id="21" type="Fixed16i8"/>
-        <field name="fixed16i16" id="22" type="Fixed16i16"/>
-        <field name="fixed16i32" id="23" type="Fixed16i32"/>
-        <field name="fixed16i64" id="24" type="Fixed16i64"/>
+        <field name="fixed16i8End" id="22" type="int32" description="End boundary of fixed16i8"/>
+        <field name="fixed16i16" id="23" type="Fixed16i16"/>
+        <field name="fixed16i16End" id="24" type="int32" description="End boundary of fixed16i16"/>
+        <field name="fixed16i32" id="25" type="Fixed16i32"/>
+        <field name="fixed16i32End" id="26" type="int32" description="End boundary of fixed16i32"/>
+        <field name="fixed16i64" id="27" type="Fixed16i64"/>
+        <field name="fixed16i64End" id="28" type="int32" description="End boundary of fixed16i64"/>
 
-        <field name="fixed16u16" id="32" type="Fixed16u16"/>
-        <field name="fixed16u32" id="33" type="Fixed16u32"/>
-        <field name="fixed16u64" id="34" type="Fixed16u64"/>
+        <field name="fixed16u16" id="33" type="Fixed16u16"/>
+        <field name="fixed16u16End" id="34" type="int32" description="End boundary of fixed16u16"/>
+        <field name="fixed16u32" id="35" type="Fixed16u32"/>
+        <field name="fixed16u32End" id="36" type="int32" description="End boundary of fixed16u32"/>
+        <field name="fixed16u64" id="37" type="Fixed16u64"/>
+        <field name="fixed16u64End" id="38" type="int32" description="End boundary of fixed16u64"/>
     </sbe:message>
 </sbe:messageSchema>


### PR DESCRIPTION
code generator for primitive arrays enhancements:
- encoder accepts slice instead of array
- now generates "*_from_iter()"
- now generates  "*_zero_padded()"