### PR TITLE
[C++] Generate safe getters for optional fields

### DIFF
--- a/sbe-tool/src/test/cpp/CMakeLists.txt
+++ b/sbe-tool/src/test/cpp/CMakeLists.txt
@@ -43,6 +43,7 @@ set(ISSUE889_SCHEMA ${CODEC_SCHEMA_DIR}/issue889.xml)
 set(ACCESS_ORDER_SCHEMA ${CODEC_SCHEMA_DIR}/field-order-check-schema.xml)
 set(VERSIONED_MESSAGE_V1_SCHEMA ${CODEC_SCHEMA_DIR}/versioned-message-v1.xml)
 set(VERSIONED_MESSAGE_V2_SCHEMA ${CODEC_SCHEMA_DIR}/versioned-message-v2.xml)
+set(OPTIONAL_ACCESSORS_SCHEMA ${CODEC_SCHEMA_DIR}/optional-accessors-schema.xml)
 
 set(GENERATED_CODECS
     ${CXX_CODEC_TARGET_DIR}
@@ -61,6 +62,7 @@ add_custom_command(
         ${ACCESS_ORDER_SCHEMA}
         ${VERSIONED_MESSAGE_V1_SCHEMA}
         ${VERSIONED_MESSAGE_V2_SCHEMA}
+        ${OPTIONAL_ACCESSORS_SCHEMA}
     sbe-jar ${SBE_JAR}
     COMMAND
         ${Java_JAVA_EXECUTABLE} --add-opens java.base/jdk.internal.misc=ALL-UNNAMED
@@ -84,6 +86,7 @@ add_custom_command(
             ${ACCESS_ORDER_SCHEMA}
             ${VERSIONED_MESSAGE_V1_SCHEMA}
             ${VERSIONED_MESSAGE_V2_SCHEMA}
+            ${OPTIONAL_ACCESSORS_SCHEMA}
 )
 
 add_custom_target(codecs DEPENDS ${GENERATED_CODECS})
@@ -108,6 +111,8 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "7.0")
         sbe_test(DtoTest codecs)
         target_compile_features(DtoTest PRIVATE cxx_std_17)
+        sbe_test(OptionalAccessorsCodeGenTest codecs)
+        target_compile_features(OptionalAccessorsCodeGenTest PRIVATE cxx_std_17)
     endif()
 
     # Check if the GCC version supports C++20
@@ -121,6 +126,8 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "CLang")
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "4.0")
         sbe_test(DtoTest codecs)
         target_compile_features(DtoTest PRIVATE cxx_std_17)
+        sbe_test(OptionalAccessorsCodeGenTest codecs)
+        target_compile_features(OptionalAccessorsCodeGenTest PRIVATE cxx_std_17)
     endif()
 
     # Check if CLang version supports C++20
@@ -133,7 +140,9 @@ if (CMAKE_CXX_COMPILER_ID STREQUAL "MSVC")
     # Check if MSVC version supports C++17 / C++20
     if (CMAKE_CXX_COMPILER_VERSION VERSION_GREATER_EQUAL "19.14")
         sbe_test(DtoTest codecs)
+        sbe_test(OptionalAccessorsCodeGenTest codecs)
         target_compile_options(DtoTest PRIVATE /std:c++17)
+        target_compile_options(OptionalAccessorsCodeGenTest PRIVATE /std:c++17)
         target_compile_options(CodeGenTest PRIVATE /std:c++20)
     endif()
 endif()

