### PR TITLE
[C#] refactor: seal PrimitiveValue and PrimitiveType, make ThrowHelper static

### DIFF
--- a/csharp/sbe-dll/PrimitiveType.cs
+++ b/csharp/sbe-dll/PrimitiveType.cs
@@ -71,7 +71,7 @@
     ///     </tbody>
     /// </table>
     /// </summary>
-    public class PrimitiveType
+    public sealed class PrimitiveType
     {
         /// <summary>
         /// Primitive type representation for SBE type CHAR

--- a/csharp/sbe-dll/PrimitiveValue.cs
+++ b/csharp/sbe-dll/PrimitiveValue.cs
@@ -74,7 +74,7 @@ namespace Org.SbeTool.Sbe.Dll
     ///         </tbody>
     ///     </table>
     /// </summary>
-    public class PrimitiveValue
+    public sealed class PrimitiveValue
     {
         private enum Representation
         {
@@ -485,26 +485,21 @@ namespace Org.SbeTool.Sbe.Dll
         /// <returns> equivalence of values </returns>
         public override bool Equals(object value)
         {
-            if (null != value && this.GetType().Equals(value.GetType()))
+            if (value is PrimitiveValue rhs && _representation == rhs._representation)
             {
-                var rhs = (PrimitiveValue) value;
-
-                if (_representation == rhs._representation)
+                switch (_representation)
                 {
-                    switch (_representation)
-                    {
-                        case Representation.Long:
-                            return _longValue == rhs._longValue;
+                    case Representation.Long:
+                        return _longValue == rhs._longValue;
 
-                        case Representation.ULong:
-                            return _unsignedLongValue == rhs._unsignedLongValue;
+                    case Representation.ULong:
+                        return _unsignedLongValue == rhs._unsignedLongValue;
 
-                        case Representation.Double:
-                            return BitConverter.DoubleToInt64Bits(_doubleValue) == BitConverter.DoubleToInt64Bits(rhs._doubleValue);
+                    case Representation.Double:
+                        return BitConverter.DoubleToInt64Bits(_doubleValue) == BitConverter.DoubleToInt64Bits(rhs._doubleValue);
 
-                        case Representation.ByteArray:
-                            return _byteArrayValue.SequenceEqual(rhs._byteArrayValue);
-                    }
+                    case Representation.ByteArray:
+                        return _byteArrayValue.SequenceEqual(rhs._byteArrayValue);
                 }
             }
 

--- a/csharp/sbe-dll/ThrowHelper.cs
+++ b/csharp/sbe-dll/ThrowHelper.cs
@@ -6,7 +6,7 @@ namespace Org.SbeTool.Sbe.Dll
     /// Helper class that provides non-returning methods that throw common exception
     /// from the generated C# code
     /// </summary>
-    public class ThrowHelper
+    public static class ThrowHelper
     {
         /// <summary>
         /// Throws a <see cref="ArgumentOutOfRangeException"/> when the "count" parameter is out of range


### PR DESCRIPTION
There is no reason `PrimitiveValue` and `PrimitiveType` are not sealed. Practically they will be never inherited. Seal them, as JIT will skip MethodTable generation and should improve the performance by a small margin.