### PR TITLE
[C#] fix: handle case when valueRef is with enum type prefix

### DIFF
--- a/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
+++ b/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/csharp/CSharpGenerator.java
@@ -2069,6 +2069,18 @@ public class CSharpGenerator implements CodeGenerator
         if (fieldToken.isConstantEncoding())
         {
             final String constValue = fieldToken.encoding().constValue().toString();
+            
+            // If constValue already contains the type prefix (e.g., "filterType.TrailingDelta"),
+            // extract just the enum value name
+            final String enumValue;
+            if (constValue.contains("."))
+            {
+                enumValue = constValue.substring(constValue.lastIndexOf('.') + 1);
+            }
+            else
+            {
+                enumValue = constValue;
+            }
 
             return String.format("\n" +
                 "%1$s" +
@@ -2076,13 +2088,14 @@ public class CSharpGenerator implements CodeGenerator
                 indent + INDENT + "{\n" +
                 indent + INDENT + INDENT + "get\n" +
                 indent + INDENT + INDENT + "{\n" +
-                indent + INDENT + INDENT + INDENT + "return %4$s;\n" +
+                indent + INDENT + INDENT + INDENT + "return %4$s.%5$s;\n" +
                 indent + INDENT + INDENT + "}\n" +
                 indent + INDENT + "}\n\n",
                 generateDocumentation(indent + INDENT, fieldToken),
                 enumName,
                 toUpperFirstChar(propertyName),
-                constValue);
+                enumName,
+                enumValue);
         }
         else
         {


### PR DESCRIPTION
## Background

Tried to generate models from [Binace Spot spec](https://raw.githubusercontent.com/binance/binance-spot-api-docs/refs/heads/master/sbe/schemas/spot_3_1.xml) which got following line `<field id="1" name="filterType" type="filterType" presence="constant" valueRef="filterType.TrailingDelta"/>`

This is producing incorrect code for c# where whole valueRef is considered as constant. In contrast this case is handled [in C++](https://github.com/aeron-io/simple-binary-encoding/blob/master/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/cpp/CppGenerator.java#L3553).  or in [Rust](https://github.com/aeron-io/simple-binary-encoding/blob/master/sbe-tool/src/main/java/uk/co/real_logic/sbe/generation/rust/RustGenerator.java#L980). 