--- a/sbe-tool/src/test/cpp/OptionalAccessorsCodeGenTest.cpp
+++ b/sbe-tool/src/test/cpp/OptionalAccessorsCodeGenTest.cpp
@@ -1,0 +1,155 @@
+/*
+ * Copyright 2013-2025 Real Logic Limited.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+#include <cmath>
+#include <iostream>
+
+#include "gtest/gtest.h"
+#include "optional_accessors_test/OptionalAccessorsMessage.h"
+
+using namespace optional::accessors::test;
+
+class OptionalAccessorsCodeGenTest : public testing::Test
+{
+public:
+    char m_buffer[2048] = {};
+    OptionalAccessorsMessage m_msg = {};
+    OptionalAccessorsMessage m_msgDecoder = {};
+};
+
+TEST_F(OptionalAccessorsCodeGenTest, shouldReturnEmptyOptionalsForNullSentinels)
+{
+    m_msg.wrapForEncode(m_buffer, 0, sizeof(m_buffer))
+        .rootPrimitive(OptionalAccessorsMessage::rootPrimitiveNullValue())
+        .rootFloat(OptionalAccessorsMessage::rootFloatNullValue())
+        .rootEnum(OptionalEnum::NULL_VALUE);
+
+    OptionalComposite &composite = m_msg.rootComposite();
+    composite
+        .compositePrimitive(OptionalComposite::compositePrimitiveNullValue())
+        .compositeFloat(OptionalComposite::compositeFloatNullValue())
+        .compositeEnum(CompositeEnum::NULL_VALUE);
+
+    OptionalAccessorsMessage::Entries &entries = m_msg.entriesCount(1);
+    entries.next()
+        .groupPrimitive(OptionalAccessorsMessage::Entries::groupPrimitiveNullValue())
+        .groupEnum(OptionalEnum::NULL_VALUE);
+
+    const std::uint64_t encodedLength = m_msg.encodedLength();
+
+    m_msgDecoder.wrapForDecode(
+        m_buffer,
+        0,
+        OptionalAccessorsMessage::sbeBlockLength(),
+        OptionalAccessorsMessage::sbeSchemaVersion(),
+        encodedLength);
+
+    // Expect: raw accessors still return null values
+    EXPECT_EQ(m_msgDecoder.rootPrimitive(), OptionalAccessorsMessage::rootPrimitiveNullValue());
+    EXPECT_TRUE(std::isnan(m_msgDecoder.rootFloat()));
+    EXPECT_EQ(m_msgDecoder.rootEnum(), OptionalEnum::NULL_VALUE);
+    // Expect: optional accessors return empty optionals
+    EXPECT_FALSE(m_msgDecoder.rootPrimitiveOpt().has_value());
+    EXPECT_FALSE(m_msgDecoder.rootFloatOpt().has_value());
+    EXPECT_FALSE(m_msgDecoder.rootEnumOpt().has_value());
+
+    // Expect: optional accessors generated for composite types
+    OptionalComposite &compositeDecoder = m_msgDecoder.rootComposite();
+    EXPECT_EQ(compositeDecoder.compositePrimitive(), OptionalComposite::compositePrimitiveNullValue());
+    EXPECT_TRUE(std::isnan(compositeDecoder.compositeFloat()));
+    EXPECT_EQ(compositeDecoder.compositeEnum(), CompositeEnum::NULL_VALUE);
+    EXPECT_FALSE(compositeDecoder.compositePrimitiveOpt().has_value());
+    EXPECT_FALSE(compositeDecoder.compositeFloatOpt().has_value());
+
+    // Expect: optional accessors generated for group fields
+    OptionalAccessorsMessage::Entries &entriesDecoder = m_msgDecoder.entries();
+    EXPECT_EQ(entriesDecoder.count(), 1u);
+    ASSERT_TRUE(entriesDecoder.hasNext());
+    entriesDecoder.next();
+    EXPECT_EQ(entriesDecoder.groupPrimitive(), OptionalAccessorsMessage::Entries::groupPrimitiveNullValue());
+    EXPECT_EQ(entriesDecoder.groupEnum(), OptionalEnum::NULL_VALUE);
+    EXPECT_FALSE(entriesDecoder.groupPrimitiveOpt().has_value());
+    EXPECT_FALSE(entriesDecoder.groupEnumOpt().has_value());
+}
+
+TEST_F(OptionalAccessorsCodeGenTest, shouldReturnValueOptionalsForNonNullFields)
+{
+    static const std::int32_t ROOT_PRIMITIVE = 42;
+    static const float ROOT_FLOAT = 101.25f;
+    static const std::int32_t COMPOSITE_PRIMITIVE = 7;
+    static const float COMPOSITE_FLOAT = 3.5f;
+    static const std::uint16_t GROUP_PRIMITIVE = 65000;
+
+    m_msg.wrapForEncode(m_buffer, 0, sizeof(m_buffer))
+        .rootPrimitive(ROOT_PRIMITIVE)
+        .rootFloat(ROOT_FLOAT)
+        .rootEnum(OptionalEnum::A);
+
+    OptionalComposite &composite = m_msg.rootComposite();
+    composite
+        .compositePrimitive(COMPOSITE_PRIMITIVE)
+        .compositeFloat(COMPOSITE_FLOAT)
+        .compositeEnum(CompositeEnum::Y);
+
+    OptionalAccessorsMessage::Entries &entries = m_msg.entriesCount(1);
+    entries.next()
+        .groupPrimitive(GROUP_PRIMITIVE)
+        .groupEnum(OptionalEnum::A);
+
+    const std::uint64_t encodedLength = m_msg.encodedLength();
+
+    m_msgDecoder.wrapForDecode(
+        m_buffer,
+        0,
+        OptionalAccessorsMessage::sbeBlockLength(),
+        OptionalAccessorsMessage::sbeSchemaVersion(),
+        encodedLength);
+
+    const std::optional<std::int32_t> rootPrimitiveOpt = m_msgDecoder.rootPrimitiveOpt();
+    ASSERT_TRUE(rootPrimitiveOpt.has_value());
+    EXPECT_EQ(rootPrimitiveOpt.value(), ROOT_PRIMITIVE);
+
+    const std::optional<float> rootFloatOpt = m_msgDecoder.rootFloatOpt();
+    ASSERT_TRUE(rootFloatOpt.has_value());
+    EXPECT_FLOAT_EQ(rootFloatOpt.value(), ROOT_FLOAT);
+
+    const std::optional<OptionalEnum::Value> rootEnumOpt = m_msgDecoder.rootEnumOpt();
+    ASSERT_TRUE(rootEnumOpt.has_value());
+    EXPECT_EQ(rootEnumOpt.value(), OptionalEnum::A);
+
+    OptionalComposite &compositeDecoder = m_msgDecoder.rootComposite();
+
+    const std::optional<std::int32_t> compositePrimitiveOpt = compositeDecoder.compositePrimitiveOpt();
+    ASSERT_TRUE(compositePrimitiveOpt.has_value());
+    EXPECT_EQ(compositePrimitiveOpt.value(), COMPOSITE_PRIMITIVE);
+
+    const std::optional<float> compositeFloatOpt = compositeDecoder.compositeFloatOpt();
+    ASSERT_TRUE(compositeFloatOpt.has_value());
+    EXPECT_FLOAT_EQ(compositeFloatOpt.value(), COMPOSITE_FLOAT);
+    EXPECT_EQ(compositeDecoder.compositeEnum(), CompositeEnum::Y);
+
+    OptionalAccessorsMessage::Entries &entriesDecoder = m_msgDecoder.entries();
+    EXPECT_EQ(entriesDecoder.count(), 1u);
+    ASSERT_TRUE(entriesDecoder.hasNext());
+    entriesDecoder.next();
+
+    const std::optional<std::uint16_t> groupPrimitiveOpt = entriesDecoder.groupPrimitiveOpt();
+    ASSERT_TRUE(groupPrimitiveOpt.has_value());
+    EXPECT_EQ(groupPrimitiveOpt.value(), GROUP_PRIMITIVE);
+
+    const std::optional<OptionalEnum::Value> groupEnumOpt = entriesDecoder.groupEnumOpt();
+    ASSERT_TRUE(groupEnumOpt.has_value());
+    EXPECT_EQ(groupEnumOpt.value(), OptionalEnum::A);
+}

--- a/sbe-tool/src/test/resources/optional-accessors-schema.xml
+++ b/sbe-tool/src/test/resources/optional-accessors-schema.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<sbe:messageSchema xmlns:sbe="http://fixprotocol.io/2016/sbe"
+                   package="optional.accessors.test"
+                   id="201"
+                   version="0"
+                   semanticVersion="1.0"
+                   description="Optional accessor generation test schema"
+                   byteOrder="littleEndian">
+    <types>
+        <composite name="messageHeader" description="Message identifiers and length of message root">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="templateId" primitiveType="uint16"/>
+            <type name="schemaId" primitiveType="uint16"/>
+            <type name="version" primitiveType="uint16"/>
+        </composite>
+        <composite name="groupSizeEncoding" description="Repeating group dimensions">
+            <type name="blockLength" primitiveType="uint16"/>
+            <type name="numInGroup" primitiveType="uint16"/>
+        </composite>
+        <enum name="OptionalEnum" encodingType="uint8" presence="optional">
+            <validValue name="A">1</validValue>
+            <validValue name="B">2</validValue>
+        </enum>
+        <composite name="OptionalComposite">
+            <type name="compositePrimitive" primitiveType="int32" presence="optional"/>
+            <type name="compositeFloat" primitiveType="float" presence="optional"/>
+            <enum name="compositeEnum" encodingType="uint8" presence="optional">
+                <validValue name="X">10</validValue>
+                <validValue name="Y">20</validValue>
+            </enum>
+        </composite>
+    </types>
+    <sbe:message name="OptionalAccessorsMessage" id="1">
+        <field name="rootPrimitive" id="1" type="int32" presence="optional"/>
+        <field name="rootFloat" id="2" type="float" presence="optional"/>
+        <field name="rootEnum" id="3" type="OptionalEnum"/>
+        <field name="rootComposite" id="4" type="OptionalComposite"/>
+        <group name="Entries" id="5" dimensionType="groupSizeEncoding">
+            <field name="groupPrimitive" id="6" type="uint16" presence="optional"/>
+            <field name="groupEnum" id="7" type="OptionalEnum"/>
+        </group>
+    </sbe:message>
+</sbe:messageSchema>


### PR DESCRIPTION
### Summary
This MR adds safe optional accessors to generated C++ codecs for optional primitive and enum fields.

### Problem
C++ generated decoders expose raw getters that return sentinel null values for optional fields. Callers had to remember field-specific null semantics (including floating-point NaN handling and enum null values), which is error-prone and inconsistent with safer optional-style APIs.

### Design Proposal
The generator now emits additional `*Opt()` accessors for optional fields:
- Optional primitive scalar fields get `std::optional<T> fieldOpt() const`.
- Optional enum fields get `std::optional<Enum::Value> fieldOpt() const`.
- Emission is gated by C++17

```cpp
// Primitive optional field

#if __cplusplus >= 201703L
SBE_NODISCARD std::optional<float> rootFloatOpt() const SBE_NOEXCEPT
{
    const float value = rootFloat();
    const float nullValue = rootFloatNullValue();
    if (std::isnan(value) || value == nullValue)
    {
        return std::nullopt;
    }

    return value;
}
#endif

// Enum optional field

#if __cplusplus >= 201703L
SBE_NODISCARD std::optional<OptionalEnum::Value> rootEnumOpt() const
{
    const OptionalEnum::Value value = rootEnum();
    if (OptionalEnum::NULL_VALUE == value)
    {
        return std::nullopt;
    }

    return value;
}
#endif
```

### Compatibility Decision
The change is additive and non-breaking for generated APIs:
- Existing raw getters/setters are unchanged.
- New optional accessors are emitted only when field presence is optional.
- C++17 guard ensures no impact on older language targets (no `std::optional` API emitted there).

Alternative considered:
- Replace existing raw accessors return type with `std::optional<T>` if building with C++17. Went the safest path not to break compilation in existing callers, but I'm open to suggestions. Replacing return type would make optional field accessors bullet proof in the long run. 

### Test Summary

To validate behavior end-to-end, this PR adds:
- `optional-accessors-schema.xml` containing optional fields in message, group, and composite (including enums).
- `OptionalAccessorsCodeGenTest.cpp` asserting:
  - null sentinels decode to empty optionals,
  - non-null values decode to populated optionals,
  - raw getters remain unchanged.