### PR TITLE
[C++] mark a generated function SBE_CONSTEXPR (#1055)

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java
@@ -2630,12 +2630,19 @@ public class CppGenerator implements CodeGenerator
             values);
 
         sb.append(String.format("\n" +
+            indent + "    #if __cplusplus >= 201402L\n" +
+            indent + "    SBE_NODISCARD static SBE_CONSTEXPR %1$s %2$s(const std::uint64_t index) SBE_NOEXCEPT\n" +
+            indent + "    {\n" +
+            indent + "        const std::uint8_t %2$sValues[] = { %3$s, 0 };\n\n" +
+            indent + "        return (char)%2$sValues[index];\n" +
+            indent + "    }\n" +
+            indent + "    #else\n" +
             indent + "    SBE_NODISCARD %1$s %2$s(const std::uint64_t index) const\n" +
             indent + "    {\n" +
             indent + "        static const std::uint8_t %2$sValues[] = { %3$s, 0 };\n\n" +
-
             indent + "        return (char)%2$sValues[index];\n" +
-            indent + "    }\n",
+            indent + "    }\n" +
+            indent + "    #endif\n",
             cppTypeName,
             propertyName,
             values));

--- a/sbe-tool/src/test/c/CodeGenTest.cpp
+++ b/sbe-tool/src/test/c/CodeGenTest.cpp
@@ -253,6 +253,7 @@ public:
         output << static_cast<char>(CGT(car_discountedModel(&car))) << ';';
 
         char code_buf[4];
+        memset(code_buf, 0, sizeof(code_buf));
         CGT(engine) engine = {};
         if (CGT(car_engine)(&car, &engine))
         {
@@ -354,6 +355,7 @@ public:
         }
 
         char code_buf[4];
+        memset(code_buf, 0, sizeof(code_buf));
         CGT(engine) engine = {};
         if (CGT(car_engine)(&car, &engine))
         {

--- a/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/cpp/CppGeneratorTest.java
+++ b/sbe-tool/src/test/java/uk/co/real_logic/sbe/generation/cpp/CppGeneratorTest.java
@@ -76,6 +76,33 @@ class CppGeneratorTest
     }
 
     @Test
+    void shouldGenerateConstexprConstantCharAccessorOnlyForCpp14AndLater() throws Exception
+    {
+        try (InputStream in = Tests.getLocalResource("code-generation-schema.xml"))
+        {
+            final ParserOptions options = ParserOptions.builder().stopOnError(true).build();
+            final MessageSchema schema = parse(in, options);
+            final IrGenerator irg = new IrGenerator();
+            final Ir ir = irg.generate(schema);
+            final StringWriterOutputManager outputManager = new StringWriterOutputManager();
+            outputManager.setPackageName(ir.applicableNamespace());
+
+            final CppGenerator generator = new CppGenerator(ir, false, outputManager);
+            generator.generate();
+
+            final String source = outputManager.getSource("code.generation.test.Engine").toString();
+            assertThat(source, containsString("#if __cplusplus >= 201402L"));
+            assertThat(source, containsString(
+                "SBE_NODISCARD static SBE_CONSTEXPR char fuel(const std::uint64_t index) SBE_NOEXCEPT"));
+            assertThat(source, containsString("const std::uint8_t fuelValues[] = { 80, 101, 116, 114, 111, 108, 0 };"));
+            assertThat(source, containsString("#else"));
+            assertThat(source, containsString("SBE_NODISCARD char fuel(const std::uint64_t index) const"));
+            assertThat(source, containsString(
+                "static const std::uint8_t fuelValues[] = { 80, 101, 116, 114, 111, 108, 0 };"));
+        }
+    }
+
+    @Test
     void dtosShouldReferenceTypesInDifferentPackages() throws Exception
     {
         try (InputStream in = Tests.getLocalResource("explicit-package-test-schema.xml"))


### PR DESCRIPTION
Add some missing SBE_CONSTEXPR to the C++ generated code.